### PR TITLE
Progress bar

### DIFF
--- a/src/VoxFlow.Desktop/Components/Pages/CompleteView.razor
+++ b/src/VoxFlow.Desktop/Components/Pages/CompleteView.razor
@@ -2,62 +2,114 @@
 @inject IResultActionService ResultActionService
 @implements IDisposable
 
-<div class="result-header" id="complete-screen" aria-label="Complete Screen">
-    <div class="result-header-left">
-        <button id="back-to-ready-button"
-                class="result-back-btn"
-                aria-label="Back To Ready Screen"
-                title="Back To Ready Screen"
-                @onclick="ViewModel.GoToReady">&#x2039;</button>
-        <span class="result-filename" id="result-file-name">@(ViewModel.CurrentFileName ?? "result")</span>
+<div class="complete-screen" id="complete-screen" aria-label="Complete Screen">
+    <!-- Success header -->
+    <div class="complete-header">
+        <div class="complete-success-icon" aria-hidden="true">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none">
+                <path d="M20 6L9 17l-5-5" stroke="currentColor" stroke-width="2.5"
+                      stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+        </div>
+        <h2 class="complete-title">Transcription Complete</h2>
     </div>
-</div>
 
-@if (ViewModel.TranscriptionResult is not null)
-{
-    var result = ViewModel.TranscriptionResult;
-
-    @if (!string.IsNullOrEmpty(result.DetectedLanguage))
+    @if (ViewModel.TranscriptionResult is not null)
     {
-        <p class="result-language" id="result-language">Language: @result.DetectedLanguage</p>
-    }
+        var result = ViewModel.TranscriptionResult;
 
-    @if (!string.IsNullOrEmpty(result.TranscriptPreview))
-    {
-        <div class="transcript-preview mt-4" id="transcript-preview">@result.TranscriptPreview</div>
-        @if (_isPreviewTruncated)
+        <!-- File info bar -->
+        <div class="complete-file-info">
+            <div class="complete-file-name-row">
+                <svg class="complete-file-icon" width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+                    <path d="M4 2a1 1 0 00-1 1v10a1 1 0 001 1h8a1 1 0 001-1V5.5L9.5 2H4z"
+                          stroke="currentColor" stroke-width="1.2"/>
+                    <path d="M9 2v4h4" stroke="currentColor" stroke-width="1.2"/>
+                </svg>
+                <span class="complete-file-name" id="result-file-name">@(ViewModel.CurrentFileName ?? "result")</span>
+            </div>
+            @if (!string.IsNullOrEmpty(result.DetectedLanguage))
+            {
+                <span class="complete-language-badge" id="result-language">@result.DetectedLanguage</span>
+            }
+        </div>
+
+        <!-- Transcript preview -->
+        @if (!string.IsNullOrEmpty(result.TranscriptPreview))
         {
-            <p class="text-muted mt-1" id="preview-truncation-notice">Preview shows a portion of the full transcript.</p>
+            <div class="complete-transcript-section">
+                <div class="complete-transcript-header">
+                    <span class="complete-transcript-label">Transcript Preview</span>
+                    @if (_isPreviewTruncated)
+                    {
+                        <span class="complete-truncation-badge" id="preview-truncation-notice">Partial</span>
+                    }
+                </div>
+                <div class="transcript-preview" id="transcript-preview">@result.TranscriptPreview</div>
+            </div>
+        }
+        else
+        {
+            <p class="text-muted mt-4" id="preview-unavailable">Transcript preview is not available.</p>
         }
     }
-    else
+
+    @if (!string.IsNullOrWhiteSpace(_actionError))
     {
-        <p class="text-muted mt-4" id="preview-unavailable">Transcript preview is not available.</p>
+        <div class="message message-error mt-2" id="action-error-message" aria-label="Action Error">
+            <span class="message-icon">&#x2717;</span>
+            <span>@_actionError</span>
+        </div>
     }
-}
 
-@if (!string.IsNullOrWhiteSpace(_actionError))
-{
-    <div class="message message-error mt-2" id="action-error-message" aria-label="Action Error">
-        <span class="message-icon">&#x2717;</span>
-        <span>@_actionError</span>
+    <!-- Action buttons -->
+    <div class="complete-actions">
+        <button id="copy-text-button"
+                class="btn @(_copied ? "btn-copied" : "btn-primary")"
+                aria-label="Copy Transcript"
+                title="Copy Transcript"
+                @onclick="CopyTranscript">
+            @if (_copied)
+            {
+                <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+                    <path d="M3 8.5l3.5 3.5L13 5" stroke="currentColor" stroke-width="1.5"
+                          stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+                <span>Copied!</span>
+            }
+            else
+            {
+                <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+                    <rect x="5" y="5" width="9" height="9" rx="1.5" stroke="currentColor" stroke-width="1.2"/>
+                    <path d="M3 11V3a2 2 0 012-2h6" stroke="currentColor" stroke-width="1.2"/>
+                </svg>
+                <span>Copy Text</span>
+            }
+        </button>
+        <button id="open-folder-button"
+                class="btn btn-secondary"
+                aria-label="Open Result Folder"
+                title="Open Result Folder"
+                @onclick="OpenFolder">
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+                <path d="M2 5a1 1 0 011-1h3l1.5 1.5H13a1 1 0 011 1V12a1 1 0 01-1 1H3a1 1 0 01-1-1V5z"
+                      stroke="currentColor" stroke-width="1.2"/>
+            </svg>
+            <span>Open Folder</span>
+        </button>
     </div>
-}
 
-<div class="btn-group mt-4">
-    <button id="open-folder-button"
-            class="btn btn-secondary"
-            aria-label="Open Result Folder"
-            title="Open Result Folder"
-            @onclick="OpenFolder">
-        Open Folder
-    </button>
-    <button id="copy-text-button"
-            class="btn btn-secondary"
-            aria-label="Copy Transcript"
-            title="Copy Transcript"
-            @onclick="CopyTranscript">
-        @(_copied ? "Copied!" : "Copy Text")
+    <!-- Return action -->
+    <button id="back-to-ready-button"
+            class="complete-new-btn"
+            aria-label="Back To Ready Screen"
+            title="Start a new transcription"
+            @onclick="ViewModel.GoToReady">
+        <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
+            <path d="M12 7H2M2 7l4-4M2 7l4 4" stroke="currentColor" stroke-width="1.3"
+                  stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+        New Transcription
     </button>
 </div>
 

