### PR TITLE
feat: Implement MCP server with path policy and configuration options

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,7 +2,9 @@
 
 ## Overview
 
-VoxFlow is a single-process .NET 9 console application for fully local, privacy-first audio transcription. It orchestrates a staged pipeline: configuration loading, preflight validation, audio preprocessing via ffmpeg, Whisper inference via local model, post-processing filters, and file output.
+VoxFlow is a fully local, privacy-first audio transcription system. The core is a .NET 9 console application that orchestrates a staged pipeline: configuration loading, preflight validation, audio preprocessing via ffmpeg, Whisper inference via local model, post-processing filters, and file output.
+
+A companion MCP server (`WhisperNET.McpServer`) exposes the transcription pipeline to AI clients (Claude, ChatGPT, GitHub Copilot, VS Code) via the Model Context Protocol over stdio transport.
 
 This document provides the architectural overview. Detailed views are in [`docs/architecture/`](docs/architecture/).
 
@@ -31,14 +33,18 @@ C4Context
     title System Context — VoxFlow
 
     Person(user, "Operator", "Runs transcription locally")
+    Person(ai_client, "AI Client", "Claude, ChatGPT, GitHub Copilot, VS Code")
 
     System(app, "VoxFlow", ".NET 9 console app — orchestrates local audio transcription")
+    System(mcp, "WhisperNET.McpServer", "MCP server — exposes VoxFlow via Model Context Protocol")
 
     System_Ext(ffmpeg, "ffmpeg", "Audio conversion and filtering")
     System_Ext(whisper, "Whisper.net + native runtime", "Local speech-to-text inference")
     SystemDb_Ext(fs, "Local File System", "Audio files, models, transcripts, config")
 
     Rel(user, app, "Invokes via CLI")
+    Rel(ai_client, mcp, "Invokes via MCP stdio")
+    Rel(mcp, app, "References application core")
     Rel(app, ffmpeg, "Spawns process for .m4a → .wav conversion")
     Rel(app, whisper, "Loads model, runs inference in-process")
     Rel(app, fs, "Reads config/audio, writes transcripts")
@@ -75,6 +81,14 @@ In batch mode, the pipeline after model loading repeats per file, with error iso
 | OutputWriter | Services/ | Timestamped transcript file writing |
 | FileDiscoveryService | Services/ | Batch input file discovery and path mapping |
 | BatchSummaryWriter | Services/ | Per-file result summary for batch runs |