--- a/src/VoxFlow.Desktop/Components/Pages/ReadyView.razor
+++ b/src/VoxFlow.Desktop/Components/Pages/ReadyView.razor
@@ -2,7 +2,6 @@
 
 <div class="text-center" id="ready-screen" aria-label="Ready Screen">
     <h1 class="app-main-title" id="ready-screen-title">Audio Transcription</h1>
-    <p class="text-secondary mt-2">Select an audio file to transcribe locally on this Mac</p>
 </div>
 
 @if (ViewModel.HasBlockingValidationErrors && !string.IsNullOrWhiteSpace(ViewModel.BlockingValidationMessage))
@@ -26,7 +25,7 @@
 </div>
 
 <p class="text-muted mt-4 text-center supported-formats">
-    Supported formats: M4A, WAV, MP3, AAC, FLAC, OGG, AIFF, MP4.
+    M4A, WAV, MP3, AAC, FLAC, OGG, AIFF, MP4
 </p>
 
 @code {

--- a/src/VoxFlow.Desktop/Components/Pages/RunningView.razor
+++ b/src/VoxFlow.Desktop/Components/Pages/RunningView.razor
@@ -131,29 +131,25 @@
     </div>
 
     <div class="progress-info">
-        <p class="progress-filename" id="running-file-name">
-            @(ViewModel.CurrentFileName ?? "audio file")
-        </p>
-
         @if (hasProgress)
         {
-            <p class="progress-stage" id="running-stage" aria-live="polite">
-                <span class="progress-stage-label">@FormatStage(ViewModel.CurrentProgress!.Stage):</span>
-                @ViewModel.CurrentProgress.Message
+            <p class="progress-message" id="running-stage" aria-live="polite">
+                @(!string.IsNullOrEmpty(ViewModel.CurrentProgress!.Message)
+                    ? ViewModel.CurrentProgress.Message
+                    : FormatStage(ViewModel.CurrentProgress.Stage))
             </p>
-
-            @if (!string.IsNullOrEmpty(ViewModel.CurrentProgress.CurrentLanguage))
-            {
-                <p class="progress-language">Language: @ViewModel.CurrentProgress.CurrentLanguage</p>
-            }
-
-            <p class="progress-elapsed">
-                Elapsed: <span class="text-secondary">@FormatElapsed(ViewModel.CurrentProgress.Elapsed)</span>
+            <p class="progress-meta">
+                <span id="running-file-name">@(ViewModel.CurrentFileName ?? "audio file")</span>
+                <span class="progress-dot" aria-hidden="true">&middot;</span>
+                <span>@FormatElapsed(ViewModel.CurrentProgress.Elapsed)</span>
             </p>
         }
         else
         {
-            <p class="progress-stage" id="running-starting-label">Starting transcription...</p>
+            <p class="progress-message" id="running-starting-label">Starting transcription...</p>
+            <p class="progress-meta">
+                <span id="running-file-name">@(ViewModel.CurrentFileName ?? "audio file")</span>
+            </p>
         }
     </div>
 </div>

--- a/src/VoxFlow.Desktop/Components/Pages/RunningView.razor
+++ b/src/VoxFlow.Desktop/Components/Pages/RunningView.razor
@@ -1,58 +1,162 @@
 @using System.ComponentModel
+@using System.Globalization
 @implements IDisposable
 @inject AppViewModel ViewModel
 
-<div class="file-card" id="running-screen" aria-label="Running Screen">
-    <div class="file-card-header">
-        <div class="file-card-info">
-            <div class="file-card-icon">&#x25B6;</div>
-            <span class="file-card-name" id="running-file-name">@(ViewModel.CurrentFileName ?? "audio file")</span>
+@{
+    var hasProgress = ViewModel.CurrentProgress is not null;
+    var percent = hasProgress ? Math.Clamp(ViewModel.CurrentProgress!.PercentComplete, 0, 100) : 0;
+    var radius = 80.0;
+    var circumference = 2.0 * Math.PI * radius;
+    var dashOffset = circumference * (1.0 - percent / 100.0);
+    var toRad = Math.PI / 180.0;
+    var progressDeg = percent / 100.0 * 360.0;
+
+    // Blob positions (screen space: 0deg = top, clockwise)
+    var leadAngle = (progressDeg - 90.0) * toRad;
+    var leadCx = 100.0 + radius * Math.Cos(leadAngle);
+    var leadCy = 100.0 + radius * Math.Sin(leadAngle);
+
+    var midAngle = (progressDeg * 0.4 - 90.0) * toRad;
+    var midCx = 100.0 + radius * Math.Cos(midAngle);
+    var midCy = 100.0 + radius * Math.Sin(midAngle);
+
+    var indeterminateArc = circumference * 0.25;
+    var indeterminateGap = circumference * 0.75;
+}
+
+<div id="running-screen" aria-label="Running Screen">
+    <div class="organic-progress-wrapper @(hasProgress ? "" : "organic-progress-indeterminate")"
+         role="progressbar"
+         aria-valuenow="@(hasProgress ? $"{percent:F0}" : null)"
+         aria-valuemin="0"
+         aria-valuemax="100"
+         aria-label="Transcription progress">
+        <svg class="organic-progress-svg" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+            <defs>
+                <filter id="blob-blur" x="-100%" y="-100%" width="300%" height="300%">
+                    <feGaussianBlur stdDeviation="5" />
+                </filter>
+                <filter id="arc-glow" x="-50%" y="-50%" width="200%" height="200%">
+                    <feGaussianBlur in="SourceGraphic" stdDeviation="3" result="blur" />
+                    <feMerge>
+                        <feMergeNode in="blur" />
+                        <feMergeNode in="SourceGraphic" />
+                    </feMerge>
+                </filter>
+                <filter id="center-shadow" x="-20%" y="-20%" width="140%" height="140%">
+                    <feDropShadow dx="0" dy="2" stdDeviation="8" flood-color="rgba(0,0,0,0.5)" />
+                </filter>
+                <radialGradient id="center-fill" cx="40%" cy="35%" r="65%">
+                    <stop offset="0%" stop-color="#1f1f38" />
+                    <stop offset="100%" stop-color="#1a1a2e" />
+                </radialGradient>
+            </defs>
+
+            <!-- Ambient glow -->
+            <circle cx="100" cy="100" r="80" fill="none"
+                    stroke="rgba(74,74,255,0.05)" stroke-width="44" />
+
+            <!-- Track ring -->
+            <circle cx="100" cy="100" r="80" fill="none"
+                    stroke="rgba(42,42,74,0.4)" stroke-width="14" />
+
+            @if (hasProgress)
+            {
+                @if (percent > 2)
+                {
+                    <!-- Start blob -->
+                    <circle class="organic-blob organic-blob-1"
+                            cx="100" cy="20" r="16"
+                            fill="rgba(92,92,255,0.30)" filter="url(#blob-blur)" />
+
+                    <!-- Lead blob -->
+                    <circle class="organic-blob organic-blob-2"
+                            cx="@Fmt(leadCx)" cy="@Fmt(leadCy)" r="18"
+                            fill="rgba(74,74,255,0.35)" filter="url(#blob-blur)" />
+                }
+
+                @if (percent > 18)
+                {
+                    <!-- Mid blob -->
+                    <ellipse class="organic-blob organic-blob-3"
+                             cx="@Fmt(midCx)" cy="@Fmt(midCy)" rx="14" ry="10"
+                             fill="rgba(58,58,224,0.25)" filter="url(#blob-blur)" />
+                }
+
+                <!-- Progress arc -->
+                <circle class="organic-arc"
+                        cx="100" cy="100" r="@Fmt(radius)"
+                        fill="none" stroke="rgba(74,74,255,0.85)" stroke-width="12"
+                        stroke-linecap="round"
+                        stroke-dasharray="@Fmt(circumference)"
+                        stroke-dashoffset="@Fmt(dashOffset)"
+                        transform="rotate(-90 100 100)"
+                        filter="url(#arc-glow)" />
+            }
+            else
+            {
+                <!-- Orbiting blobs -->
+                <g class="organic-orbit">
+                    <circle cx="100" cy="20" r="14"
+                            fill="rgba(74,74,255,0.25)" filter="url(#blob-blur)" />
+                    <circle cx="168" cy="140" r="12"
+                            fill="rgba(92,92,255,0.20)" filter="url(#blob-blur)" />
+                </g>
+
+                <!-- Spinning arc -->
+                <circle class="organic-spin-arc"
+                        cx="100" cy="100" r="@Fmt(radius)"
+                        fill="none" stroke="rgba(74,74,255,0.70)" stroke-width="12"
+                        stroke-linecap="round"
+                        stroke-dasharray="@Fmt(indeterminateArc) @Fmt(indeterminateGap)" />
+            }
+
+            <!-- Inner circle -->
+            <circle cx="100" cy="100" r="58" fill="url(#center-fill)" filter="url(#center-shadow)" />
+            <circle cx="100" cy="100" r="58" fill="none" stroke="rgba(74,74,255,0.10)" stroke-width="1" />
+        </svg>
+
+        <div class="organic-progress-center">
+            @if (hasProgress)
+            {
+                <span class="organic-progress-value" id="running-percent">@($"{percent:F0}")</span>
+                <span class="organic-progress-unit">%</span>
+            }
+            else
+            {
+                <div class="organic-progress-spinner"></div>
+            }
         </div>
     </div>
 
-    @if (ViewModel.CurrentProgress is not null)
-    {
-        var percent = ViewModel.CurrentProgress.PercentComplete;
-
-        <div class="progress-container">
-            <div class="progress-track"
-                 role="progressbar"
-                 aria-valuenow="@($"{percent:F0}")"
-                 aria-valuemin="0"
-                 aria-valuemax="100"
-                 aria-label="Transcription progress">
-                <div class="progress-bar"
-                     style="width: @($"{percent:F0}%")">
-                </div>
-            </div>
-            <span class="progress-percent" id="running-percent">@($"{percent:F0}%")</span>
-        </div>
-
-        <p class="file-card-stage" id="running-stage" aria-live="polite">
-            <span class="file-card-stage-label">@FormatStage(ViewModel.CurrentProgress.Stage):</span>
-            @ViewModel.CurrentProgress.Message
+    <div class="progress-info">
+        <p class="progress-filename" id="running-file-name">
+            @(ViewModel.CurrentFileName ?? "audio file")
         </p>
 
-        @if (!string.IsNullOrEmpty(ViewModel.CurrentProgress.CurrentLanguage))
+        @if (hasProgress)
         {
-            <p class="text-muted mt-2">Language: @ViewModel.CurrentProgress.CurrentLanguage</p>
-        }
-    }
-    else
-    {
-        <div class="mt-4">
-            <div class="spinner spinner-lg"></div>
-            <p class="text-muted mt-2" id="running-starting-label">Starting transcription...</p>
-        </div>
-    }
-</div>
+            <p class="progress-stage" id="running-stage" aria-live="polite">
+                <span class="progress-stage-label">@FormatStage(ViewModel.CurrentProgress!.Stage):</span>
+                @ViewModel.CurrentProgress.Message
+            </p>
 
-@if (ViewModel.CurrentProgress is not null)
-{
-    <p class="text-muted mt-4 text-center">
-        Elapsed Time: <span class="text-secondary">@FormatElapsed(ViewModel.CurrentProgress.Elapsed)</span>
-    </p>
-}
+            @if (!string.IsNullOrEmpty(ViewModel.CurrentProgress.CurrentLanguage))
+            {
+                <p class="progress-language">Language: @ViewModel.CurrentProgress.CurrentLanguage</p>
+            }
+
+            <p class="progress-elapsed">
+                Elapsed: <span class="text-secondary">@FormatElapsed(ViewModel.CurrentProgress.Elapsed)</span>
+            </p>
+        }
+        else
+        {
+            <p class="progress-stage" id="running-starting-label">Starting transcription...</p>
+        }
+    </div>
+</div>
 
 <div class="btn-group mt-4">
     <button id="cancel-transcription-button"
@@ -74,6 +178,9 @@
     {
         _ = InvokeAsync(StateHasChanged);
     }
+
+    private static string Fmt(double val) =>
+        val.ToString("F2", CultureInfo.InvariantCulture);
 
     private static string FormatElapsed(TimeSpan elapsed)
     {

--- a/src/VoxFlow.Desktop/Components/Pages/RunningView.razor
+++ b/src/VoxFlow.Desktop/Components/Pages/RunningView.razor
@@ -6,9 +6,10 @@
 @{
     var hasProgress = ViewModel.CurrentProgress is not null;
     var percent = hasProgress ? Math.Clamp(ViewModel.CurrentProgress!.PercentComplete, 0, 100) : 0;
+    var isComplete = hasProgress && ViewModel.CurrentProgress!.Stage == VoxFlow.Core.Models.ProgressStage.Complete;
     var radius = 80.0;
     var circumference = 2.0 * Math.PI * radius;
-    var dashOffset = circumference * (1.0 - percent / 100.0);
+    var dashOffset = isComplete ? 0 : circumference * (1.0 - percent / 100.0);
     var toRad = Math.PI / 180.0;
     var progressDeg = percent / 100.0 * 360.0;
 
@@ -23,10 +24,12 @@
 
     var indeterminateArc = circumference * 0.25;
     var indeterminateGap = circumference * 0.75;
+
+    var wrapperClass = isComplete ? "organic-progress-done" : hasProgress ? "" : "organic-progress-indeterminate";
 }
 
 <div id="running-screen" aria-label="Running Screen">
-    <div class="organic-progress-wrapper @(hasProgress ? "" : "organic-progress-indeterminate")"
+    <div class="organic-progress-wrapper @wrapperClass"
          role="progressbar"
          aria-valuenow="@(hasProgress ? $"{percent:F0}" : null)"
          aria-valuemin="0"
@@ -54,11 +57,11 @@
             </defs>
 
             <!-- Ambient glow -->
-            <circle cx="100" cy="100" r="80" fill="none"
+            <circle class="organic-ambient" cx="100" cy="100" r="80" fill="none"
                     stroke="rgba(74,74,255,0.05)" stroke-width="44" />
 
             <!-- Track ring -->
-            <circle cx="100" cy="100" r="80" fill="none"
+            <circle class="organic-track" cx="100" cy="100" r="80" fill="none"
                     stroke="rgba(42,42,74,0.4)" stroke-width="14" />
 
             @if (hasProgress)
@@ -114,11 +117,22 @@
 
             <!-- Inner circle -->
             <circle cx="100" cy="100" r="58" fill="url(#center-fill)" filter="url(#center-shadow)" />
-            <circle cx="100" cy="100" r="58" fill="none" stroke="rgba(74,74,255,0.10)" stroke-width="1" />
+            <circle class="organic-inner-border" cx="100" cy="100" r="58" fill="none"
+                    stroke="rgba(74,74,255,0.10)" stroke-width="1" />
         </svg>
 
         <div class="organic-progress-center">
-            @if (hasProgress)
+            @if (isComplete)
+            {
+                <div class="organic-done-content">
+                    <svg width="48" height="48" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                        <path d="M20 6L9 17l-5-5" stroke="currentColor" stroke-width="2.5"
+                              stroke-linecap="round" stroke-linejoin="round"/>
+                    </svg>
+                    <span class="organic-done-label">Done</span>
+                </div>
+            }
+            else if (hasProgress)
             {
                 <span class="organic-progress-value" id="running-percent">@($"{percent:F0}")</span>
                 <span class="organic-progress-unit">%</span>
@@ -131,7 +145,11 @@
     </div>
 
     <div class="progress-info">
-        @if (hasProgress)
+        @if (isComplete)
+        {
+            <p class="progress-message progress-message-done" id="running-stage">Transcription complete</p>
+        }
+        else if (hasProgress)
         {
             <p class="progress-message" id="running-stage" aria-live="polite">
                 @(!string.IsNullOrEmpty(ViewModel.CurrentProgress!.Message)
@@ -154,7 +172,7 @@
     </div>
 </div>
 
-<div class="btn-group mt-4">
+<div class="btn-group mt-4" style="@(isComplete ? "opacity:0;pointer-events:none" : "")">
     <button id="cancel-transcription-button"
             class="btn btn-secondary"
             aria-label="Cancel Transcription"

--- a/src/VoxFlow.Desktop/Components/Shared/DropZone.razor
+++ b/src/VoxFlow.Desktop/Components/Shared/DropZone.razor
@@ -10,23 +10,30 @@
      @onclick="BrowseFiles"
      @onkeydown="HandleKeyDown">
 
-    <div class="file-icon">
-        <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
-            <polyline points="17 8 12 3 7 8"/>
-            <line x1="12" y1="3" x2="12" y2="15"/>
-        </svg>
+    <div class="drop-zone-visual" aria-hidden="true">
+        <div class="ripple ripple-1"></div>
+        <div class="ripple ripple-2"></div>
+        <div class="ripple ripple-3"></div>
+        <div class="drop-zone-circle">
+            <svg width="28" height="28" viewBox="0 0 24 24" fill="none">
+                <path d="M12 19V5" stroke="currentColor" stroke-width="2"
+                      stroke-linecap="round"/>
+                <path d="M5 12l7-7 7 7" stroke="currentColor" stroke-width="2"
+                      stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+        </div>
     </div>
-    <span id="drop-zone-label" class="drop-label">@(Label ?? "No file selected")</span>
-    <span class="drop-hint">Choose an audio file to transcribe.</span>
+
+    <span id="drop-zone-label" class="drop-label">Drop audio file here</span>
+    <span class="drop-or">or</span>
     <button id="browse-files-button"
-            class="btn btn-primary mt-4"
+            class="btn btn-primary"
             aria-label="Browse Files"
             title="Browse Files"
             disabled="@IsDisabled"
             @onclick="BrowseFiles"
             @onclick:stopPropagation="true">
-        + Browse Files
+        Choose File
     </button>
 </div>
 

--- a/src/VoxFlow.Desktop/Components/Shared/DropZone.razor
+++ b/src/VoxFlow.Desktop/Components/Shared/DropZone.razor
@@ -15,7 +15,7 @@
         <div class="ripple ripple-2"></div>
         <div class="ripple ripple-3"></div>
         <div class="drop-zone-circle">
-            <svg width="28" height="28" viewBox="0 0 24 24" fill="none">
+            <svg width="48" height="48" viewBox="0 0 24 24" fill="none">
                 <path d="M12 19V5" stroke="currentColor" stroke-width="2"
                       stroke-linecap="round"/>
                 <path d="M5 12l7-7 7 7" stroke="currentColor" stroke-width="2"

--- a/src/VoxFlow.Desktop/ViewModels/AppViewModel.cs
+++ b/src/VoxFlow.Desktop/ViewModels/AppViewModel.cs
@@ -160,9 +160,22 @@ public class AppViewModel : INotifyPropertyChanged
         var cts = new CancellationTokenSource();
         _cts = cts;
         var progress = new BlazorProgressHandler(this);
+
+        // Load config to get wavFilePath for cleanup and resolve output directory
+        var options = await _configService.LoadAsync();
+        var wavPath = options.WavFilePath;
+
+        // Place result in ~/Documents/VoxFlow/output/{inputName}.txt
+        var outputDir = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments),
+            "VoxFlow", "output");
+        Directory.CreateDirectory(outputDir);
+        var resultFileName = Path.GetFileNameWithoutExtension(filePath) + ".txt";
+        var resultFilePath = Path.Combine(outputDir, resultFileName);
+
         try
         {
-            var request = new TranscribeFileRequest(filePath);
+            var request = new TranscribeFileRequest(filePath, ResultFilePath: resultFilePath);
             TranscriptionResult = await _transcriptionService.TranscribeFileAsync(request, progress, cts.Token);
             if (TranscriptionResult.Success)
             {
@@ -191,6 +204,7 @@ public class AppViewModel : INotifyPropertyChanged
                 _cts.Dispose();
                 _cts = null;
             }
+            CleanupTempFile(wavPath);
         }
         System.Diagnostics.Debug.WriteLine($"[AppViewModel] TranscribeFileAsync finished. State={CurrentState}");
     }
@@ -219,6 +233,21 @@ public class AppViewModel : INotifyPropertyChanged
     }
 
     public void CancelTranscription() => _cts?.Cancel();