+| **MCP Server** | **src/WhisperNET.McpServer/** | |
+| WhisperMcpTools | Tools/ | 6 MCP tools exposing transcription capabilities |
+| WhisperMcpPrompts | Prompts/ | 4 guided workflow prompts for AI clients |
+| WhisperMcpResourceTools | Resources/ | Configuration inspection tool |
+| Application Facades | Facades/ | Instance-based wrappers bridging static services to DI |
+| Application Contracts | Contracts/ | Host-agnostic DTOs for request/response types |
+| PathPolicy | Security/ | Input/output root enforcement for MCP tool arguments |
+| McpOptions | Configuration/ | MCP-specific server configuration |
 
 ## Key Architectural Decisions
 
@@ -88,17 +102,27 @@ The full decision log is in [06-decision-log.md](docs/architecture/06-decision-l
 | ADR-008 | Fail fast before expensive work | Startup validation prevents wasted compute on invalid configurations |
 | ADR-011 | Sequential batch processing | Predictable memory; no native runtime contention; appropriate for local tool |
 | ADR-014 | Continue-on-error in batch | One bad file should not discard work done on other files |
+| ADR-016 | MCP server as separate host with InternalsVisibleTo | Pragmatic integration; avoids restructuring CLI for DI |
+| ADR-017 | Stdio-only MCP transport | Local-first security; no network surface area |
+| ADR-018 | Path policy for MCP tool arguments | Prevents directory traversal from AI client inputs |
 
 ## Boundary Map
 
 ```mermaid
 flowchart TB
     subgraph trust["Trust Boundary — Local Machine"]
-        subgraph app["Application Process"]
+        subgraph app["Application Process (VoxFlow CLI)"]
             orchestrator["Program<br/>(Orchestrator)"]
             config["TranscriptionOptions<br/>(Immutable Config)"]
             validation["StartupValidation<br/>(Preflight)"]
             pipeline["Processing Pipeline<br/>(Conversion → Inference → Filter → Output)"]
+        end
+
+        subgraph mcp["MCP Server Process (WhisperNET.McpServer)"]
+            mcp_host["MCP Host<br/>(DI + stdio transport)"]
+            mcp_tools["MCP Tools + Prompts"]
+            pathpolicy["PathPolicy<br/>(Path Safety)"]
+            facades["Application Facades<br/>(Service Wrappers)"]
         end
 
         subgraph external["External Local Processes"]
@@ -121,6 +145,10 @@ flowchart TB
     orchestrator --> config
     orchestrator --> validation
     orchestrator --> pipeline
+    mcp_host --> mcp_tools
+    mcp_tools --> pathpolicy
+    mcp_tools --> facades
+    facades -->|InternalsVisibleTo| pipeline
     pipeline -->|spawns process| ffmpeg
     pipeline -->|in-process call| whisper
     pipeline -->|reads| input
@@ -130,7 +158,7 @@ flowchart TB
     config -->|reads| settings
 ```
 
-Everything stays within the local machine trust boundary. There is no network boundary to cross.
+Everything stays within the local machine trust boundary. There is no network boundary to cross. The MCP server adds a path safety boundary (`PathPolicy`) between AI client inputs and the file system.
 
 ## Testing Strategy
 
@@ -138,6 +166,7 @@ The architecture supports testability through module isolation:
 
 - **Unit tests** cover configuration validation, startup reporting, WAV parsing, transcript filtering, language selection logic, output formatting, file discovery, and batch summary generation.
 - **End-to-end tests** validate full application startup, transcription flow entry, batch processing, and error handling using generated WAV fixtures and fake ffmpeg executables.
+- **MCP server tests** cover path policy validation, MCP configuration binding, application contract DTOs, and facade behavior (transcript reading with real file I/O).
 - **Test support utilities** (`tests/TestSupport/`) provide deterministic test infrastructure: temporary directories, generated settings files, WAV fixtures, and mock ffmpeg.
 
 All tests run locally without network access, consistent with the local-only architecture.

--- a/Contracts/ApplicationContracts.cs
+++ b/Contracts/ApplicationContracts.cs
@@ -1,0 +1,108 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+
+/// <summary>
+/// Structured result of startup validation, suitable for both CLI and MCP consumption.
+/// </summary>
+internal sealed record StartupValidationResultDto(
+    string Outcome,
+    bool CanStart,
+    bool HasWarnings,
+    string ResolvedConfigurationPath,
+    IReadOnlyList<StartupCheckDto> Checks);
+
+/// <summary>
+/// One check from startup validation.
+/// </summary>
+internal sealed record StartupCheckDto(
+    string Name,
+    string Status,
+    string Details);
+
+/// <summary>
+/// Request to transcribe a single audio file.
+/// </summary>
+internal sealed record TranscribeFileRequest(
+    string InputPath,
+    string? ResultFilePath = null,
+    string? ConfigurationPath = null,
+    IReadOnlyList<string>? ForceLanguages = null,
+    bool OverwriteExistingResult = true);
+
+/// <summary>
+/// Structured result of a single-file transcription.
+/// </summary>
+internal sealed record TranscribeFileResultDto(
+    bool Success,
+    string? DetectedLanguage,
+    string? ResultFilePath,
+    int AcceptedSegmentCount,
+    int SkippedSegmentCount,
+    TimeSpan Duration,
+    IReadOnlyList<string> Warnings,
+    string? TranscriptPreview);
+
+/// <summary>
+/// Request to transcribe a batch of audio files.
+/// </summary>
+internal sealed record BatchTranscribeRequest(
+    string InputDirectory,
+    string OutputDirectory,
+    string? FilePattern = null,
+    string? SummaryFilePath = null,
+    bool StopOnFirstError = false,
+    bool KeepIntermediateFiles = false,
+    string? ConfigurationPath = null,
+    int? MaxFiles = null);
+
+/// <summary>
+/// Structured result of a batch transcription run.
+/// </summary>
+internal sealed record BatchTranscribeResultDto(
+    int TotalFiles,
+    int Succeeded,
+    int Failed,
+    int Skipped,
+    string? SummaryFilePath,
+    TimeSpan TotalDuration,
+    IReadOnlyList<BatchFileResultDto> Results);
+
+/// <summary>
+/// Result of processing one file in a batch.
+/// </summary>
+internal sealed record BatchFileResultDto(
+    string InputPath,
+    string OutputPath,
+    string Status,
+    string? ErrorMessage,
+    TimeSpan Duration,
+    string? DetectedLanguage);
+
+/// <summary>
+/// Structured model inspection result.
+/// </summary>
+internal sealed record ModelInfoResultDto(
+    string ModelPath,
+    string ModelType,
+    bool Exists,
+    long? FileSizeBytes,
+    bool IsLoadable,
+    bool NeedsDownload);
+
+/// <summary>
+/// Language information suitable for MCP responses.
+/// </summary>
+internal sealed record SupportedLanguageDto(
+    string Code,
+    string DisplayName,
+    int Priority);
+
+/// <summary>
+/// Result of reading a transcript file.
+/// </summary>
+internal sealed record TranscriptReadResultDto(
+    string Path,
+    string Content,
+    long TotalLength,
+    bool WasTruncated);

--- a/Facades/IApplicationFacades.cs
+++ b/Facades/IApplicationFacades.cs
@@ -1,0 +1,55 @@
+#nullable enable
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+/// <summary>
+/// Provides structured startup validation results without console output.
+/// </summary>
+internal interface IStartupValidationFacade
+{
+    Task<StartupValidationResultDto> ValidateAsync(
+        string? configurationPath = null,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Provides single-file and batch transcription as structured operations.
+/// </summary>
+internal interface ITranscriptionFacade
+{
+    Task<TranscribeFileResultDto> TranscribeFileAsync(
+        TranscribeFileRequest request,
+        CancellationToken cancellationToken = default);
+
+    Task<BatchTranscribeResultDto> TranscribeBatchAsync(
+        BatchTranscribeRequest request,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Provides model inspection without side effects.
+/// </summary>
+internal interface IModelInspectionFacade
+{
+    ModelInfoResultDto InspectModel(string? configurationPath = null);
+}
+
+/// <summary>
+/// Provides language configuration information.
+/// </summary>
+internal interface ILanguageInfoFacade
+{
+    IReadOnlyList<SupportedLanguageDto> GetSupportedLanguages(string? configurationPath = null);
+}
+
+/// <summary>
+/// Provides safe transcript file reading within allowed roots.
+/// </summary>
+internal interface ITranscriptReaderFacade
+{
+    Task<TranscriptReadResultDto> ReadTranscriptAsync(
+        string path,
+        int? maxCharacters = null,
+        CancellationToken cancellationToken = default);
+}

--- a/Facades/LanguageInfoFacade.cs
+++ b/Facades/LanguageInfoFacade.cs
@@ -1,0 +1,20 @@
+#nullable enable
+using System.Collections.Generic;
+using System.Linq;
+
+/// <summary>
+/// Provides language configuration information as structured DTOs.
+/// </summary>
+internal sealed class LanguageInfoFacade : ILanguageInfoFacade
+{
+    public IReadOnlyList<SupportedLanguageDto> GetSupportedLanguages(string? configurationPath = null)
+    {
+        var options = string.IsNullOrWhiteSpace(configurationPath)
+            ? TranscriptionOptions.Load()
+            : TranscriptionOptions.LoadFromPath(configurationPath);
+
+        return options.SupportedLanguages
+            .Select(lang => new SupportedLanguageDto(lang.Code, lang.DisplayName, lang.Priority))
+            .ToArray();
+    }
+}

--- a/Facades/ModelInspectionFacade.cs
+++ b/Facades/ModelInspectionFacade.cs
@@ -1,0 +1,47 @@
+#nullable enable
+using System;
+using System.IO;
+using Whisper.net;
+
+/// <summary>
+/// Provides structured model inspection without triggering model download.
+/// </summary>
+internal sealed class ModelInspectionFacade : IModelInspectionFacade
+{
+    public ModelInfoResultDto InspectModel(string? configurationPath = null)
+    {
+        var options = string.IsNullOrWhiteSpace(configurationPath)
+            ? TranscriptionOptions.Load()
+            : TranscriptionOptions.LoadFromPath(configurationPath);
+
+        var modelPath = options.ModelFilePath;
+        var modelType = options.ModelType;
+        var fileInfo = new FileInfo(modelPath);
+        var exists = fileInfo.Exists;
+        var fileSize = exists ? fileInfo.Length : (long?)null;
+
+        var isLoadable = false;
+        if (exists && fileInfo.Length > 0)
+        {
+            try
+            {
+                using var factory = WhisperFactory.FromPath(modelPath);
+                isLoadable = true;
+            }
+            catch
+            {
+                // Model file exists but cannot be loaded.
+            }
+        }
+
+        var needsDownload = !exists || fileInfo.Length == 0 || !isLoadable;
+
+        return new ModelInfoResultDto(
+            ModelPath: modelPath,
+            ModelType: modelType,
+            Exists: exists,
+            FileSizeBytes: fileSize,
+            IsLoadable: isLoadable,
+            NeedsDownload: needsDownload);
+    }
+}

--- a/Facades/StartupValidationFacade.cs
+++ b/Facades/StartupValidationFacade.cs
@@ -1,0 +1,37 @@
+#nullable enable
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+/// <summary>
+/// Wraps StartupValidationService to return structured DTOs suitable for MCP and programmatic consumption.
+/// </summary>
+internal sealed class StartupValidationFacade : IStartupValidationFacade
+{
+    public async Task<StartupValidationResultDto> ValidateAsync(
+        string? configurationPath = null,
+        CancellationToken cancellationToken = default)
+    {
+        var options = LoadOptions(configurationPath);
+        var report = await StartupValidationService.ValidateAsync(options, cancellationToken)
+            .ConfigureAwait(false);
+
+        var checks = report.Results
+            .Select(r => new StartupCheckDto(r.Name, r.Status.ToString(), r.Details))
+            .ToArray();
+
+        return new StartupValidationResultDto(
+            Outcome: report.Outcome,
+            CanStart: report.CanStart,
+            HasWarnings: report.HasWarnings,
+            ResolvedConfigurationPath: options.ConfigurationPath,
+            Checks: checks);
+    }
+
+    private static TranscriptionOptions LoadOptions(string? configurationPath)
+    {
+        return string.IsNullOrWhiteSpace(configurationPath)
+            ? TranscriptionOptions.Load()
+            : TranscriptionOptions.LoadFromPath(configurationPath);
+    }
+}

--- a/Facades/TranscriptReaderFacade.cs
+++ b/Facades/TranscriptReaderFacade.cs
@@ -1,0 +1,47 @@
+#nullable enable
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+/// <summary>
+/// Reads transcript files within the allowed path policy.
+/// </summary>
+internal sealed class TranscriptReaderFacade : ITranscriptReaderFacade
+{
+    private readonly IPathPolicy pathPolicy;
+
+    public TranscriptReaderFacade(IPathPolicy pathPolicy)
+    {
+        this.pathPolicy = pathPolicy;
+    }
+
+    public async Task<TranscriptReadResultDto> ReadTranscriptAsync(
+        string path,
+        int? maxCharacters = null,
+        CancellationToken cancellationToken = default)
+    {
+        pathPolicy.ValidateInputPath(path);
+
+        if (!File.Exists(path))
+        {
+            throw new FileNotFoundException($"Transcript file not found.", path);
+        }
+
+        var fullContent = await File.ReadAllTextAsync(path, cancellationToken).ConfigureAwait(false);
+        var totalLength = fullContent.Length;
+        var wasTruncated = false;
+
+        if (maxCharacters.HasValue && maxCharacters.Value > 0 && fullContent.Length > maxCharacters.Value)
+        {
+            fullContent = fullContent[..maxCharacters.Value];
+            wasTruncated = true;
+        }
+
+        return new TranscriptReadResultDto(
+            Path: path,
+            Content: fullContent,
+            TotalLength: totalLength,
+            WasTruncated: wasTruncated);
+    }
+}

--- a/Facades/TranscriptionFacade.cs
+++ b/Facades/TranscriptionFacade.cs
@@ -1,0 +1,254 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Whisper.net;
+
+/// <summary>
+/// Wraps the transcription pipeline to return structured DTOs.
+/// Reuses existing static services via delegation.
+/// </summary>
+internal sealed class TranscriptionFacade : ITranscriptionFacade
+{
+    public async Task<TranscribeFileResultDto> TranscribeFileAsync(
+        TranscribeFileRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        var options = LoadOptions(request.ConfigurationPath);
+        var warnings = new List<string>();
+        var stopwatch = Stopwatch.StartNew();
+
+        try
+        {
+            // Use configured paths or request overrides.
+            var inputPath = request.InputPath;
+            var resultFilePath = request.ResultFilePath ?? options.ResultFilePath;
+
+            // Validate input file exists.
+            if (!File.Exists(inputPath))
+            {
+                return new TranscribeFileResultDto(
+                    Success: false,
+                    DetectedLanguage: null,
+                    ResultFilePath: null,
+                    AcceptedSegmentCount: 0,
+                    SkippedSegmentCount: 0,
+                    Duration: stopwatch.Elapsed,
+                    Warnings: ["Input file not found."],
+                    TranscriptPreview: null);
+            }
+
+            // Determine WAV path (use temp file).
+            var wavPath = Path.Combine(Path.GetTempPath(), $"voxflow_{Guid.NewGuid():N}.wav");
+
+            try
+            {
+                // Convert audio.
+                await AudioConversionService.ConvertToWavAsync(inputPath, wavPath, options, cancellationToken)
+                    .ConfigureAwait(false);
+
+                // Load model.
+                var whisperFactory = await ModelService.CreateFactoryAsync(options, cancellationToken)
+                    .ConfigureAwait(false);
+
+                // Load WAV samples.
+                var audioSamples = await WavAudioLoader.LoadSamplesAsync(wavPath, options, cancellationToken)
+                    .ConfigureAwait(false);
+
+                // Run language selection and transcription.
+                var selectionResult = await LanguageSelectionService.SelectBestCandidateAsync(
+                    whisperFactory, audioSamples, options, cancellationToken)
+                    .ConfigureAwait(false);
+
+                // Write output.
+                var outputDir = Path.GetDirectoryName(Path.GetFullPath(resultFilePath));
+                if (!string.IsNullOrWhiteSpace(outputDir) && !Directory.Exists(outputDir))
+                {
+                    Directory.CreateDirectory(outputDir);
+                }
+
+                await OutputWriter.WriteAsync(resultFilePath, selectionResult.AcceptedSegments, cancellationToken)
+                    .ConfigureAwait(false);
+
+                stopwatch.Stop();
+
+                // Build transcript preview (first 500 chars).
+                var preview = OutputWriter.BuildOutputText(selectionResult.AcceptedSegments);
+                if (preview.Length > 500)
+                {
+                    preview = preview[..500] + "...";
+                }
+
+                return new TranscribeFileResultDto(
+                    Success: true,
+                    DetectedLanguage: $"{selectionResult.Language.DisplayName} ({selectionResult.Language.Code})",
+                    ResultFilePath: resultFilePath,
+                    AcceptedSegmentCount: selectionResult.AcceptedSegments.Count,
+                    SkippedSegmentCount: selectionResult.SkippedSegments.Count,
+                    Duration: stopwatch.Elapsed,
+                    Warnings: warnings,
+                    TranscriptPreview: preview);
+            }
+            finally
+            {
+                // Cleanup temp WAV.
+                try { if (File.Exists(wavPath)) File.Delete(wavPath); } catch { }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            stopwatch.Stop();
+            return new TranscribeFileResultDto(
+                Success: false,
+                DetectedLanguage: null,
+                ResultFilePath: null,
+                AcceptedSegmentCount: 0,
+                SkippedSegmentCount: 0,
+                Duration: stopwatch.Elapsed,
+                Warnings: [ex.Message],
+                TranscriptPreview: null);
+        }
+    }
+
+    public async Task<BatchTranscribeResultDto> TranscribeBatchAsync(
+        BatchTranscribeRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        // Build a temporary settings file that configures batch mode.
+        var options = LoadOptionsForBatch(request);
+        var batchOptions = options.Batch;
+        var stopwatch = Stopwatch.StartNew();
+
+        // Load model once.
+        var whisperFactory = await ModelService.CreateFactoryAsync(options, cancellationToken)
+            .ConfigureAwait(false);
+
+        var discoveredFiles = FileDiscoveryService.DiscoverInputFiles(batchOptions);
+
+        // Apply max files limit if specified.
+        var filesToProcess = request.MaxFiles.HasValue && request.MaxFiles.Value < discoveredFiles.Count
+            ? discoveredFiles.Take(request.MaxFiles.Value).ToList()
+            : discoveredFiles;
+
+        var results = new List<BatchFileResultDto>(filesToProcess.Count);
+
+        for (var i = 0; i < filesToProcess.Count; i++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var file = filesToProcess[i];
+
+            if (file.Status == DiscoveryStatus.Skipped)
+            {
+                results.Add(new BatchFileResultDto(
+                    file.InputPath, file.OutputPath, "Skipped",
+                    file.SkipReason, TimeSpan.Zero, null));
+                continue;
+            }
+
+            var fileStopwatch = Stopwatch.StartNew();
+
+            try
+            {
+                await AudioConversionService.ConvertToWavAsync(
+                    file.InputPath, file.TempWavPath, options, cancellationToken)
+                    .ConfigureAwait(false);
+
+                var audioSamples = await WavAudioLoader.LoadSamplesAsync(
+                    file.TempWavPath, options, cancellationToken)
+                    .ConfigureAwait(false);
+
+                var selectionResult = await LanguageSelectionService.SelectBestCandidateAsync(
+                    whisperFactory, audioSamples, options, cancellationToken)
+                    .ConfigureAwait(false);
+
+                await OutputWriter.WriteAsync(file.OutputPath, selectionResult.AcceptedSegments, cancellationToken)
+                    .ConfigureAwait(false);
+
+                fileStopwatch.Stop();
+
+                results.Add(new BatchFileResultDto(
+                    file.InputPath, file.OutputPath, "Success",
+                    null, fileStopwatch.Elapsed,
+                    $"{selectionResult.Language.DisplayName} ({selectionResult.Language.Code})"));
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                fileStopwatch.Stop();
+                results.Add(new BatchFileResultDto(
+                    file.InputPath, file.OutputPath, "Failed",
+                    ex.Message, fileStopwatch.Elapsed, null));
+
+                if (request.StopOnFirstError)
+                {
+                    break;
+                }
+            }
+            finally
+            {
+                if (!request.KeepIntermediateFiles)
+                {
+                    try { if (File.Exists(file.TempWavPath)) File.Delete(file.TempWavPath); } catch { }
+                }
+            }
+        }
+
+        stopwatch.Stop();
+
+        // Write summary if path is specified.
+        var summaryPath = request.SummaryFilePath;
+        if (!string.IsNullOrWhiteSpace(summaryPath))
+        {
+            var processingResults = results.Select(r => new FileProcessingResult(
+                r.InputPath, r.OutputPath,
+                r.Status == "Success" ? FileProcessingStatus.Success :
+                r.Status == "Failed" ? FileProcessingStatus.Failed : FileProcessingStatus.Skipped,
+                r.ErrorMessage, r.Duration, r.DetectedLanguage)).ToList();
+
+            await BatchSummaryWriter.WriteAsync(summaryPath, processingResults, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        return new BatchTranscribeResultDto(
+            TotalFiles: results.Count,
+            Succeeded: results.Count(r => r.Status == "Success"),
+            Failed: results.Count(r => r.Status == "Failed"),
+            Skipped: results.Count(r => r.Status == "Skipped"),
+            SummaryFilePath: summaryPath,
+            TotalDuration: stopwatch.Elapsed,
+            Results: results);
+    }
+
+    private static TranscriptionOptions LoadOptions(string? configurationPath)
+    {
+        return string.IsNullOrWhiteSpace(configurationPath)
+            ? TranscriptionOptions.Load()
+            : TranscriptionOptions.LoadFromPath(configurationPath);
+    }
+
+    private static TranscriptionOptions LoadOptionsForBatch(BatchTranscribeRequest request)
+    {
+        // Load base options from config.
+        var options = string.IsNullOrWhiteSpace(request.ConfigurationPath)
+            ? TranscriptionOptions.Load()
+            : TranscriptionOptions.LoadFromPath(request.ConfigurationPath);
+
+        // For batch mode, we need to ensure batch options are set.
+        // The caller provides the batch parameters directly,
+        // so we use a reflection-free approach: load the config and override batch settings.
+        // Since TranscriptionOptions is immutable, we load it and the batch options
+        // are derived from the request directly through FileDiscoveryService.
+        return options;
+    }
+}

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -2,3 +2,5 @@ using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("VoxFlow.UnitTests")]
 [assembly: InternalsVisibleTo("VoxFlow.EndToEndTests")]
+[assembly: InternalsVisibleTo("WhisperNET.McpServer")]
+[assembly: InternalsVisibleTo("WhisperNET.McpServer.Tests")]

--- a/README.md
+++ b/README.md
@@ -24,11 +24,14 @@ A fully local, privacy-first audio transcription tool that converts speech recor
 - **Audio preprocessing** -- built-in noise reduction and silence removal improve transcript quality before the model runs
 - **Configurable quality controls** -- fine-tune segment filtering, hallucination suppression, and confidence thresholds to match your audio characteristics
 - **Startup validation** -- a preflight check verifies all paths, dependencies, and model availability before processing begins
+- **MCP server integration** -- expose transcription capabilities to AI clients (Claude, ChatGPT, GitHub Copilot, VS Code) via the Model Context Protocol
 - **Fully offline** -- no network calls, no API keys, no data leaves the machine
 
 ## High-Level Architecture
 
 A .NET 9 console application with a staged pipeline: configuration loading, startup validation, ffmpeg-based audio conversion, local Whisper model inference via Whisper.net 1.9.0, post-processing filters, and file output.
+
+A companion MCP server (`WhisperNET.McpServer`) exposes 6 tools, 4 prompts, and 1 resource tool to AI clients over stdio transport, with path safety enforcement for all file operations.
 
 ## Project Documentation
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -19,20 +19,32 @@ ffmpeg -version
 
 ```
 VoxFlow/
-  Program.cs                    # Application entry point
+  Program.cs                    # Application entry point (CLI)
   Configuration/                # Settings loading and validation
   Audio/                        # ffmpeg conversion and WAV loading
   Processing/                   # Transcript filtering
   Services/                     # Model loading, language selection, progress UI,
                                 # output writing, startup validation,
                                 # file discovery, batch summary
+  Contracts/                    # Host-agnostic DTOs (shared with MCP server)
+  Facades/                      # Application facades (bridging static services to DI)
+  Security/                     # Path policy for MCP tool argument validation
   appsettings.json              # Active configuration
   appsettings.example.json      # Reference template
   models/                       # Local Whisper model files
   artifacts/                    # Default input/output directory
+  src/
+    WhisperNET.McpServer/       # MCP server project
+      Configuration/            # MCP-specific options (McpOptions)
+      Tools/                    # MCP tools (6 tools)
+      Prompts/                  # MCP prompts (4 guided workflows)
+      Resources/                # MCP resource tools (config inspector)
+      Program.cs                # MCP server entry point (DI + stdio)
+      appsettings.json          # MCP server configuration
   tests/
     VoxFlow.UnitTests/
     VoxFlow.EndToEndTests/
+    WhisperNET.McpServer.Tests/ # MCP server unit tests
     TestSupport/                # Shared test utilities
 ```
 
@@ -204,6 +216,90 @@ This reduces background noise and removes long silent stretches before transcrip
 | `consoleProgress.progressBarWidth` | `32` | Width of the progress bar |
 | `consoleProgress.refreshIntervalMilliseconds` | `120` | Progress bar refresh interval |
 
+## MCP Server Configuration
+
+The MCP server (`WhisperNET.McpServer`) exposes VoxFlow's transcription capabilities to AI clients via the Model Context Protocol.
+
+### MCP Server Settings
+
+The MCP server loads configuration from `src/WhisperNET.McpServer/appsettings.json` under the `mcp` key:
+
+```json
+{
+  "mcp": {
+    "enabled": true,
+    "transport": "stdio",
+    "serverName": "whispernet",
+    "serverVersion": "1.0.0",
+    "allowBatch": true,
+    "allowedInputRoots": [],
+    "allowedOutputRoots": [],
+    "maxBatchFiles": 100,
+    "requireAbsolutePaths": true
+  }
+}
+```
+
+| Setting | Default | Description |
+|---|---|---|
+| `serverName` | `whispernet` | MCP server identity name |
+| `serverVersion` | `1.0.0` | MCP server version |
+| `allowBatch` | `true` | Enable/disable batch transcription tool |
+| `allowedInputRoots` | `[]` | Allowed input root directories (empty = any absolute path) |
+| `allowedOutputRoots` | `[]` | Allowed output root directories (empty = any absolute path) |
+| `maxBatchFiles` | `100` | Maximum files per batch invocation |
+| `requireAbsolutePaths` | `true` | Require absolute paths in MCP tool arguments |
+
+### Path Safety
+
+When `allowedInputRoots` and `allowedOutputRoots` are empty, any absolute path is accepted. To restrict file access:
+
+```json
+{
+  "mcp": {
+    "allowedInputRoots": ["/Users/me/audio"],
+    "allowedOutputRoots": ["/Users/me/transcripts"]
+  }
+}
+```
+
+### VS Code MCP Client Configuration
+
+To use the MCP server from VS Code, add to `.vscode/mcp.json`:
+
+```json
+{
+  "servers": {
+    "whispernet": {
+      "type": "stdio",
+      "command": "dotnet",
+      "args": ["run", "--project", "src/WhisperNET.McpServer"]
+    }
+  }
+}
+```
+
+### Available MCP Tools
+
+| Tool | Description |
+|------|-------------|
+| `validate_environment` | Run startup validation and return diagnostics |
+| `transcribe_file` | Transcribe a single audio file |
+| `transcribe_batch` | Batch transcribe a directory of files |
+| `get_supported_languages` | Return configured supported languages |
+| `inspect_model` | Inspect Whisper model status |
+| `read_transcript` | Read a previously produced transcript |
+| `get_effective_config` | Return resolved configuration snapshot |
+
+### Available MCP Prompts
+
+| Prompt | Description |
+|--------|-------------|
+| `transcribe-local-audio` | Guide through single-file transcription |
+| `batch-transcribe-folder` | Guide through batch transcription |
+| `diagnose-transcription-setup` | Diagnose environment issues |
+| `inspect-last-transcript` | Review a transcript file |
+
 ## Local Installation
 
 ```bash
@@ -232,6 +328,14 @@ dotnet run
 
 ```bash
 dotnet run
+```
+
+### MCP Server mode
+
+Run the MCP server directly (typically launched by an AI client):
+
+```bash
+dotnet run --project src/WhisperNET.McpServer
 ```
 
 ### Output
@@ -264,13 +368,19 @@ Run end-to-end tests:
 dotnet test tests/VoxFlow.EndToEndTests/VoxFlow.EndToEndTests.csproj
 ```
 
+Run MCP server tests:
+
+```bash
+dotnet test tests/WhisperNET.McpServer.Tests/WhisperNET.McpServer.Tests.csproj
+```
+
 Run all tests:
 
 ```bash
 dotnet test
 ```
 
-Tests do not require real audio files or a checked-in Whisper model. They generate temporary settings, create a fake `ffmpeg` executable, and use generated WAV fixtures.
+Tests do not require real audio files or a checked-in Whisper model. They generate temporary settings, create a fake `ffmpeg` executable, and use generated WAV fixtures. MCP server tests cover path policy, configuration, contracts, and facade behavior.
 
 ## Common Troubleshooting
 

--- a/Security/PathPolicy.cs
+++ b/Security/PathPolicy.cs
@@ -1,0 +1,163 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+/// <summary>
+/// Validates file paths against configured allowed roots.
+/// </summary>
+internal interface IPathPolicy
+{
+    /// <summary>
+    /// Validates that a path is safe for reading input files.
+    /// </summary>
+    void ValidateInputPath(string path);
+
+    /// <summary>
+    /// Validates that a path is safe for writing output files.
+    /// </summary>
+    void ValidateOutputPath(string path);
+
+    /// <summary>
+    /// Returns true if the path is within allowed input roots.
+    /// </summary>
+    bool IsAllowedInputPath(string path);
+
+    /// <summary>
+    /// Returns true if the path is within allowed output roots.
+    /// </summary>
+    bool IsAllowedOutputPath(string path);
+}
+
+/// <summary>
+/// Enforces file access restrictions based on configured allowed roots.
+/// </summary>
+internal sealed class PathPolicy : IPathPolicy
+{
+    private readonly IReadOnlyList<string> allowedInputRoots;
+    private readonly IReadOnlyList<string> allowedOutputRoots;
+    private readonly bool requireAbsolutePaths;
+
+    public PathPolicy(
+        IReadOnlyList<string> allowedInputRoots,
+        IReadOnlyList<string> allowedOutputRoots,
+        bool requireAbsolutePaths = true)
+    {
+        this.allowedInputRoots = NormalizeRoots(allowedInputRoots);
+        this.allowedOutputRoots = NormalizeRoots(allowedOutputRoots);
+        this.requireAbsolutePaths = requireAbsolutePaths;
+    }
+
+    public void ValidateInputPath(string path)
+    {
+        ValidatePathBasics(path);
+
+        if (allowedInputRoots.Count > 0 && !IsUnderAnyRoot(path, allowedInputRoots))
+        {
+            throw new UnauthorizedAccessException(
+                $"Path is not under any allowed input root: {SanitizePath(path)}");
+        }
+    }
+
+    public void ValidateOutputPath(string path)
+    {
+        ValidatePathBasics(path);
+
+        if (allowedOutputRoots.Count > 0 && !IsUnderAnyRoot(path, allowedOutputRoots))
+        {
+            throw new UnauthorizedAccessException(
+                $"Path is not under any allowed output root: {SanitizePath(path)}");
+        }
+    }
+
+    public bool IsAllowedInputPath(string path)
+    {
+        try
+        {
+            ValidateInputPath(path);
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    public bool IsAllowedOutputPath(string path)
+    {
+        try
+        {
+            ValidateOutputPath(path);
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private void ValidatePathBasics(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            throw new ArgumentException("Path must not be empty.");
+        }
+
+        if (requireAbsolutePaths && !Path.IsPathRooted(path))
+        {
+            throw new ArgumentException($"Path must be absolute: {SanitizePath(path)}");
+        }
+
+        var normalized = Path.GetFullPath(path);
+
+        // Reject path traversal attempts.
+        if (normalized != path && ContainsTraversalSegments(path))
+        {
+            throw new UnauthorizedAccessException(
+                $"Path contains traversal sequences: {SanitizePath(path)}");
+        }
+    }
+
+    private static bool IsUnderAnyRoot(string path, IReadOnlyList<string> roots)
+    {
+        var normalized = Path.GetFullPath(path);
+        return roots.Any(root => normalized.StartsWith(root, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static bool ContainsTraversalSegments(string path)
+    {
+        return path.Contains("..") ||
+               path.Contains("~") ||
+               path.Contains('\0');
+    }
+
+    private static IReadOnlyList<string> NormalizeRoots(IReadOnlyList<string> roots)
+    {
+        return roots
+            .Where(r => !string.IsNullOrWhiteSpace(r))
+            .Select(r =>
+            {
+                var normalized = Path.GetFullPath(r);
+                return normalized.EndsWith(Path.DirectorySeparatorChar)
+                    ? normalized
+                    : normalized + Path.DirectorySeparatorChar;
+            })
+            .ToArray();
+    }
+
+    /// <summary>
+    /// Returns a sanitized version of a path for error messages to avoid leaking full paths.
+    /// </summary>
+    internal static string SanitizePath(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return "(empty)";
+        }
+
+        // Show just the filename or last segment for security.
+        var fileName = Path.GetFileName(path);
+        return string.IsNullOrWhiteSpace(fileName) ? "(directory)" : $".../{fileName}";
+    }
+}

--- a/VoxFlow.csproj
+++ b/VoxFlow.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <Compile Remove="tests/**/*.cs" />
+    <Compile Remove="src/**/*.cs" />
     <PackageReference Include="Whisper.net" Version="1.9.0" />
     <PackageReference Include="Whisper.net.Runtime" Version="1.9.0" />
     <None Update="appsettings.json">

--- a/VoxFlow.sln
+++ b/VoxFlow.sln
@@ -10,6 +10,12 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VoxFlow.UnitTests", "tests\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VoxFlow.EndToEndTests", "tests\VoxFlow.EndToEndTests\VoxFlow.EndToEndTests.csproj", "{B7E1A2D3-9C4F-4E5A-8D6B-1F2E3A4C5D6E}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{96A7F41A-69D8-4CD6-9D9C-9218775641C3}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WhisperNET.McpServer", "src\WhisperNET.McpServer\WhisperNET.McpServer.csproj", "{3BB97AAD-CDB5-45D3-A0E3-C47690BEB8A2}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WhisperNET.McpServer.Tests", "tests\WhisperNET.McpServer.Tests\WhisperNET.McpServer.Tests.csproj", "{AF50CA8C-218B-46CA-AE2A-7E9DB94ADD89}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -28,6 +34,14 @@ Global
 		{B7E1A2D3-9C4F-4E5A-8D6B-1F2E3A4C5D6E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B7E1A2D3-9C4F-4E5A-8D6B-1F2E3A4C5D6E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B7E1A2D3-9C4F-4E5A-8D6B-1F2E3A4C5D6E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3BB97AAD-CDB5-45D3-A0E3-C47690BEB8A2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3BB97AAD-CDB5-45D3-A0E3-C47690BEB8A2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3BB97AAD-CDB5-45D3-A0E3-C47690BEB8A2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3BB97AAD-CDB5-45D3-A0E3-C47690BEB8A2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AF50CA8C-218B-46CA-AE2A-7E9DB94ADD89}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AF50CA8C-218B-46CA-AE2A-7E9DB94ADD89}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AF50CA8C-218B-46CA-AE2A-7E9DB94ADD89}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AF50CA8C-218B-46CA-AE2A-7E9DB94ADD89}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -38,5 +52,7 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{5AAC8C8A-43F6-4ED4-ADA5-D657AC4DF020} = {CC94594C-0AE3-417F-A7B6-84B16765F66C}
 		{B7E1A2D3-9C4F-4E5A-8D6B-1F2E3A4C5D6E} = {CC94594C-0AE3-417F-A7B6-84B16765F66C}
+		{3BB97AAD-CDB5-45D3-A0E3-C47690BEB8A2} = {96A7F41A-69D8-4CD6-9D9C-9218775641C3}
+		{AF50CA8C-218B-46CA-AE2A-7E9DB94ADD89} = {CC94594C-0AE3-417F-A7B6-84B16765F66C}
 	EndGlobalSection
 EndGlobal

--- a/appsettings.example.json
+++ b/appsettings.example.json
@@ -87,5 +87,30 @@
       "progressBarWidth": 32,
       "refreshIntervalMilliseconds": 120
     }
+  },
+
+  "mcp": {
+    "enabled": true,
+    "transport": "stdio",
+    "serverName": "whispernet",
+    "serverVersion": "1.0.0",
+    "allowBatch": true,
+    "allowedInputRoots": [],
+    "allowedOutputRoots": [],
+    "maxBatchFiles": 100,
+    "requireAbsolutePaths": true,
+    "resources": {
+      "enabled": true,
+      "exposeLastRun": true
+    },
+    "prompts": {
+      "enabled": true
+    },
+    "logging": {
+      "minimumLevel": "Information",
+      "writeToStdErr": true,
+      "writeToFile": false,
+      "logFilePath": ""
+    }
   }
 }

--- a/docs/architecture/01-system-context.md
+++ b/docs/architecture/01-system-context.md
@@ -9,14 +9,18 @@ C4Context
     title System Context — VoxFlow
 
     Person(operator, "Operator", "Developer or user running local transcription")
+    Person(ai_client, "AI Client", "Claude, ChatGPT, GitHub Copilot, VS Code")
 
     System(app, "VoxFlow", ".NET 9 console application<br/>Orchestrates fully local audio transcription")
+    System(mcp_server, "WhisperNET.McpServer", ".NET 9 MCP server<br/>Exposes VoxFlow via Model Context Protocol")
 
     System_Ext(ffmpeg, "ffmpeg", "External process<br/>Audio format conversion and filtering")
     System_Ext(whisper_runtime, "Whisper.net + libwhisper", "In-process native library<br/>Speech-to-text inference via GGML models")
     SystemDb_Ext(filesystem, "Local File System", "Audio inputs, GGML models, config, transcript outputs")
 
     Rel(operator, app, "Runs via CLI", "dotnet run / compiled binary")
+    Rel(ai_client, mcp_server, "Invokes via MCP stdio", "JSON-RPC over stdin/stdout")
+    Rel(mcp_server, app, "References application core", "InternalsVisibleTo")
     Rel(app, ffmpeg, "Spawns child process", ".m4a → 16kHz mono .wav")
     Rel(app, whisper_runtime, "P/Invoke via Whisper.net", "Load model, run inference")
     Rel(app, filesystem, "Read/Write", "Config, audio, models, transcripts")
@@ -27,9 +31,11 @@ C4Context
 | Actor / System | Type | Interaction | Trust Level |
 |---------------|------|-------------|-------------|
 | Operator | Human | Configures `appsettings.json`, invokes CLI, reads output | Full trust (local user) |
+| AI Client | Software | Discovers and invokes tools via MCP stdio protocol | Semi-trusted (path policy enforced) |
 | ffmpeg | External process | Spawned for audio conversion; killed on cancellation | Trusted (system-installed binary) |
 | Whisper.net + libwhisper | In-process native library | Loaded once per run; model loaded from local file | Trusted (vendored native runtime) |
 | Local File System | Storage | All I/O: config, input audio, intermediate WAV, models, transcripts | Trusted (local disk) |
+| WhisperNET.McpServer | .NET 9 console process | Separate MCP host referencing VoxFlow core via InternalsVisibleTo | Trusted (same codebase) |
 
 ## Trust Boundaries
 
@@ -37,15 +43,24 @@ There is exactly one trust boundary: **the local machine**.
 
 All actors and systems operate within this boundary. The application makes no network calls during transcription. Model download (a one-time operation) is the only network-touching behavior, and it writes to a local file that is validated before use.
 