+
+    private static void CleanupTempFile(string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path) || !File.Exists(path))
+            return;
+        try
+        {
+            File.Delete(path);
+            System.Diagnostics.Debug.WriteLine($"[AppViewModel] Deleted temp file: {path}");
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"[AppViewModel] Failed to delete temp file: {ex.Message}");
+        }
+    }
 
     public event PropertyChangedEventHandler? PropertyChanged;
     public void NotifyStateChanged() => OnPropertyChanged(string.Empty);

--- a/src/VoxFlow.Desktop/ViewModels/AppViewModel.cs
+++ b/src/VoxFlow.Desktop/ViewModels/AppViewModel.cs
@@ -164,6 +164,11 @@ public class AppViewModel : INotifyPropertyChanged
         {
             var request = new TranscribeFileRequest(filePath);
             TranscriptionResult = await _transcriptionService.TranscribeFileAsync(request, progress, cts.Token);
+            if (TranscriptionResult.Success)
+            {
+                try { await Task.Delay(1500, cts.Token); }
+                catch (OperationCanceledException) { GoToReady(); return; }
+            }
             CurrentState = TranscriptionResult.Success ? AppState.Complete : AppState.Failed;
             if (!TranscriptionResult.Success)
                 ErrorMessage = string.Join("; ", TranscriptionResult.Warnings);

--- a/src/VoxFlow.Desktop/wwwroot/css/app.css
+++ b/src/VoxFlow.Desktop/wwwroot/css/app.css
@@ -82,63 +82,142 @@ html, body {
     display: flex;
     flex-direction: column;
     align-items: center;
-    justify-content: center;
     width: 100%;
-    max-width: 480px;
-    min-height: 220px;
-    padding: 40px 32px;
-    border: 2px dashed var(--drop-zone-border);
-    border-radius: var(--border-radius);
-    background: rgba(15, 52, 96, 0.15);
-    color: var(--text-secondary);
-    text-align: center;
+    max-width: 400px;
+    padding: 48px 32px 40px;
     cursor: pointer;
-    transition: border-color var(--transition-normal),
-                background var(--transition-normal),
-                transform var(--transition-fast);
+    text-align: center;
+    transition: transform var(--transition-fast);
 }
 
 .drop-zone:hover {
-    border-color: var(--accent);
-    background: rgba(74, 74, 255, 0.06);
-}
-
-.drop-zone-disabled,
-.drop-zone-disabled:hover {
-    border-color: var(--border);
-    background: rgba(15, 52, 96, 0.08);
-    color: var(--text-muted);
-    cursor: not-allowed;
-    transform: none;
-}
-
-.drop-zone-disabled .btn {
-    cursor: not-allowed;
-}
-
-.drop-zone.drag-over {
-    border-color: var(--accent);
-    background: rgba(74, 74, 255, 0.12);
     transform: scale(1.01);
-    box-shadow: 0 0 24px rgba(74, 74, 255, 0.15);
 }
 
-.drop-zone .drop-icon {
-    font-size: 48px;
-    margin-bottom: 12px;
-    opacity: 0.7;
+/* Central circle and ripple container */
+.drop-zone-visual {
+    position: relative;
+    width: 120px;
+    height: 120px;
+    margin-bottom: 28px;
 }
 
+/* Subtle outer ring */
+.drop-zone-visual::before {
+    content: '';
+    position: absolute;
+    inset: -12px;
+    border-radius: 50%;
+    border: 1px solid rgba(74, 74, 255, 0.06);
+}
+
+.drop-zone-circle {
+    position: absolute;
+    inset: 0;
+    border-radius: 50%;
+    background: rgba(22, 33, 62, 0.7);
+    border: 1.5px solid rgba(74, 74, 255, 0.15);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--accent);
+    z-index: 1;
+    box-shadow:
+        0 4px 20px rgba(0, 0, 0, 0.3),
+        inset 0 1px 3px rgba(255, 255, 255, 0.03);
+    transition: border-color var(--transition-normal),
+                box-shadow var(--transition-normal),
+                transform var(--transition-normal);
+}
+
+.drop-zone:hover .drop-zone-circle {
+    border-color: rgba(74, 74, 255, 0.3);
+    box-shadow:
+        0 4px 30px rgba(74, 74, 255, 0.12),
+        inset 0 1px 3px rgba(255, 255, 255, 0.03);
+}
+
+/* Ripple waves */
+.ripple {
+    position: absolute;
+    inset: 0;
+    border-radius: 50%;
+    border: 1.5px solid rgba(74, 74, 255, 0.12);
+    animation: ripple-wave 3s ease-out infinite;
+}
+
+.ripple-2 { animation-delay: 1s; }
+.ripple-3 { animation-delay: 2s; }
+
+@keyframes ripple-wave {
+    0% {
+        transform: scale(1);
+        opacity: 0.5;
+    }
+    100% {
+        transform: scale(2.5);
+        opacity: 0;
+    }
+}
+
+/* Drop zone text */
 .drop-zone .drop-label {
-    font-size: 16px;
+    font-size: 15px;
     font-weight: 500;
     color: var(--text-primary);
     margin-bottom: 4px;
 }
 
-.drop-zone .drop-hint {
+.drop-zone .drop-or {
     font-size: 13px;
     color: var(--text-muted);
+    margin-bottom: 16px;
+}
+
+/* Drag-over state */
+.drop-zone.drag-over {
+    transform: scale(1.02);
+}
+
+.drop-zone.drag-over .drop-zone-circle {
+    border-color: rgba(74, 74, 255, 0.5);
+    box-shadow: 0 0 40px rgba(74, 74, 255, 0.2);
+    transform: scale(1.08);
+}
+
+.drop-zone.drag-over .ripple {
+    animation-duration: 1.5s;
+    border-color: rgba(74, 74, 255, 0.25);
+}
+
+.drop-zone.drag-over .drop-label {
+    color: var(--accent);
+}
+
+/* Disabled state */
+.drop-zone-disabled,
+.drop-zone-disabled:hover {
+    cursor: not-allowed;
+    transform: none;
+}
+
+.drop-zone-disabled .drop-zone-circle {
+    opacity: 0.35;
+    border-color: var(--border);
+}
+
+.drop-zone-disabled .ripple {
+    animation-play-state: paused;
+    opacity: 0.15;
+}
+
+.drop-zone-disabled .drop-label,
+.drop-zone-disabled .drop-or {
+    color: var(--text-muted);
+}
+
+.drop-zone-disabled .btn {
+    cursor: not-allowed;
 }
 
 .drop-zone-file-input {
@@ -264,33 +343,24 @@ html, body {
     margin: 0 auto;
 }
 
-.progress-filename {
-    font-size: 14px;
-    font-weight: 500;
-    color: var(--text-primary);
+.progress-message {
+    font-size: 13px;
+    color: var(--text-secondary);
     margin-bottom: 4px;
 }
 
-.progress-stage {
-    font-size: 12px;
-    color: var(--text-secondary);
-    margin-bottom: 2px;
-}
-
-.progress-stage-label {
-    font-weight: 500;
-}
-
-.progress-language {
+.progress-meta {
     font-size: 12px;
     color: var(--text-muted);
-    margin-top: 2px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
 }
 
-.progress-elapsed {
-    font-size: 12px;
-    color: var(--text-muted);
-    margin-top: 6px;
+.progress-dot {
+    font-size: 10px;
+    opacity: 0.5;
 }
 
 /* ---------- Transcript Preview ---------- */
@@ -308,6 +378,7 @@ html, body {
     color: var(--text-primary);
     white-space: pre-wrap;
     word-wrap: break-word;
+    user-select: text;
 }
 
 .transcript-preview::-webkit-scrollbar {
@@ -607,48 +678,176 @@ button {
     font-weight: 500;
 }
 
-/* ---------- Result Header (Complete View) ---------- */
-.result-header {
+/* ---------- Complete Screen ---------- */
+.complete-screen {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: 100%;
+    max-width: 600px;
+    animation: complete-enter 0.3s ease-out;
+}
+
+@keyframes complete-enter {
+    from { opacity: 0; transform: translateY(8px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+.complete-header {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 24px;
+}
+
+.complete-success-icon {
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    background: rgba(40, 200, 64, 0.12);
+    color: var(--success);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    animation: success-pop 0.4s ease-out 0.15s both;
+}
+
+@keyframes success-pop {
+    0% { transform: scale(0); }
+    60% { transform: scale(1.15); }
+    100% { transform: scale(1); }
+}
+
+.complete-title {
+    font-size: 20px;
+    font-weight: 600;
+    color: var(--text-primary);
+    letter-spacing: -0.3px;
+}
+
+.complete-file-info {
     display: flex;
     align-items: center;
     justify-content: space-between;
     width: 100%;
-    max-width: 600px;
-    margin-bottom: 4px;
+    padding: 12px 16px;
+    background: rgba(22, 33, 62, 0.5);
+    border: 1px solid var(--border);
+    border-radius: var(--border-radius);
+    margin-bottom: 16px;
 }
 
-.result-header-left {
+.complete-file-name-row {
     display: flex;
     align-items: center;
-    gap: 12px;
+    gap: 8px;
+    min-width: 0;
 }
 
-.result-back-btn {
+.complete-file-icon {
+    color: var(--accent);
+    flex-shrink: 0;
+}
+
+.complete-file-name {
+    font-size: 14px;
+    font-weight: 500;
+    color: var(--text-primary);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.complete-language-badge {
+    font-size: 11px;
+    font-weight: 500;
+    color: var(--accent);
+    background: rgba(74, 74, 255, 0.1);
+    border: 1px solid rgba(74, 74, 255, 0.2);
+    padding: 3px 10px;
+    border-radius: 12px;
+    letter-spacing: 0.3px;
+    white-space: nowrap;
+    flex-shrink: 0;
+}
+
+.complete-transcript-section {
+    width: 100%;
+}
+
+.complete-transcript-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 8px;
+}
+
+.complete-transcript-label {
+    font-size: 11px;
+    font-weight: 500;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.complete-truncation-badge {
+    font-size: 10px;
+    font-weight: 500;
+    color: var(--warning);
+    background: rgba(254, 188, 46, 0.08);
+    border: 1px solid rgba(254, 188, 46, 0.15);
+    padding: 2px 8px;
+    border-radius: 10px;
+    letter-spacing: 0.3px;
+}
+
+.complete-actions {
+    display: flex;
+    gap: 10px;
+    margin-top: 20px;
+}
+
+.complete-new-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    margin-top: 16px;
+    padding: 8px 16px;
     background: transparent;
     border: none;
-    color: var(--text-secondary);
-    font-size: 24px;
+    color: var(--text-muted);
+    font-size: 13px;
+    font-family: var(--font-family);
     cursor: pointer;
-    padding: 4px 8px;
     border-radius: 6px;
-    transition: background var(--transition-fast), color var(--transition-fast);
+    transition: color var(--transition-fast), background var(--transition-fast);
 }
 
-.result-back-btn:hover {
-    background: rgba(255, 255, 255, 0.06);
+.complete-new-btn:hover {
     color: var(--text-primary);
+    background: rgba(255, 255, 255, 0.04);
 }
 
-.result-filename {
-    color: var(--text-primary);
-    font-size: 16px;
-    font-weight: 600;
+/* Copied state for copy button */
+.btn-copied {
+    background: rgba(40, 200, 64, 0.15);
+    color: var(--success);
+    border: 1px solid rgba(40, 200, 64, 0.3);
 }
 
-.result-language {
-    color: var(--accent);
-    font-size: 12px;
-    margin-left: 44px;
+.btn-copied:hover:not(:disabled) {
+    background: rgba(40, 200, 64, 0.2);
+    border-color: rgba(40, 200, 64, 0.4);
+}
+
+.btn-copied svg {
+    animation: check-pop 0.2s ease-out;
+}
+
+@keyframes check-pop {
+    from { transform: scale(0.5); }
+    to { transform: scale(1); }
 }
 
 /* ---------- Blazor Error UI ---------- */

--- a/src/VoxFlow.Desktop/wwwroot/css/app.css
+++ b/src/VoxFlow.Desktop/wwwroot/css/app.css
@@ -97,9 +97,9 @@ html, body {
 /* Central circle and ripple container */
 .drop-zone-visual {
     position: relative;
-    width: 120px;
-    height: 120px;
-    margin-bottom: 28px;
+    width: 240px;
+    height: 240px;
+    margin-bottom: 32px;
 }
 
 /* Subtle outer ring */
@@ -231,9 +231,9 @@ html, body {
 /* ---------- Organic Circular Progress ---------- */
 .organic-progress-wrapper {
     position: relative;
-    width: 220px;
-    height: 220px;
-    margin: 0 auto 20px;
+    width: 440px;
+    height: 440px;
+    margin: 0 auto 24px;
 }
 
 .organic-progress-svg {
@@ -254,24 +254,24 @@ html, body {
 }
 
 .organic-progress-value {
-    font-size: 32px;
+    font-size: 56px;
     font-weight: 600;
     color: var(--accent);
-    letter-spacing: -1px;
+    letter-spacing: -2px;
     line-height: 1;
 }
 
 .organic-progress-unit {
-    font-size: 16px;
+    font-size: 28px;
     font-weight: 400;
     color: var(--accent);
     opacity: 0.7;
 }
 
 .organic-progress-spinner {
-    width: 28px;
-    height: 28px;
-    border: 2px solid rgba(74, 74, 255, 0.2);
+    width: 48px;
+    height: 48px;
+    border: 3px solid rgba(74, 74, 255, 0.2);
     border-top-color: var(--accent);
     border-radius: 50%;
     animation: spin 0.8s linear infinite;
@@ -279,7 +279,18 @@ html, body {
 
 /* Progress arc smooth transition */
 .organic-arc {
-    transition: stroke-dashoffset 300ms ease-out;
+    transition: stroke-dashoffset 300ms ease-out, stroke 500ms ease;
+}
+
+/* SVG element color transitions for completion */
+.organic-ambient,
+.organic-track,
+.organic-inner-border {
+    transition: stroke 500ms ease;
+}
+
+.organic-blob {
+    transition: fill 500ms ease;
 }
 
 /* Blob pulse animations */
@@ -361,6 +372,72 @@ html, body {
 .progress-dot {
     font-size: 10px;
     opacity: 0.5;
+}
+
+.progress-message-done {
+    color: var(--success);
+    font-weight: 500;
+}
+
+/* ---------- Completion State (green) ---------- */
+.organic-progress-done {
+    animation: done-pulse 0.6s ease-out;
+}
+
+@keyframes done-pulse {
+    0% { transform: scale(1); }
+    30% { transform: scale(1.03); }
+    100% { transform: scale(1); }
+}
+
+.organic-progress-done .organic-ambient {
+    stroke: rgba(40, 200, 64, 0.06);
+}
+
+.organic-progress-done .organic-track {
+    stroke: rgba(40, 200, 64, 0.15);
+}
+
+.organic-progress-done .organic-arc {
+    stroke: rgba(40, 200, 64, 0.85);
+}
+
+.organic-progress-done .organic-inner-border {
+    stroke: rgba(40, 200, 64, 0.15);
+}
+
+.organic-progress-done .organic-blob-1 {
+    fill: rgba(40, 200, 64, 0.30);
+}
+
+.organic-progress-done .organic-blob-2 {
+    fill: rgba(40, 200, 64, 0.35);
+}
+
+.organic-progress-done .organic-blob-3 {
+    fill: rgba(40, 200, 64, 0.25);
+}
+
+/* Done content in center */
+.organic-done-content {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+    color: var(--success);
+    animation: done-pop 0.4s ease-out;
+}
+
+.organic-done-label {
+    font-size: 22px;
+    font-weight: 600;
+    letter-spacing: 0.5px;
+}
+
+@keyframes done-pop {
+    0% { transform: scale(0.5); opacity: 0; }
+    60% { transform: scale(1.1); }
+    100% { transform: scale(1); opacity: 1; }
 }
 
 /* ---------- Transcript Preview ---------- */

--- a/src/VoxFlow.Desktop/wwwroot/css/app.css
+++ b/src/VoxFlow.Desktop/wwwroot/css/app.css
@@ -149,75 +149,148 @@ html, body {
     pointer-events: none;
 }
 
-/* ---------- Progress Bar ---------- */
-.progress-container {
-    width: 100%;
-    max-width: 480px;
-    margin: 16px 0;
-}
-
-.progress-track {
-    width: 100%;
-    height: 6px;
-    background: var(--progress-track);
-    border-radius: 3px;
-    overflow: hidden;
-}
-
-.progress-bar {
-    height: 100%;
-    background: var(--progress-bar);
-    border-radius: 3px;
-    transition: width 300ms ease-out;
+/* ---------- Organic Circular Progress ---------- */
+.organic-progress-wrapper {
     position: relative;
+    width: 220px;
+    height: 220px;
+    margin: 0 auto 20px;
 }
 
-.progress-percent {
+.organic-progress-svg {
+    width: 100%;
+    height: 100%;
     display: block;
-    text-align: right;
-    font-size: 0.85rem;
-    color: var(--text-secondary);
-    margin-top: 4px;
 }
 
-.progress-bar::after {
-    content: '';
+.organic-progress-center {
     position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background: linear-gradient(
-        90deg,
-        transparent 0%,
-        rgba(255, 255, 255, 0.15) 50%,
-        transparent 100%
-    );
-    animation: progress-shimmer 1.5s ease-in-out infinite;
-}
-
-@keyframes progress-shimmer {
-    0% { transform: translateX(-100%); }
-    100% { transform: translateX(100%); }
-}
-
-.progress-label {
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
     display: flex;
-    justify-content: space-between;
-    margin-top: 8px;
+    align-items: baseline;
+    justify-content: center;
+    gap: 2px;
+}
+
+.organic-progress-value {
+    font-size: 32px;
+    font-weight: 600;
+    color: var(--accent);
+    letter-spacing: -1px;
+    line-height: 1;
+}
+
+.organic-progress-unit {
+    font-size: 16px;
+    font-weight: 400;
+    color: var(--accent);
+    opacity: 0.7;
+}
+
+.organic-progress-spinner {
+    width: 28px;
+    height: 28px;
+    border: 2px solid rgba(74, 74, 255, 0.2);
+    border-top-color: var(--accent);
+    border-radius: 50%;
+    animation: spin 0.8s linear infinite;
+}
+
+/* Progress arc smooth transition */
+.organic-arc {
+    transition: stroke-dashoffset 300ms ease-out;
+}
+
+/* Blob pulse animations */
+.organic-blob {
+    transform-box: fill-box;
+    transform-origin: center;
+}
+
+.organic-blob-1 {
+    animation: blob-pulse-1 2.5s ease-in-out infinite;
+}
+
+.organic-blob-2 {
+    animation: blob-pulse-2 3s ease-in-out infinite;
+}
+
+.organic-blob-3 {
+    animation: blob-pulse-3 3.5s ease-in-out infinite;
+}
+
+@keyframes blob-pulse-1 {
+    0%, 100% { transform: scale(1); opacity: 1; }
+    50% { transform: scale(1.3); opacity: 0.6; }
+}
+
+@keyframes blob-pulse-2 {
+    0%, 100% { transform: scale(1); opacity: 1; }
+    50% { transform: scale(1.35); opacity: 0.55; }
+}
+
+@keyframes blob-pulse-3 {
+    0%, 100% { transform: scale(1) rotate(0deg); opacity: 1; }
+    50% { transform: scale(1.25) rotate(10deg); opacity: 0.65; }
+}
+
+/* Indeterminate animations */
+.organic-spin-arc {
+    transform-origin: 100px 100px;
+    animation: organic-spin 1.4s linear infinite;
+}
+
+@keyframes organic-spin {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
+}
+
+.organic-orbit {
+    transform-origin: 100px 100px;
+    animation: organic-orbit 3s linear infinite;
+}
+
+@keyframes organic-orbit {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
+}
+
+/* Progress info section */
+.progress-info {
+    text-align: center;
+    max-width: 480px;
+    margin: 0 auto;
+}
+
+.progress-filename {
+    font-size: 14px;
+    font-weight: 500;
+    color: var(--text-primary);
+    margin-bottom: 4px;
+}
+
+.progress-stage {
     font-size: 12px;
     color: var(--text-secondary);
+    margin-bottom: 2px;
 }
 
-/* Indeterminate progress */
-.progress-bar.indeterminate {
-    width: 30% !important;
-    animation: progress-indeterminate 1.4s ease-in-out infinite;
+.progress-stage-label {
+    font-weight: 500;
 }
 
-@keyframes progress-indeterminate {
-    0% { transform: translateX(-100%); }
-    100% { transform: translateX(400%); }
+.progress-language {
+    font-size: 12px;
+    color: var(--text-muted);
+    margin-top: 2px;
+}
+
+.progress-elapsed {
+    font-size: 12px;
+    color: var(--text-muted);
+    margin-top: 6px;
 }
 
 /* ---------- Transcript Preview ---------- */


### PR DESCRIPTION
## Summary

This PR stands alone as a focused desktop transcription-flow UX pass. It refreshes the Ready, Running, and Complete screens with a more polished file-pick/drop experience, a richer circular progress state, and clearer result actions once transcription finishes.

It also tightens the result flow behind the UI changes by writing transcript output to `~/Documents/VoxFlow/output`, improving the Open Folder behavior, and cleaning up the temporary WAV file after transcription completes.

## Testing

- `dotnet test tests/VoxFlow.Desktop.Tests/VoxFlow.Desktop.Tests.csproj --no-restore`
  - Result: failed (`42 passed`, `23 failed`, `2 skipped`)
  - The failures are in existing desktop component tests that still expect the old Ready/Running/Complete markup, selectors, and progress-copy behavior after this UI rewrite.

## Checklist

- [x] The change is scoped to one problem or one closely related slice of work.
- [x] I linked the relevant issue or explained why this PR stands alone.
- [ ] I added or updated tests when behavior changed.
- [ ] I updated docs, configuration examples, or screenshots when needed.
- [x] I did not include secrets, sensitive transcripts, or private recordings.