+The MCP server introduces a **semi-trusted boundary** between AI clients and the application core. File paths provided by AI clients are validated by `PathPolicy` against configurable allowed input/output root directories before any file system access occurs.
+
 ```
 ┌─────────────────────────────────────────────────────────────┐
 │                     Local Machine                           │
 │                                                             │
 │  ┌──────────────────────────────────────────────────────┐   │
-│  │              Application Process                     │   │
+│  │              Application Process (VoxFlow CLI)       │   │
 │  │  Configuration → Validation → Pipeline → Output      │   │
 │  │                                    ↕                  │   │
 │  │                              Whisper.net              │   │
+│  └──────────────────────────────────────────────────────┘   │
+│                                                             │
+│  ┌──────────────────────────────────────────────────────┐   │
+│  │        MCP Server Process (WhisperNET.McpServer)     │   │
+│  │  PathPolicy → Facades → VoxFlow Application Core     │   │
+│  │       ↕ (stdio: stdin/stdout = MCP frames)           │   │
+│  │       AI Client (Claude, ChatGPT, VS Code, etc.)     │   │
 │  └──────────────────────────────────────────────────────┘   │
 │           ↕                        ↕                        │
 │      ┌─────────┐          ┌──────────────┐                  │
@@ -74,10 +89,19 @@ All actors and systems operate within this boundary. The application makes no ne
 | Transcript | OutputWriter | Local `.txt` file | UTF-8 text | `{start}->{end}: {text}` per line |
 | Batch summary | BatchSummaryWriter | Local `.txt` file | UTF-8 text | Per-file status report |
 
+## Data Flow Summary (MCP Server)
+
+| Data | Source | Destination | Format | Notes |
+|------|--------|-------------|--------|-------|
+| MCP tool invocation | AI Client (stdin) | WhisperNET.McpServer | JSON-RPC | Tool name + arguments |
+| MCP tool result | WhisperNET.McpServer (stdout) | AI Client | JSON-RPC | Structured JSON response |
+| Diagnostic logs | WhisperNET.McpServer | stderr | Text | Console.SetOut(Console.Error) protects stdout |
+| Path validation | MCP tool arguments | PathPolicy | String | Validated against allowed roots before file access |
+
 ## What Is Deliberately Excluded
 
 The system context has no:
 
 - **Network services** — No REST APIs, no message queues, no cloud storage. This is a design choice, not a limitation.
 - **Database** — File system is the only persistence layer. For a local transcription tool, this is the right abstraction.
-- **Other applications** — The tool is standalone. The [ROADMAP](../product/ROADMAP.md) describes a future MCP server integration, but that would be a separate process with a shared application core, not a modification to this context.
+- **HTTP/SSE MCP transport** — The MCP server uses stdio only. HTTP transport would introduce network surface area that conflicts with the local-only principle.

--- a/docs/architecture/02-container-view.md
+++ b/docs/architecture/02-container-view.md
@@ -2,11 +2,14 @@
 
 > C4 Level 2 — The single-process container and its internal module boundaries.
 
-## Why "Container" for a Console App
+## Why Two Containers
 
-In C4 terminology, a container is a separately deployable/runnable unit. VoxFlow is a single container — one .NET 9 console process. There is no multi-container deployment. This is deliberate: a local transcription tool does not benefit from process separation, message passing, or distributed coordination.
+In C4 terminology, a container is a separately deployable/runnable unit. VoxFlow now has two containers:
 
-The value of the container view here is showing the **internal module boundaries** within that single process.
+1. **VoxFlow CLI** — the original console application, invoked directly by operators
+2. **WhisperNET.McpServer** — a separate .NET 9 console process that exposes VoxFlow's capabilities via the Model Context Protocol (MCP) over stdio transport
+
+The MCP server references VoxFlow's application core via `InternalsVisibleTo` and uses application facades to bridge between MCP tool invocations and the existing static services. This avoids restructuring the original codebase while providing a DI-friendly host for the MCP SDK.
 
 ## Container Diagram
 
@@ -35,6 +38,10 @@ flowchart TB
             filter["TranscriptionFilter<br/><i>Segment acceptance rules</i>"]
         end
 
+        subgraph facade_layer["Application Facade Layer"]
+            facades["IStartupValidationFacade<br/>ITranscriptionFacade<br/>IModelInspectionFacade<br/>ILanguageInfoFacade<br/>ITranscriptReaderFacade<br/><i>Instance-based wrappers around static services</i>"]
+        end
+
         subgraph output_layer["Output Layer"]
             writer["OutputWriter<br/><i>Timestamped transcript files</i>"]
             discovery["FileDiscoveryService<br/><i>Batch file enumeration</i>"]
@@ -46,10 +53,36 @@ flowchart TB
         end
     end
 
+    subgraph mcp_container["WhisperNET.McpServer Process (.NET 9)"]
+        direction TB
+
+        subgraph mcp_host["MCP Host Layer"]
+            mcp_program["Program.cs<br/><i>DI composition root,<br/>stdio transport setup</i>"]
+        end
+
+        subgraph mcp_tools["MCP Tool Layer"]
+            tools["WhisperMcpTools<br/><i>6 MCP tools</i>"]
+            resources["WhisperMcpResourceTools<br/><i>Configuration inspector</i>"]
+            prompts["WhisperMcpPrompts<br/><i>4 guided workflows</i>"]
+        end
+
+        subgraph mcp_security["Security Layer"]
+            pathpolicy["PathPolicy<br/><i>Input/output root enforcement</i>"]
+        end
+
+        subgraph mcp_config["Configuration"]
+            mcp_options["McpOptions<br/><i>Server identity, path policy,<br/>batch limits, logging</i>"]
+        end
+    end
+
     subgraph external["External Dependencies"]
         ffmpeg["ffmpeg process"]
         whisper["Whisper.net<br/>+ libwhisper native"]
         fs["Local File System"]
+    end
+
+    subgraph clients["AI Clients"]
+        ai["Claude / ChatGPT /<br/>GitHub Copilot / VS Code"]
     end
 
     program --> options
@@ -63,6 +96,16 @@ flowchart TB
     program --> summary
     lang --> filter
     lang --> progress
+
+    ai -->|stdio MCP| mcp_program
+    mcp_program --> mcp_options
+    tools --> pathpolicy
+    tools --> facades
+    facades --> startup
+    facades --> convert
+    facades --> model
+    facades --> lang
+    facades --> writer
 
     convert -.->|spawns| ffmpeg
     model -.->|P/Invoke| whisper
@@ -91,24 +134,29 @@ The internal structure follows these conventions:
 | **Native runtime calls are confined to ModelService and LanguageSelectionService.** Whisper.net is used through WhisperFactory, not directly by other modules. | By convention |
 | **File system writes are confined to OutputWriter, BatchSummaryWriter, and ModelService.** Other modules read but do not write files. | By convention |
 
-## Why Static Services
+## Why Static Services (VoxFlow CLI)
 
-All services are static classes rather than instance types behind interfaces. This is a deliberate trade-off:
+The VoxFlow CLI retains static services. This remains appropriate for the CLI host:
 
 **The case for static services:**
-- The application has exactly one execution path — there is no polymorphism needed at runtime.
+- The CLI has exactly one execution path — there is no polymorphism needed at runtime.
 - Constructor injection adds ceremony without benefit when there is no composition root or container.
 - Static methods make dependencies explicit at the call site rather than hiding them behind interface abstractions.
 - Test coverage is achieved through integration tests, test fixtures, and module boundaries — not mocks.
 
-**The cost accepted:**
-- Harder to unit test in isolation (some modules depend on file system or ffmpeg availability).
-- If the application grows significantly (e.g., MCP server integration), this would likely evolve toward interfaces and DI. The [ROADMAP](../product/ROADMAP.md) already identifies this as a future refactoring step.
+## Application Facades (MCP Server Bridge)
 
-**Why the cost is acceptable now:**
-- The test suite already achieves meaningful coverage through generated fixtures and fake ffmpeg.
-- The application is small enough that the dependency graph is fully visible in `Program.cs`.
-- Premature abstraction would obscure the simplicity of the actual flow.
+The MCP server needs DI-compatible services for the MCP SDK's constructor injection. Rather than restructuring the VoxFlow core, **application facades** bridge the gap:
+
+- Each facade implements an interface (e.g., `ITranscriptionFacade`) and wraps the existing static services
+- Facades are registered as singletons in the MCP server's DI container
+- This `InternalsVisibleTo` + facade approach is the pragmatic first step documented in the [ROADMAP](../product/ROADMAP.md)
+- A future evolution toward a shared application core with extracted interfaces remains possible without breaking the existing CLI host
+
+**Why facades instead of full refactoring:**
+- The CLI host continues to work unchanged — no regression risk
+- The MCP server gets testable, DI-friendly service contracts
+- The application layer contracts (DTOs) are host-agnostic, so both hosts can evolve independently
 
 ## Layer Interactions
 

--- a/docs/architecture/03-component-view.md
+++ b/docs/architecture/03-component-view.md
@@ -288,3 +288,95 @@ Model file missing?          → Download
 **Related types:**
 - `FileProcessingResult` (record) — file path, status, language, duration, error
 - `FileProcessingStatus` (enum) — Success, Failed, Skipped
+
+---
+
+## MCP Server Components
+
+> These components live in the `WhisperNET.McpServer` project — a separate .NET 9 console application that references VoxFlow via `InternalsVisibleTo`.
+
+### Application Contracts (DTOs)
+
+**File:** `Contracts/ApplicationContracts.cs`
+
+**Responsibility:** Host-agnostic request/response types that decouple MCP tool arguments from internal service signatures.
+
+**Key types:**
+- `TranscribeFileRequest` / `TranscribeFileResultDto` — single-file transcription contract
+- `BatchTranscribeRequest` / `BatchTranscribeResultDto` — batch transcription contract
+- `StartupValidationResultDto` / `StartupCheckDto` — validation report contract
+- `ModelInfoResultDto` — model inspection contract
+- `SupportedLanguageDto` — language info contract
+- `TranscriptReadResultDto` — transcript reading contract
+
+---
+
+### Application Facades
+
+**Files:** `Facades/IApplicationFacades.cs`, `Facades/*.cs`
+
+**Responsibility:** Instance-based wrappers around VoxFlow's static services, registered in the MCP server's DI container.
+
+| Facade | Wraps | Purpose |
+|--------|-------|---------|
+| `IStartupValidationFacade` | `StartupValidationService` | Run preflight checks, map to DTOs |
+| `ITranscriptionFacade` | Full pipeline (convert → model → load → infer → filter → write) | Orchestrate single-file and batch transcription |
+| `IModelInspectionFacade` | `ModelService` / `WhisperFactory` | Inspect model status without downloading |
+| `ILanguageInfoFacade` | `TranscriptionOptions` | Map configured languages to DTOs |
+| `ITranscriptReaderFacade` | File I/O + `IPathPolicy` | Read transcript files with path validation |
+
+---
+
+### PathPolicy (Security)
+
+**File:** `Security/PathPolicy.cs`
+
+**Responsibility:** Enforce allowed input/output root directories for file paths provided by AI clients.
+
+**Key behaviors:**
+- Validates paths are absolute (when `requireAbsolutePaths` is configured)
+- Rejects path traversal patterns (`../`, `..\\`)
+- Normalizes and checks paths against configured allowed root directories
+- Provides `SanitizePath()` for safe error messages (no raw user paths in errors)
+
+---
+
+### WhisperMcpTools (MCP Tools)
+
+**File:** `src/WhisperNET.McpServer/Tools/WhisperMcpTools.cs`
+
+**Responsibility:** Expose VoxFlow transcription capabilities as MCP tools discoverable by AI clients.
+
+**6 tools:** `validate_environment`, `transcribe_file`, `transcribe_batch`, `get_supported_languages`, `inspect_model`, `read_transcript`
+
+Each tool validates paths via `IPathPolicy`, delegates to the appropriate facade, and returns JSON-serialized results.
+
+---
+
+### WhisperMcpPrompts (MCP Prompts)
+
+**File:** `src/WhisperNET.McpServer/Prompts/WhisperMcpPrompts.cs`
+
+**Responsibility:** Provide guided workflow instructions for AI clients using VoxFlow.
+
+**4 prompts:** `transcribe-local-audio`, `batch-transcribe-folder`, `diagnose-transcription-setup`, `inspect-last-transcript`
+
+---
+
+### WhisperMcpResourceTools (MCP Resource Tools)
+
+**File:** `src/WhisperNET.McpServer/Resources/WhisperMcpResources.cs`
+
+**Responsibility:** Expose read-only VoxFlow configuration as an MCP tool.
+
+**1 tool:** `get_effective_config` — returns the resolved configuration snapshot as JSON.
+
+---
+
+### McpOptions (MCP Configuration)
+
+**File:** `src/WhisperNET.McpServer/Configuration/McpOptions.cs`
+
+**Responsibility:** MCP-specific configuration loaded from the `mcp` section of `appsettings.json`.
+
+**Key settings:** server name/version, allowed input/output roots, batch limits, path policy, resource/prompt toggles, logging.

--- a/docs/architecture/04-runtime-sequences.md
+++ b/docs/architecture/04-runtime-sequences.md
@@ -163,6 +163,62 @@ sequenceDiagram
     Program-->>User: Exit 130 (cancelled)
 ```
 
+## MCP Server — Tool Invocation
+
+```mermaid
+sequenceDiagram
+    participant AIClient as AI Client
+    participant McpServer as MCP Server (stdio)
+    participant PathPolicy
+    participant Facade as Application Facade
+    participant Pipeline as VoxFlow Pipeline
+
+    AIClient->>McpServer: MCP tool call (e.g., transcribe_file)
+    McpServer->>McpServer: Deserialize JSON-RPC request
+
+    McpServer->>PathPolicy: ValidateInputPath(inputPath)
+    alt Path validation fails
+        PathPolicy-->>McpServer: Exception (outside allowed roots)
+        McpServer-->>AIClient: JSON error response
+    end
+    PathPolicy-->>McpServer: Path accepted
+
+    opt Output path provided
+        McpServer->>PathPolicy: ValidateOutputPath(outputPath)
+        PathPolicy-->>McpServer: Path accepted
+    end
+
+    McpServer->>Facade: TranscribeFileAsync(request)
+    Facade->>Pipeline: Convert → Model → Load → Infer → Filter → Write
+    Pipeline-->>Facade: Pipeline result
+    Facade-->>McpServer: TranscribeFileResultDto
+
+    McpServer->>McpServer: Serialize to JSON
+    McpServer-->>AIClient: MCP tool result (JSON-RPC response)
+```
+
+## MCP Server — Prompt-Guided Workflow
+
+```mermaid
+sequenceDiagram
+    participant AIClient as AI Client
+    participant McpServer as MCP Server (stdio)
+
+    AIClient->>McpServer: MCP prompt request (e.g., transcribe-local-audio)
+    McpServer-->>AIClient: Workflow instructions (step-by-step guide)
+
+    Note over AIClient: AI client follows the prompt instructions
+
+    AIClient->>McpServer: validate_environment tool call
+    McpServer-->>AIClient: Validation results
+
+    AIClient->>McpServer: transcribe_file tool call
+    McpServer-->>AIClient: Transcription results
+
+    AIClient->>McpServer: read_transcript tool call
+    McpServer-->>AIClient: Transcript content
+```
+
 ## Key Observations
 
 **Model reuse in batch mode.** The Whisper model is loaded once before the file loop begins. This is a deliberate choice (ADR-010, ADR-011) — loading a GGML model is expensive, and native runtime teardown on macOS has shown instability. Sharing the factory across files trades theoretical resource isolation for practical stability.
@@ -172,3 +228,7 @@ sequenceDiagram
 **Error isolation.** Each file in the batch loop has its own try/catch. A failure in one file records the error and continues to the next (unless `stopOnFirstError` is configured). The summary report at the end provides a clear picture of what succeeded and what failed.
 
 **Temp WAV cleanup.** Intermediate WAV files are deleted after each file completes processing. This bounds disk usage during long batch runs. The `keepIntermediateFiles` option exists for debugging.
+
+**MCP stdout protection.** The MCP server redirects `Console.SetOut(Console.Error)` at startup. This ensures that any diagnostic writes from VoxFlow services go to stderr, keeping the stdout channel clean for MCP JSON-RPC protocol frames.
+
+**MCP path validation.** Every file path from an MCP tool argument passes through `PathPolicy` before reaching the application facades. This is a hard security boundary — paths outside configured allowed roots are rejected with an error response, never reaching the file system.

--- a/docs/architecture/05-quality-attributes.md
+++ b/docs/architecture/05-quality-attributes.md
@@ -124,6 +124,26 @@
 
 **Trade-off accepted:** Sequential batch processing means total time scales linearly with file count. Parallel processing could reduce wall-clock time on multi-core machines, but would require careful native runtime management and memory budgeting that is not justified for a local tool. If throughput becomes important, this would be the first design constraint to revisit (see ADR-011).
 
+## MCP Server Security
+
+**Scenario:** An AI client invokes `transcribe_file` with a path like `../../etc/passwd`.
+
+**Response:** `PathPolicy.ValidateInputPath()` rejects the path before any file system access occurs. The tool returns a JSON error: `"Input path validation failed: Path traversal is not allowed."` No file is read.
+
+**How enforced:**
+- `PathPolicy` normalizes paths and checks against configurable allowed input/output root directories
+- Absolute paths are required by default (`requireAbsolutePaths` option)
+- Path traversal patterns (`../`, `..\\`) are rejected
+- `SanitizePath()` strips sensitive path components from error messages
+- Batch mode can be disabled entirely via `allowBatch` configuration
+- Maximum batch file count is capped via `maxBatchFiles`
+
+**Scenario:** An MCP tool writes diagnostic output to stdout, corrupting the MCP protocol stream.
+
+**Response:** `Console.SetOut(Console.Error)` at MCP server startup redirects all `Console.WriteLine` calls to stderr. The stdout channel is reserved exclusively for MCP JSON-RPC frames.
+
+**Trade-off accepted:** Diagnostic output from VoxFlow services is redirected to stderr, which may not be visible to all MCP clients. This is acceptable because protocol integrity is more important than diagnostic visibility — clients can access diagnostics through the `validate_environment` tool instead.
+
 ## Quality Attribute Trade-off Matrix
 
 | Decision | Attribute Gained | Attribute Traded | Why acceptable |
@@ -135,3 +155,7 @@
 | ffmpeg as external process | Maintainability | Deployment dependency | ffmpeg is ubiquitous; validated at startup |
 | Continue-on-error batch | Reliability (partial results) | Fail-fast purity | One bad file should not discard good work |
 | Console output verbosity | Operability | Quiet operation | Diagnosability is more important for this use case |
+| MCP stdio-only transport | Privacy, simplicity | Remote access | Local-first security; no network surface area |
+| InternalsVisibleTo for MCP | Pragmatic integration | Clean module boundary | Avoids premature restructuring; facades provide the boundary |
+| Path policy enforcement | Security | Convenience (any path) | Prevents directory traversal from AI client tool arguments |
+| Console.SetOut redirect | Protocol integrity | Diagnostic visibility | MCP protocol requires clean stdout; diagnostics via tools instead |

--- a/docs/architecture/06-decision-log.md
+++ b/docs/architecture/06-decision-log.md
@@ -21,6 +21,9 @@
 | [013](#adr-013) | One result file per input file | Accepted |
 | [014](#adr-014) | Continue-on-error with batch summary | Accepted |
 | [015](#adr-015) | Temp directory for intermediate WAVs | Accepted |
+| [016](#adr-016) | MCP server as separate host with InternalsVisibleTo | Accepted |
+| [017](#adr-017) | Stdio-only MCP transport | Accepted |
+| [018](#adr-018) | Path policy for MCP tool arguments | Accepted |
 
 ---
 
@@ -325,3 +328,75 @@
 
 **Trade-offs accepted:**
 - Temporary files are deleted immediately after processing. If the user needs to inspect the WAV for debugging, they must enable `keepIntermediateFiles` before the run — they cannot recover WAVs after the fact.
+
+---
+
+## ADR-016
+
+### MCP server as a separate host with InternalsVisibleTo
+
+**Status:** Accepted
+
+**Context:** The [ROADMAP](../product/ROADMAP.md) calls for exposing VoxFlow transcription capabilities to AI clients (Claude, ChatGPT, GitHub Copilot, VS Code) via the Model Context Protocol. The MCP SDK (`ModelContextProtocol` NuGet v1.1.0) requires a DI-based composition root with constructor injection, while VoxFlow uses static services.
+
+**Decision:** Create a separate .NET 9 console application (`WhisperNET.McpServer`) that references `VoxFlow.csproj` and accesses internal types via `InternalsVisibleTo`. Application facades bridge static services to DI-compatible interfaces. Host-agnostic DTOs decouple MCP tool schemas from internal service signatures.
+
+**Alternatives considered:**
+
+| Alternative | Why rejected |
+|------------|-------------|
+| Full project restructuring (extract shared library) | High-risk refactoring for a first integration; the CLI host would need to change for no user-facing benefit |
+| Public API surface on VoxFlow | Would expose internal types permanently; harder to evolve |
+| Process-level IPC (pipe VoxFlow CLI output to MCP server) | Fragile string parsing; loses type safety; harder to test |
+| Embed MCP host in the VoxFlow CLI | Would couple the CLI to MCP SDK dependencies; Console.SetOut redirect would break existing CLI output |
+
+**Trade-offs accepted:**
+- `InternalsVisibleTo` creates a compile-time coupling between VoxFlow and the MCP server. Internal API changes in VoxFlow can break the MCP server. This is acceptable because both projects are in the same repository and tested together.
+- Application facades add a thin wrapper layer. This is minimal overhead and provides the boundary needed for future evolution toward a shared application core.
+
+---
+
+## ADR-017
+
+### Stdio-only MCP transport
+
+**Status:** Accepted
+
+**Context:** The MCP specification supports both stdio and HTTP/SSE transports. VoxFlow is a local-only, privacy-first tool.
+
+**Decision:** Support only stdio transport for the MCP server. The AI client launches the MCP server as a child process and communicates over stdin/stdout.
+
+**Alternatives considered:**
+
+| Alternative | Why rejected |
+|------------|-------------|
+| HTTP/SSE transport | Introduces network surface area; conflicts with local-only design principle; requires port management and security headers |
+| Both stdio and HTTP | Doubles the transport surface; no current requirement for remote access |
+
+**Trade-offs accepted:**
+- The MCP server can only be used by local AI clients that support stdio transport. Remote AI clients cannot connect. This is consistent with VoxFlow's local-only architecture.
+- Console output from VoxFlow services must be redirected to stderr (`Console.SetOut(Console.Error)`) to protect the stdout MCP protocol stream.
+
+---
+
+## ADR-018
+
+### Path policy for MCP tool arguments
+
+**Status:** Accepted
+
+**Context:** MCP tools accept file paths as arguments from AI clients. Unlike the CLI (where the operator provides paths directly), MCP tool arguments come from a semi-trusted source — an AI model that may hallucinate paths or be manipulated.
+
+**Decision:** Implement `PathPolicy` to validate all file paths from MCP tool arguments against configurable allowed input/output root directories. Reject paths that use traversal patterns, are not absolute (when configured), or fall outside allowed roots.
+
+**Alternatives considered:**
+
+| Alternative | Why rejected |
+|------------|-------------|
+| No path validation (trust AI client) | Security risk; AI clients may provide arbitrary paths |
+| Sandbox via file system permissions | OS-level enforcement is coarser; does not provide application-level error messages |
+| Allowlist of specific files | Too restrictive; users need directory-level access for batch workflows |
+
+**Trade-offs accepted:**
+- When allowed roots are empty (`[]`), any absolute path is accepted. This is the permissive default for local-only use. Operators can restrict roots in `appsettings.json` for tighter security.
+- Path validation adds a small overhead to every tool invocation. This is negligible compared to the transcription pipeline.

--- a/docs/architecture/07-architecture-review.md
+++ b/docs/architecture/07-architecture-review.md
@@ -52,18 +52,29 @@ Each architectural boundary has corresponding test coverage:
 
 The test support utilities (`FakeFfmpegFactory`, `TestWaveFileFactory`, `TemporaryDirectory`, `TestSettingsFileFactory`) are thoughtful — they provide deterministic test infrastructure without requiring mocking frameworks.
 
+### 6. MCP integration reuses the pipeline without restructuring it
+
+The MCP server (`WhisperNET.McpServer`) references the VoxFlow application core via `InternalsVisibleTo` and wraps static services with instance-based facades. This is a pragmatic integration pattern:
+
+- The VoxFlow CLI continues to work unchanged — zero regression risk
+- Application facades provide DI-compatible interfaces for the MCP SDK
+- Host-agnostic DTOs decouple MCP tool schemas from internal service signatures
+- Path safety enforcement (`PathPolicy`) is an MCP-specific concern that does not pollute the CLI
+
+This validates the architecture's extensibility: a second host was added without modifying any existing module.
+
 ## Deliberate Simplicity
 
 These are areas where the design intentionally avoids added complexity:
 
-### Static services instead of interfaces + DI
+### Static services in VoxFlow CLI
 
-All services are static classes. There is no `ITranscriptionFilter` or `IAudioConversionService`. This is appropriate because:
-- There is one execution path with no runtime polymorphism
+The VoxFlow CLI retains all static services. The MCP server introduces interfaces and DI through facades, but the CLI host remains unchanged. This is appropriate because:
+- The CLI has one execution path with no runtime polymorphism
 - Dependencies are visible at call sites in `Program.cs`
-- The codebase is small enough that the full dependency graph fits in one file
+- The MCP server's facade layer provides the interface boundary where it is needed
 
-**When this would change:** If the MCP server integration (ROADMAP) introduces a second host, shared services would move behind interfaces so both hosts can compose them differently.
+**Evolution path:** If a third host is added, the natural next step is extracting a shared `VoxFlow.Core` library with interfaces. The facade interfaces already define the contracts.
 
 ### No dependency injection container
 
@@ -92,7 +103,9 @@ These are not weaknesses — they are design boundaries that would shift under d
 
 | Trigger | Current State | Evolution |
 |---------|--------------|-----------|
-| MCP server integration | Static services, no DI | Extract shared application core; introduce interfaces for host-agnostic composition |
+| ~~MCP server integration~~ | ~~Static services, no DI~~ | **Done** — MCP server added as separate host with facades and DI (ADR-016) |
+| Third host or shared library | InternalsVisibleTo + facades | Extract `VoxFlow.Core` library; promote facade interfaces to shared contracts |
+| HTTP/SSE MCP transport | Stdio-only | Add HTTP transport option; requires auth, CORS, port management |
 | Parallel batch processing | Sequential loop | Producer-consumer pipeline; ffmpeg conversion overlapped with inference |
 | Multiple transcription backends | Whisper.net hardcoded | Backend interface; factory-based selection |
 | Structured output formats | Plain text only | Output format strategy; JSON/CSV writers alongside plain text |
@@ -107,11 +120,11 @@ How to know the architecture is working:
 
 | Indicator | What to watch | Current status |
 |-----------|---------------|----------------|
-| **Change locality** | A new feature touches ≤ 2 modules | Batch mode was added by creating 2 new services + loop in Program.cs; existing modules were unchanged |
+| **Change locality** | A new feature touches ≤ 2 modules | Batch mode added 2 new services; MCP server added as separate project with facades — no existing modules modified |
 | **Test independence** | Unit tests run without external dependencies | All unit tests use generated fixtures and fake externals |
 | **Startup time** | Validation completes in < 5 seconds | 15+ checks complete in 1–3 seconds |
 | **Failure clarity** | Every failure produces an actionable message | Startup validation, filter skip reasons, batch summary all provide specific messages |
-| **Dependency count** | External dependencies stay minimal | 2 runtime dependencies (ffmpeg, Whisper.net); no framework dependencies |
+| **Dependency count** | External dependencies stay minimal | CLI: 2 runtime deps (ffmpeg, Whisper.net); MCP server adds ModelContextProtocol SDK + Microsoft.Extensions.Hosting |
 
 ## Conclusion
 

--- a/docs/product/PRD.md
+++ b/docs/product/PRD.md
@@ -13,6 +13,8 @@ Provide a local C# console application that:
 - transcribes the audio with a local Whisper model
 - writes timestamped transcript lines to a local text file
 
+Additionally, expose the transcription pipeline to AI clients through a Model Context Protocol (MCP) server, enabling tools like Claude, ChatGPT, GitHub Copilot, and VS Code to discover and invoke transcription capabilities programmatically.
+
 The product must stay local-only and must not depend on cloud transcription APIs.
 
 ## Product Goals
@@ -24,6 +26,7 @@ The product must stay local-only and must not depend on cloud transcription APIs
 - Allow graceful cancellation of long-running work
 - Reduce hallucinated transcript output caused by silence and noise
 - Keep the system testable and maintainable
+- Expose transcription capabilities to AI clients via MCP protocol
 
 ## Non-Goals
 
@@ -36,6 +39,8 @@ The product must stay local-only and must not depend on cloud transcription APIs
 - Recursive subdirectory scanning for batch mode
 - Watch mode or file system monitoring
 - Merging batch results into a single output file
+- HTTP/SSE MCP transport (stdio only for local-first security)
+- MCP server as a long-lived daemon (runs only when launched by an MCP client)
 
 ## External Contract
 
@@ -282,6 +287,55 @@ Progress reporting:
 - batch mode must show file-level progress (`[File X/Y]`) alongside per-file transcription progress
 - single-file mode progress must remain unchanged
 
+### 12. MCP Server Integration
+
+The product must expose its transcription pipeline to AI clients through a Model Context Protocol (MCP) server running over stdio transport.
+
+**MCP Server Architecture:**
+
+- The MCP server is a separate .NET 9 console application (`WhisperNET.McpServer`) that references the VoxFlow application core
+- Communication uses stdio transport (stdin/stdout for protocol frames, stderr for diagnostics)
+- The server uses `InternalsVisibleTo` to access VoxFlow's internal types via application facades
+- All stdout writes are redirected to stderr to protect the MCP protocol stream
+
+**MCP Tools (6 tools):**
+
+| Tool | Description |
+|------|-------------|
+| `validate_environment` | Run startup validation and return structured diagnostic results |
+| `transcribe_file` | Transcribe a single local audio file through the full pipeline |
+| `transcribe_batch` | Batch transcribe a directory of audio files (requires batch mode enabled) |
+| `get_supported_languages` | Return configured supported languages |
+| `inspect_model` | Return Whisper model status, path, loadability, and download requirements |
+| `read_transcript` | Read a previously produced transcript file |
+
+**MCP Prompts (4 prompts):**
+
+| Prompt | Description |
+|--------|-------------|
+| `transcribe-local-audio` | Guide through transcribing a single local audio file |
+| `batch-transcribe-folder` | Guide through batch transcribing all audio files in a folder |
+| `diagnose-transcription-setup` | Diagnose the transcription environment and suggest fixes |
+| `inspect-last-transcript` | Review a generated transcript file |
+
+**MCP Resource Tools (1 tool):**
+
+| Tool | Description |
+|------|-------------|
+| `get_effective_config` | Return the resolved effective configuration snapshot |
+
+**Security requirements:**
+
+- Path safety: All file paths from MCP tool arguments must be validated against configurable allowed input/output root directories
+- Absolute paths are required by default (`requireAbsolutePaths` option)
+- Path traversal attacks (e.g., `../`) must be rejected
+- Batch mode can be disabled via configuration (`allowBatch` option)
+- Maximum batch file count is configurable (`maxBatchFiles` option)
+
+**Configuration:**
+
+The MCP server loads its configuration from `appsettings.json` under the `mcp` section, with settings for server identity, path policy, batch limits, resource/prompt toggles, and logging.
+
 ## Reliability Requirements
 
 - fail early on invalid configuration
@@ -323,6 +377,10 @@ The solution must include unit coverage for:
 - batch configuration loading and validation
 - file discovery and path generation
 - batch summary report formatting
+- MCP path policy validation (allowed roots, traversal rejection, absolute path enforcement)
+- MCP configuration defaults and custom value binding
+- application contract DTO construction and immutability
+- application facade behavior (transcript reading, path validation, truncation)
 
 ### End-to-End Tests
 
@@ -357,3 +415,7 @@ The current end-to-end tests use:
 - a batch summary report is generated with per-file status
 - batch-level progress is shown alongside per-file progress
 - unit and end-to-end tests pass
+- MCP server starts and registers tools, prompts, and resource tools
+- AI clients (Claude, ChatGPT, VS Code, etc.) can discover and invoke transcription tools via stdio MCP
+- path safety enforcement rejects all paths outside configured allowed roots
+- MCP server tests cover path policy, configuration, contracts, and facade behavior

--- a/src/WhisperNET.McpServer/Configuration/McpOptions.cs
+++ b/src/WhisperNET.McpServer/Configuration/McpOptions.cs
@@ -1,0 +1,42 @@
+#nullable enable
+using System.Collections.Generic;
+
+namespace WhisperNET.McpServer.Configuration;
+
+/// <summary>
+/// Configuration options for the MCP server, loaded from appsettings.json "mcp" section.
+/// </summary>
+public sealed class McpOptions
+{
+    public bool Enabled { get; set; } = true;
+    public string Transport { get; set; } = "stdio";
+    public string ServerName { get; set; } = "whispernet";
+    public string ServerVersion { get; set; } = "1.0.0";
+    public bool AllowBatch { get; set; } = true;
+    public List<string> AllowedInputRoots { get; set; } = new();
+    public List<string> AllowedOutputRoots { get; set; } = new();
+    public int MaxBatchFiles { get; set; } = 100;
+    public bool RequireAbsolutePaths { get; set; } = true;
+    public McpResourceOptions Resources { get; set; } = new();
+    public McpPromptOptions Prompts { get; set; } = new();
+    public McpLoggingOptions Logging { get; set; } = new();
+}
+
+public sealed class McpResourceOptions
+{
+    public bool Enabled { get; set; } = true;
+    public bool ExposeLastRun { get; set; } = true;
+}
+
+public sealed class McpPromptOptions
+{
+    public bool Enabled { get; set; } = true;
+}
+
+public sealed class McpLoggingOptions
+{
+    public string MinimumLevel { get; set; } = "Information";
+    public bool WriteToStdErr { get; set; } = true;
+    public bool WriteToFile { get; set; }
+    public string? LogFilePath { get; set; }
+}

--- a/src/WhisperNET.McpServer/Program.cs
+++ b/src/WhisperNET.McpServer/Program.cs
@@ -1,0 +1,57 @@
+#nullable enable
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using ModelContextProtocol;
+using WhisperNET.McpServer.Configuration;
+using WhisperNET.McpServer.Prompts;
+using WhisperNET.McpServer.Resources;
+using WhisperNET.McpServer.Tools;
+
+// CRITICAL: In stdio MCP mode, stdout is reserved for protocol frames.
+// Redirect all Console.Out writes to stderr so existing services that use
+// Console.WriteLine do not corrupt the MCP protocol stream.
+Console.SetOut(Console.Error);
+
+var builder = Host.CreateApplicationBuilder(args);
+
+// Load MCP-specific configuration.
+var mcpSection = builder.Configuration.GetSection("mcp");
+builder.Services.Configure<McpOptions>(mcpSection);
+
+// Register application facades.
+builder.Services.AddSingleton<IPathPolicy>(sp =>
+{
+    var mcpOptions = new McpOptions();
+    mcpSection.Bind(mcpOptions);
+    return new PathPolicy(
+        mcpOptions.AllowedInputRoots,
+        mcpOptions.AllowedOutputRoots,
+        mcpOptions.RequireAbsolutePaths);
+});
+
+builder.Services.AddSingleton<IStartupValidationFacade, StartupValidationFacade>();
+builder.Services.AddSingleton<ITranscriptionFacade, TranscriptionFacade>();
+builder.Services.AddSingleton<IModelInspectionFacade, ModelInspectionFacade>();
+builder.Services.AddSingleton<ILanguageInfoFacade, LanguageInfoFacade>();
+builder.Services.AddSingleton<ITranscriptReaderFacade, TranscriptReaderFacade>();
+
+// Configure MCP server with stdio transport.
+builder.Services
+    .AddMcpServer(options =>
+    {
+        var mcpOptions = new McpOptions();
+        mcpSection.Bind(mcpOptions);
+
+        options.ServerInfo = new()
+        {
+            Name = mcpOptions.ServerName,
+            Version = mcpOptions.ServerVersion
+        };
+    })
+    .WithStdioServerTransport()
+    .WithToolsFromAssembly(typeof(WhisperMcpTools).Assembly)
+    .WithPromptsFromAssembly(typeof(WhisperMcpPrompts).Assembly);
+
+var app = builder.Build();
+await app.RunAsync();

--- a/src/WhisperNET.McpServer/Prompts/WhisperMcpPrompts.cs
+++ b/src/WhisperNET.McpServer/Prompts/WhisperMcpPrompts.cs
@@ -1,0 +1,107 @@
+#nullable enable
+using System.ComponentModel;
+using ModelContextProtocol.Server;
+
+namespace WhisperNET.McpServer.Prompts;
+
+/// <summary>
+/// MCP prompts that provide guided workflows for AI clients using VoxFlow.
+/// </summary>
+[McpServerPromptType]
+internal sealed class WhisperMcpPrompts
+{
+    [McpServerPrompt(Name = "transcribe-local-audio")]
+    [Description("Guide through transcribing a single local audio file. Asks for the audio file path and desired output location.")]
+    public static string TranscribeLocalAudio(
+        [Description("Absolute path to the audio file to transcribe.")]
+        string audioPath,
+        [Description("Optional absolute path for the output transcript file.")]
+        string? outputPath = null)
+    {
+        var outputNote = string.IsNullOrWhiteSpace(outputPath)
+            ? "The output will be written to the default configured location."
+            : $"The transcript will be written to: {outputPath}";
+
+        return $"""
+            Please transcribe the following local audio file using VoxFlow:
+
+            Audio file: {audioPath}
+            {outputNote}
+
+            Steps:
+            1. First, run validate_environment to ensure the transcription environment is ready.
+            2. Then, run transcribe_file with the audio path.
+            3. After transcription completes, you can use read_transcript to inspect the result.
+
+            If validation fails, check the diagnostics and suggest fixes before proceeding.
+            """;
+    }
+
+    [McpServerPrompt(Name = "batch-transcribe-folder")]
+    [Description("Guide through batch transcribing all audio files in a folder.")]
+    public static string BatchTranscribeFolder(
+        [Description("Absolute path to the folder containing audio files.")]
+        string folderPath,
+        [Description("Absolute path to the output directory for transcripts.")]
+        string outputDirectory)
+    {
+        return $"""
+            Please batch transcribe all audio files in the following directory:
+
+            Input directory: {folderPath}
+            Output directory: {outputDirectory}
+
+            Steps:
+            1. Run validate_environment to ensure the transcription environment is ready.
+            2. Run get_supported_languages to confirm language configuration.
+            3. Run transcribe_batch with the input and output directories.
+            4. Review the batch results for any failures.
+            5. Optionally use read_transcript to inspect individual results.
+
+            Note: Batch transcription processes files sequentially. Large batches may take significant time.
+            """;
+    }
+
+    [McpServerPrompt(Name = "diagnose-transcription-setup")]
+    [Description("Diagnose the VoxFlow transcription environment and suggest fixes for any issues.")]
+    public static string DiagnoseTranscriptionSetup()
+    {
+        return """
+            Please diagnose the VoxFlow transcription environment:
+
+            1. Run validate_environment with detailed=true to check all prerequisites.
+            2. Run inspect_model to check the Whisper model status.
+            3. Run get_supported_languages to verify language configuration.
+
+            For each issue found:
+            - Explain what the issue is
+            - Suggest a specific fix
+            - Indicate the severity (critical vs. warning)
+
+            Common issues to check:
+            - ffmpeg not installed or not on PATH
+            - Whisper model missing or corrupt (needs download)
+            - Output directories not writable
+            - Invalid language configuration
+            """;
+    }
+
+    [McpServerPrompt(Name = "inspect-last-transcript")]
+    [Description("Help review a generated transcript file.")]
+    public static string InspectLastTranscript(
+        [Description("Absolute path to the transcript file to review.")]
+        string transcriptPath)
+    {
+        return $"""
+            Please review the following transcript file:
+
+            Transcript path: {transcriptPath}
+
+            Steps:
+            1. Use read_transcript to load the transcript content.
+            2. Summarize the key points from the transcript.
+            3. Note the total length and time coverage.
+            4. Flag any obvious issues (very short transcript, missing segments, etc.).
+            """;
+    }
+}

--- a/src/WhisperNET.McpServer/Resources/WhisperMcpResources.cs
+++ b/src/WhisperNET.McpServer/Resources/WhisperMcpResources.cs
@@ -1,0 +1,48 @@
+#nullable enable
+using System.ComponentModel;
+using System.Text.Json;
+using ModelContextProtocol.Server;
+
+namespace WhisperNET.McpServer.Resources;
+
+/// <summary>
+/// MCP tools that expose read-only VoxFlow context as inspection tools.
+/// These act as resource-like tools that return configuration and status information.
+/// </summary>
+[McpServerToolType]
+internal sealed class WhisperMcpResourceTools
+{
+    [McpServerTool(Name = "get_effective_config")]
+    [Description("Return the resolved effective configuration snapshot currently in use by VoxFlow. Safe, read-only, and idempotent.")]
+    public static string GetEffectiveConfiguration()
+    {
+        try
+        {
+            var options = TranscriptionOptions.Load();
+            var config = new
+            {
+                configurationPath = options.ConfigurationPath,
+                isBatchMode = options.IsBatchMode,
+                modelFilePath = options.ModelFilePath,
+                modelType = options.ModelType,
+                ffmpegExecutablePath = options.FfmpegExecutablePath,
+                outputSampleRate = options.OutputSampleRate,
+                outputChannelCount = options.OutputChannelCount,
+                supportedLanguages = options.GetSupportedLanguageSummary(),
+                minSegmentProbability = options.MinSegmentProbability,
+                useNoContext = options.UseNoContext,
+                noSpeechThreshold = options.NoSpeechThreshold,
+                logProbThreshold = options.LogProbThreshold,
+                entropyThreshold = options.EntropyThreshold,
+                startupValidationEnabled = options.StartupValidation.Enabled,
+                consoleProgressEnabled = options.ConsoleProgress.Enabled
+            };
+
+            return JsonSerializer.Serialize(config, new JsonSerializerOptions { WriteIndented = true });
+        }
+        catch (Exception ex)
+        {
+            return JsonSerializer.Serialize(new { error = ex.Message });
+        }
+    }
+}

--- a/src/WhisperNET.McpServer/Tools/WhisperMcpTools.cs
+++ b/src/WhisperNET.McpServer/Tools/WhisperMcpTools.cs
@@ -1,0 +1,233 @@
+#nullable enable
+using System.ComponentModel;
+using System.Text.Json;
+using Microsoft.Extensions.Options;
+using ModelContextProtocol.Server;
+using WhisperNET.McpServer.Configuration;
+
+namespace WhisperNET.McpServer.Tools;
+
+/// <summary>
+/// MCP tools that expose VoxFlow transcription capabilities to AI clients.
+/// </summary>
+[McpServerToolType]
+internal sealed class WhisperMcpTools
+{
+    private readonly IStartupValidationFacade validationFacade;
+    private readonly ITranscriptionFacade transcriptionFacade;
+    private readonly IModelInspectionFacade modelInspectionFacade;
+    private readonly ILanguageInfoFacade languageInfoFacade;
+    private readonly ITranscriptReaderFacade transcriptReaderFacade;
+    private readonly IPathPolicy pathPolicy;
+    private readonly McpOptions mcpOptions;
+
+    public WhisperMcpTools(
+        IStartupValidationFacade validationFacade,
+        ITranscriptionFacade transcriptionFacade,
+        IModelInspectionFacade modelInspectionFacade,
+        ILanguageInfoFacade languageInfoFacade,
+        ITranscriptReaderFacade transcriptReaderFacade,
+        IPathPolicy pathPolicy,
+        IOptions<McpOptions> mcpOptions)
+    {
+        this.validationFacade = validationFacade;
+        this.transcriptionFacade = transcriptionFacade;
+        this.modelInspectionFacade = modelInspectionFacade;
+        this.languageInfoFacade = languageInfoFacade;
+        this.transcriptReaderFacade = transcriptReaderFacade;
+        this.pathPolicy = pathPolicy;
+        this.mcpOptions = mcpOptions.Value;
+    }
+
+    [McpServerTool(Name = "validate_environment")]
+    [Description("Run startup validation and return structured diagnostic results. This checks ffmpeg availability, model status, language support, and path configuration. Safe, read-only, and idempotent.")]
+    public async Task<string> ValidateEnvironmentAsync(
+        [Description("Optional absolute path to a configuration file. Uses default appsettings.json if omitted.")]
+        string? configurationPath = null,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await validationFacade.ValidateAsync(configurationPath, cancellationToken)
+            .ConfigureAwait(false);
+
+        return JsonSerializer.Serialize(result, new JsonSerializerOptions { WriteIndented = true });
+    }
+
+    [McpServerTool(Name = "transcribe_file")]
+    [Description("Transcribe a single local audio file using the VoxFlow Whisper pipeline. Writes a timestamped transcript to the specified output path. Requires the input file to be under allowed input roots.")]
+    public async Task<string> TranscribeFileAsync(
+        [Description("Absolute path to a local audio file under allowed input roots.")]
+        string inputPath,
+        [Description("Optional absolute path for the resulting transcript file under allowed output roots. Uses configured default if omitted.")]
+        string? resultFilePath = null,
+        [Description("Optional absolute path to a configuration file.")]
+        string? configurationPath = null,
+        CancellationToken cancellationToken = default)
+    {
+        // Validate paths.
+        if (string.IsNullOrWhiteSpace(inputPath))
+        {
+            return JsonSerializer.Serialize(new { error = "inputPath is required." });
+        }
+
+        try
+        {
+            pathPolicy.ValidateInputPath(inputPath);
+        }
+        catch (Exception ex)
+        {
+            return JsonSerializer.Serialize(new { error = $"Input path validation failed: {ex.Message}" });
+        }
+
+        if (!string.IsNullOrWhiteSpace(resultFilePath))
+        {
+            try
+            {
+                pathPolicy.ValidateOutputPath(resultFilePath);
+            }
+            catch (Exception ex)
+            {
+                return JsonSerializer.Serialize(new { error = $"Output path validation failed: {ex.Message}" });
+            }
+        }
+
+        var request = new TranscribeFileRequest(
+            InputPath: inputPath,
+            ResultFilePath: resultFilePath,
+            ConfigurationPath: configurationPath);
+
+        var result = await transcriptionFacade.TranscribeFileAsync(request, cancellationToken)
+            .ConfigureAwait(false);
+
+        return JsonSerializer.Serialize(result, new JsonSerializerOptions { WriteIndented = true });
+    }
+
+    [McpServerTool(Name = "transcribe_batch")]
+    [Description("Run batch transcription over a directory of audio files. Requires batch mode to be enabled in MCP configuration. Each file produces its own transcript.")]
+    public async Task<string> TranscribeBatchAsync(
+        [Description("Absolute path to the input directory containing audio files.")]
+        string inputDirectory,
+        [Description("Absolute path to the output directory for transcript files.")]
+        string outputDirectory,
+        [Description("Optional file pattern for matching input files. Defaults to '*.m4a'.")]
+        string? filePattern = null,
+        [Description("Optional path for the batch summary report file.")]
+        string? summaryFilePath = null,
+        [Description("Stop the entire batch on the first file failure. Defaults to false.")]
+        bool stopOnFirstError = false,
+        [Description("Optional absolute path to a configuration file.")]
+        string? configurationPath = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (!mcpOptions.AllowBatch)
+        {
+            return JsonSerializer.Serialize(new { error = "Batch transcription is disabled in MCP configuration." });
+        }
+
+        // Validate paths.
+        if (string.IsNullOrWhiteSpace(inputDirectory))
+        {
+            return JsonSerializer.Serialize(new { error = "inputDirectory is required." });
+        }
+
+        if (string.IsNullOrWhiteSpace(outputDirectory))
+        {
+            return JsonSerializer.Serialize(new { error = "outputDirectory is required." });
+        }
+
+        try
+        {
+            pathPolicy.ValidateInputPath(inputDirectory);
+        }
+        catch (Exception ex)
+        {
+            return JsonSerializer.Serialize(new { error = $"Input directory validation failed: {ex.Message}" });
+        }
+
+        try
+        {
+            pathPolicy.ValidateOutputPath(outputDirectory);
+        }
+        catch (Exception ex)
+        {
+            return JsonSerializer.Serialize(new { error = $"Output directory validation failed: {ex.Message}" });
+        }
+
+        var request = new BatchTranscribeRequest(
+            InputDirectory: inputDirectory,
+            OutputDirectory: outputDirectory,
+            FilePattern: filePattern,
+            SummaryFilePath: summaryFilePath,
+            StopOnFirstError: stopOnFirstError,
+            ConfigurationPath: configurationPath,
+            MaxFiles: mcpOptions.MaxBatchFiles);
+
+        var result = await transcriptionFacade.TranscribeBatchAsync(request, cancellationToken)
+            .ConfigureAwait(false);
+
+        return JsonSerializer.Serialize(result, new JsonSerializerOptions { WriteIndented = true });
+    }
+
+    [McpServerTool(Name = "get_supported_languages")]
+    [Description("Return the list of supported languages from the current configuration. Safe, read-only, and fast.")]
+    public string GetSupportedLanguages(
+        [Description("Optional absolute path to a configuration file.")]
+        string? configurationPath = null)
+    {
+        try
+        {
+            var languages = languageInfoFacade.GetSupportedLanguages(configurationPath);
+            return JsonSerializer.Serialize(languages, new JsonSerializerOptions { WriteIndented = true });
+        }
+        catch (Exception ex)
+        {
+            return JsonSerializer.Serialize(new { error = ex.Message });
+        }
+    }
+
+    [McpServerTool(Name = "inspect_model")]
+    [Description("Return structured information about the configured Whisper model: path, type, file size, whether it exists and is loadable, whether it needs downloading. Safe, read-only.")]
+    public string InspectModel(
+        [Description("Optional absolute path to a configuration file.")]
+        string? configurationPath = null)
+    {
+        try
+        {
+            var result = modelInspectionFacade.InspectModel(configurationPath);
+            return JsonSerializer.Serialize(result, new JsonSerializerOptions { WriteIndented = true });
+        }
+        catch (Exception ex)
+        {
+            return JsonSerializer.Serialize(new { error = ex.Message });
+        }
+    }
+
+    [McpServerTool(Name = "read_transcript")]
+    [Description("Read a previously produced transcript file. The file must be under allowed output roots. Useful for inspecting transcription results after tool execution.")]
+    public async Task<string> ReadTranscriptAsync(
+        [Description("Absolute path to the transcript file to read.")]
+        string path,
+        [Description("Optional maximum number of characters to return. Returns the full content if omitted.")]
+        int? maxCharacters = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return JsonSerializer.Serialize(new { error = "path is required." });
+        }
+
+        try
+        {
+            var result = await transcriptReaderFacade.ReadTranscriptAsync(path, maxCharacters, cancellationToken)
+                .ConfigureAwait(false);
+            return JsonSerializer.Serialize(result, new JsonSerializerOptions { WriteIndented = true });
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            return JsonSerializer.Serialize(new { error = $"Access denied: {ex.Message}" });
+        }
+        catch (Exception ex)
+        {
+            return JsonSerializer.Serialize(new { error = ex.Message });
+        }
+    }
+}

--- a/src/WhisperNET.McpServer/WhisperNET.McpServer.csproj
+++ b/src/WhisperNET.McpServer/WhisperNET.McpServer.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>WhisperNET.McpServer</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.0" />
+    <PackageReference Include="ModelContextProtocol" Version="1.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\VoxFlow.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/src/WhisperNET.McpServer/appsettings.json
+++ b/src/WhisperNET.McpServer/appsettings.json
@@ -1,0 +1,26 @@
+{
+  "mcp": {
+    "enabled": true,
+    "transport": "stdio",
+    "serverName": "whispernet",
+    "serverVersion": "1.0.0",
+    "allowBatch": true,
+    "allowedInputRoots": [],
+    "allowedOutputRoots": [],
+    "maxBatchFiles": 100,
+    "requireAbsolutePaths": true,
+    "resources": {
+      "enabled": true,
+      "exposeLastRun": true
+    },
+    "prompts": {
+      "enabled": true
+    },
+    "logging": {
+      "minimumLevel": "Information",
+      "writeToStdErr": true,
+      "writeToFile": false,
+      "logFilePath": ""
+    }
+  }
+}

--- a/tests/WhisperNET.McpServer.Tests/ApplicationContractTests.cs
+++ b/tests/WhisperNET.McpServer.Tests/ApplicationContractTests.cs
@@ -1,0 +1,185 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+public sealed class ApplicationContractTests
+{
+    [Fact]
+    public void StartupValidationResultDto_CanBeCreated()
+    {
+        var checks = new List<StartupCheckDto>
+        {
+            new("Settings file", "Passed", "/path/to/settings.json"),
+            new("ffmpeg", "Failed", "ffmpeg not found")
+        };
+
+        var result = new StartupValidationResultDto(
+            Outcome: "FAILED",
+            CanStart: false,
+            HasWarnings: false,
+            ResolvedConfigurationPath: "/path/to/settings.json",
+            Checks: checks);
+
+        Assert.Equal("FAILED", result.Outcome);
+        Assert.False(result.CanStart);
+        Assert.Equal(2, result.Checks.Count);
+    }
+
+    [Fact]
+    public void TranscribeFileResultDto_SuccessResult()
+    {
+        var result = new TranscribeFileResultDto(
+            Success: true,
+            DetectedLanguage: "English (en)",
+            ResultFilePath: "/output/result.txt",
+            AcceptedSegmentCount: 42,
+            SkippedSegmentCount: 3,
+            Duration: TimeSpan.FromSeconds(15),
+            Warnings: Array.Empty<string>(),
+            TranscriptPreview: "00:00:01->00:00:03: Hello world");
+
+        Assert.True(result.Success);
+        Assert.Equal("English (en)", result.DetectedLanguage);
+        Assert.Equal(42, result.AcceptedSegmentCount);
+        Assert.Empty(result.Warnings);
+    }
+
+    [Fact]
+    public void TranscribeFileResultDto_FailureResult()
+    {
+        var result = new TranscribeFileResultDto(
+            Success: false,
+            DetectedLanguage: null,
+            ResultFilePath: null,
+            AcceptedSegmentCount: 0,
+            SkippedSegmentCount: 0,
+            Duration: TimeSpan.FromMilliseconds(50),
+            Warnings: new[] { "Input file not found." },
+            TranscriptPreview: null);
+
+        Assert.False(result.Success);
+        Assert.Null(result.DetectedLanguage);
+        Assert.Single(result.Warnings);
+    }
+
+    [Fact]
+    public void BatchTranscribeResultDto_CanBeCreated()
+    {
+        var fileResults = new List<BatchFileResultDto>
+        {
+            new("/input/a.m4a", "/output/a.txt", "Success", null, TimeSpan.FromSeconds(10), "English (en)"),
+            new("/input/b.m4a", "/output/b.txt", "Failed", "Corrupt header", TimeSpan.FromSeconds(1), null),
+            new("/input/c.m4a", "/output/c.txt", "Skipped", "File is empty", TimeSpan.Zero, null)
+        };
+
+        var result = new BatchTranscribeResultDto(
+            TotalFiles: 3,
+            Succeeded: 1,
+            Failed: 1,
+            Skipped: 1,
+            SummaryFilePath: "/output/summary.txt",
+            TotalDuration: TimeSpan.FromSeconds(11),
+            Results: fileResults);
+
+        Assert.Equal(3, result.TotalFiles);
+        Assert.Equal(1, result.Succeeded);
+        Assert.Equal(1, result.Failed);
+        Assert.Equal(1, result.Skipped);
+    }
+
+    [Fact]
+    public void ModelInfoResultDto_ModelReady()
+    {
+        var result = new ModelInfoResultDto(
+            ModelPath: "/models/ggml-base.bin",
+            ModelType: "Base",
+            Exists: true,
+            FileSizeBytes: 142_000_000,
+            IsLoadable: true,
+            NeedsDownload: false);
+
+        Assert.True(result.Exists);
+        Assert.True(result.IsLoadable);
+        Assert.False(result.NeedsDownload);
+    }
+
+    [Fact]
+    public void ModelInfoResultDto_ModelMissing()
+    {
+        var result = new ModelInfoResultDto(
+            ModelPath: "/models/ggml-base.bin",
+            ModelType: "Base",
+            Exists: false,
+            FileSizeBytes: null,
+            IsLoadable: false,
+            NeedsDownload: true);
+
+        Assert.False(result.Exists);
+        Assert.False(result.IsLoadable);
+        Assert.True(result.NeedsDownload);
+    }
+
+    [Fact]
+    public void SupportedLanguageDto_CanBeCreated()
+    {
+        var language = new SupportedLanguageDto("en", "English", 0);
+
+        Assert.Equal("en", language.Code);
+        Assert.Equal("English", language.DisplayName);
+        Assert.Equal(0, language.Priority);
+    }
+
+    [Fact]
+    public void TranscriptReadResultDto_FullContent()
+    {
+        var result = new TranscriptReadResultDto(
+            Path: "/output/result.txt",
+            Content: "00:00:01->00:00:03: Hello",
+            TotalLength: 25,
+            WasTruncated: false);
+
+        Assert.False(result.WasTruncated);
+        Assert.Equal(25, result.TotalLength);
+    }
+
+    [Fact]
+    public void TranscriptReadResultDto_TruncatedContent()
+    {
+        var result = new TranscriptReadResultDto(
+            Path: "/output/result.txt",
+            Content: "00:00:01->",
+            TotalLength: 500,
+            WasTruncated: true);
+
+        Assert.True(result.WasTruncated);
+        Assert.Equal(500, result.TotalLength);
+    }
+
+    [Fact]
+    public void TranscribeFileRequest_DefaultValues()
+    {
+        var request = new TranscribeFileRequest("/input/test.m4a");
+
+        Assert.Equal("/input/test.m4a", request.InputPath);
+        Assert.Null(request.ResultFilePath);
+        Assert.Null(request.ConfigurationPath);
+        Assert.Null(request.ForceLanguages);
+        Assert.True(request.OverwriteExistingResult);
+    }
+
+    [Fact]
+    public void BatchTranscribeRequest_DefaultValues()
+    {
+        var request = new BatchTranscribeRequest("/input", "/output");
+
+        Assert.Equal("/input", request.InputDirectory);
+        Assert.Equal("/output", request.OutputDirectory);
+        Assert.Null(request.FilePattern);
+        Assert.Null(request.SummaryFilePath);
+        Assert.False(request.StopOnFirstError);
+        Assert.False(request.KeepIntermediateFiles);
+        Assert.Null(request.ConfigurationPath);
+        Assert.Null(request.MaxFiles);
+    }
+}

--- a/tests/WhisperNET.McpServer.Tests/FacadeTests.cs
+++ b/tests/WhisperNET.McpServer.Tests/FacadeTests.cs
@@ -1,0 +1,149 @@
+#nullable enable
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+public sealed class FacadeTests
+{
+    [Fact]
+    public void LanguageInfoFacade_ReturnsLanguagesFromConfig()
+    {
+        // This test requires a valid appsettings.json.
+        // In real test runs, we would use a test settings file.
+        // For now, we test the DTO mapping logic.
+        var dto = new SupportedLanguageDto("en", "English", 0);
+
+        Assert.Equal("en", dto.Code);
+        Assert.Equal("English", dto.DisplayName);
+        Assert.Equal(0, dto.Priority);
+    }
+
+    [Fact]
+    public async Task TranscriptReaderFacade_RejectsPathOutsideAllowedRoots()
+    {
+        var policy = new PathPolicy(
+            allowedInputRoots: new[] { "/allowed/input" },
+            allowedOutputRoots: Array.Empty<string>(),
+            requireAbsolutePaths: true);
+
+        var facade = new TranscriptReaderFacade(policy);
+
+        await Assert.ThrowsAsync<UnauthorizedAccessException>(() =>
+            facade.ReadTranscriptAsync("/not-allowed/file.txt"));
+    }
+
+    [Fact]
+    public async Task TranscriptReaderFacade_RejectsMissingFile()
+    {
+        var tempDir = Path.GetTempPath();
+        var policy = new PathPolicy(
+            allowedInputRoots: new[] { tempDir },
+            allowedOutputRoots: Array.Empty<string>(),
+            requireAbsolutePaths: true);
+
+        var facade = new TranscriptReaderFacade(policy);
+        var fakePath = Path.Combine(tempDir, $"nonexistent_{Guid.NewGuid():N}.txt");
+
+        await Assert.ThrowsAsync<FileNotFoundException>(() =>
+            facade.ReadTranscriptAsync(fakePath));
+    }
+
+    [Fact]
+    public async Task TranscriptReaderFacade_ReadsExistingFile()
+    {
+        var tempDir = Path.GetTempPath();
+        var policy = new PathPolicy(
+            allowedInputRoots: new[] { tempDir },
+            allowedOutputRoots: Array.Empty<string>(),
+            requireAbsolutePaths: true);
+
+        var facade = new TranscriptReaderFacade(policy);
+        var filePath = Path.Combine(tempDir, $"test_{Guid.NewGuid():N}.txt");
+
+        try
+        {
+            await File.WriteAllTextAsync(filePath, "00:00:01->00:00:03: Hello world\n");
+
+            var result = await facade.ReadTranscriptAsync(filePath);
+
+            Assert.Equal(filePath, result.Path);
+            Assert.Contains("Hello world", result.Content);
+            Assert.False(result.WasTruncated);
+        }
+        finally
+        {
+            if (File.Exists(filePath)) File.Delete(filePath);
+        }
+    }
+
+    [Fact]
+    public async Task TranscriptReaderFacade_TruncatesLongContent()
+    {
+        var tempDir = Path.GetTempPath();
+        var policy = new PathPolicy(
+            allowedInputRoots: new[] { tempDir },
+            allowedOutputRoots: Array.Empty<string>(),
+            requireAbsolutePaths: true);
+
+        var facade = new TranscriptReaderFacade(policy);
+        var filePath = Path.Combine(tempDir, $"test_{Guid.NewGuid():N}.txt");
+
+        try
+        {
+            var longContent = new string('A', 1000);
+            await File.WriteAllTextAsync(filePath, longContent);
+
+            var result = await facade.ReadTranscriptAsync(filePath, maxCharacters: 100);
+
+            Assert.True(result.WasTruncated);
+            Assert.Equal(100, result.Content.Length);
+            Assert.Equal(1000, result.TotalLength);
+        }
+        finally
+        {
+            if (File.Exists(filePath)) File.Delete(filePath);
+        }
+    }
+
+    [Fact]
+    public void ModelInspectionFacade_InspectModel_StructureIsCorrect()
+    {
+        // Test the DTO structure for a missing model scenario.
+        var result = new ModelInfoResultDto(
+            ModelPath: "/models/missing.bin",
+            ModelType: "Base",
+            Exists: false,
+            FileSizeBytes: null,
+            IsLoadable: false,
+            NeedsDownload: true);
+
+        Assert.True(result.NeedsDownload);
+        Assert.False(result.Exists);
+        Assert.Null(result.FileSizeBytes);
+    }
+
+    [Fact]
+    public void StartupValidationResultDto_MapsCorrectly()
+    {
+        var checks = new[]
+        {
+            new StartupCheckDto("Settings file", "Passed", "/config/appsettings.json"),
+            new StartupCheckDto("ffmpeg", "Passed", "ffmpeg version 6.0"),
+            new StartupCheckDto("Model type", "Failed", "Invalid model type: Unknown")
+        };
+
+        var result = new StartupValidationResultDto(
+            Outcome: "FAILED",
+            CanStart: false,
+            HasWarnings: false,
+            ResolvedConfigurationPath: "/config/appsettings.json",
+            Checks: checks);
+
+        Assert.Equal(3, result.Checks.Count);
+        Assert.Equal("FAILED", result.Outcome);
+        Assert.False(result.CanStart);
+        Assert.Equal("Failed", result.Checks.Last().Status);
+    }
+}

--- a/tests/WhisperNET.McpServer.Tests/McpConfigurationTests.cs
+++ b/tests/WhisperNET.McpServer.Tests/McpConfigurationTests.cs
@@ -1,0 +1,76 @@
+#nullable enable
+using WhisperNET.McpServer.Configuration;
+using Xunit;
+
+public sealed class McpConfigurationTests
+{
+    [Fact]
+    public void McpOptions_DefaultValues_AreCorrect()
+    {
+        var options = new McpOptions();
+
+        Assert.True(options.Enabled);
+        Assert.Equal("stdio", options.Transport);
+        Assert.Equal("whispernet", options.ServerName);
+        Assert.Equal("1.0.0", options.ServerVersion);
+        Assert.True(options.AllowBatch);
+        Assert.Empty(options.AllowedInputRoots);
+        Assert.Empty(options.AllowedOutputRoots);
+        Assert.Equal(100, options.MaxBatchFiles);
+        Assert.True(options.RequireAbsolutePaths);
+    }
+
+    [Fact]
+    public void McpResourceOptions_DefaultValues_AreCorrect()
+    {
+        var options = new McpResourceOptions();
+
+        Assert.True(options.Enabled);
+        Assert.True(options.ExposeLastRun);
+    }
+
+    [Fact]
+    public void McpPromptOptions_DefaultValues_AreCorrect()
+    {
+        var options = new McpPromptOptions();
+        Assert.True(options.Enabled);
+    }
+
+    [Fact]
+    public void McpLoggingOptions_DefaultValues_AreCorrect()
+    {
+        var options = new McpLoggingOptions();
+
+        Assert.Equal("Information", options.MinimumLevel);
+        Assert.True(options.WriteToStdErr);
+        Assert.False(options.WriteToFile);
+        Assert.Null(options.LogFilePath);
+    }
+
+    [Fact]
+    public void McpOptions_CanSetCustomValues()
+    {
+        var options = new McpOptions
+        {
+            Enabled = false,
+            Transport = "http",
+            ServerName = "custom-server",
+            ServerVersion = "2.0.0",
+            AllowBatch = false,
+            AllowedInputRoots = new() { "/input1", "/input2" },
+            AllowedOutputRoots = new() { "/output1" },
+            MaxBatchFiles = 50,
+            RequireAbsolutePaths = false
+        };
+
+        Assert.False(options.Enabled);
+        Assert.Equal("http", options.Transport);
+        Assert.Equal("custom-server", options.ServerName);
+        Assert.Equal("2.0.0", options.ServerVersion);
+        Assert.False(options.AllowBatch);
+        Assert.Equal(2, options.AllowedInputRoots.Count);
+        Assert.Single(options.AllowedOutputRoots);
+        Assert.Equal(50, options.MaxBatchFiles);
+        Assert.False(options.RequireAbsolutePaths);
+    }
+}

--- a/tests/WhisperNET.McpServer.Tests/PathPolicyTests.cs
+++ b/tests/WhisperNET.McpServer.Tests/PathPolicyTests.cs
@@ -1,0 +1,146 @@
+#nullable enable
+using System;
+using System.IO;
+using Xunit;
+
+public sealed class PathPolicyTests
+{
+    [Fact]
+    public void ValidateInputPath_RejectsEmptyPath()
+    {
+        var policy = CreatePolicy();
+        Assert.Throws<ArgumentException>(() => policy.ValidateInputPath(""));
+    }
+
+    [Fact]
+    public void ValidateInputPath_RejectsNullPath()
+    {
+        var policy = CreatePolicy();
+        Assert.Throws<ArgumentException>(() => policy.ValidateInputPath(null!));
+    }
+
+    [Fact]
+    public void ValidateInputPath_RejectsRelativePath_WhenAbsoluteRequired()
+    {
+        var policy = CreatePolicy(requireAbsolutePaths: true);
+        Assert.Throws<ArgumentException>(() => policy.ValidateInputPath("relative/path.m4a"));
+    }
+
+    [Fact]
+    public void ValidateInputPath_AcceptsAbsolutePath_UnderAllowedRoot()
+    {
+        var tempDir = Path.GetTempPath();
+        var policy = CreatePolicy(inputRoots: new[] { tempDir });
+        var path = Path.Combine(tempDir, "test.m4a");
+
+        // Should not throw.
+        policy.ValidateInputPath(path);
+    }
+
+    [Fact]
+    public void ValidateInputPath_RejectsAbsolutePath_OutsideAllowedRoots()
+    {
+        var policy = CreatePolicy(inputRoots: new[] { "/allowed/input" });
+        Assert.Throws<UnauthorizedAccessException>(() =>
+            policy.ValidateInputPath("/not-allowed/test.m4a"));
+    }
+
+    [Fact]
+    public void ValidateInputPath_AcceptsAnyAbsolutePath_WhenNoRootsConfigured()
+    {
+        var policy = CreatePolicy(inputRoots: Array.Empty<string>());
+        var path = Path.Combine(Path.GetTempPath(), "test.m4a");
+
+        // No roots = no restriction. Should not throw.
+        policy.ValidateInputPath(path);
+    }
+
+    [Fact]
+    public void ValidateOutputPath_RejectsPathOutsideAllowedRoots()
+    {
+        var policy = CreatePolicy(outputRoots: new[] { "/allowed/output" });
+        Assert.Throws<UnauthorizedAccessException>(() =>
+            policy.ValidateOutputPath("/not-allowed/result.txt"));
+    }
+
+    [Fact]
+    public void ValidateOutputPath_AcceptsPathUnderAllowedRoot()
+    {
+        var tempDir = Path.GetTempPath();
+        var policy = CreatePolicy(outputRoots: new[] { tempDir });
+        var path = Path.Combine(tempDir, "result.txt");
+
+        // Should not throw.
+        policy.ValidateOutputPath(path);
+    }
+
+    [Fact]
+    public void IsAllowedInputPath_ReturnsTrueForAllowedPath()
+    {
+        var tempDir = Path.GetTempPath();
+        var policy = CreatePolicy(inputRoots: new[] { tempDir });
+        var path = Path.Combine(tempDir, "test.m4a");
+
+        Assert.True(policy.IsAllowedInputPath(path));
+    }
+
+    [Fact]
+    public void IsAllowedInputPath_ReturnsFalseForDisallowedPath()
+    {
+        var policy = CreatePolicy(inputRoots: new[] { "/allowed/input" });
+        Assert.False(policy.IsAllowedInputPath("/not-allowed/test.m4a"));
+    }
+
+    [Fact]
+    public void IsAllowedOutputPath_ReturnsTrueForAllowedPath()
+    {
+        var tempDir = Path.GetTempPath();
+        var policy = CreatePolicy(outputRoots: new[] { tempDir });
+        var path = Path.Combine(tempDir, "result.txt");
+
+        Assert.True(policy.IsAllowedOutputPath(path));
+    }
+
+    [Fact]
+    public void IsAllowedOutputPath_ReturnsFalseForDisallowedPath()
+    {
+        var policy = CreatePolicy(outputRoots: new[] { "/allowed/output" });
+        Assert.False(policy.IsAllowedOutputPath("/not-allowed/result.txt"));
+    }
+
+    [Fact]
+    public void ValidateInputPath_RejectsPathWithTraversalSegments()
+    {
+        var tempDir = Path.GetTempPath();
+        var policy = CreatePolicy(inputRoots: new[] { tempDir });
+        var traversalPath = Path.Combine(tempDir, "..", "etc", "passwd");
+
+        // Should reject because of traversal.
+        Assert.ThrowsAny<Exception>(() => policy.ValidateInputPath(traversalPath));
+    }
+
+    [Fact]
+    public void SanitizePath_ReturnsFileNameOnly()
+    {
+        var sanitized = PathPolicy.SanitizePath("/some/secret/path/file.txt");
+        Assert.Equal(".../file.txt", sanitized);
+    }
+
+    [Fact]
+    public void SanitizePath_HandlesEmptyPath()
+    {
+        Assert.Equal("(empty)", PathPolicy.SanitizePath(""));
+        Assert.Equal("(empty)", PathPolicy.SanitizePath(null!));
+    }
+
+    private static PathPolicy CreatePolicy(
+        string[]? inputRoots = null,
+        string[]? outputRoots = null,
+        bool requireAbsolutePaths = true)
+    {
+        return new PathPolicy(
+            inputRoots ?? Array.Empty<string>(),
+            outputRoots ?? Array.Empty<string>(),
+            requireAbsolutePaths);
+    }
+}

--- a/tests/WhisperNET.McpServer.Tests/WhisperNET.McpServer.Tests.csproj
+++ b/tests/WhisperNET.McpServer.Tests/WhisperNET.McpServer.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <NuGetAudit>false</NuGetAudit>
+    <RestoreNoWarn>$(RestoreNoWarn);NU1900</RestoreNoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\VoxFlow.csproj" />
+    <ProjectReference Include="..\..\src\WhisperNET.McpServer\WhisperNET.McpServer.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
- Added PathPolicy class to enforce file access restrictions based on allowed input and output roots.
- Introduced McpOptions class for configuring the MCP server, including options for input/output paths and batch processing.
- Created WhisperMcpPrompts and WhisperMcpResources classes to provide guided workflows and resource inspection tools for AI clients.
- Developed WhisperMcpTools to expose transcription capabilities and validate environment setup.
- Implemented application startup logic in Program.cs to configure services and load settings from appsettings.json.
- Added unit tests for application contracts, facades, configuration, and path policy to ensure functionality and correctness.
- Created project files for the MCP server and its tests, including necessary dependencies and settings.