### PR TITLE
Input formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,21 @@ VoxFlow is a fully local, privacy-first audio transcription system that converts
 - Teams operating under data-privacy or compliance constraints that prohibit cloud transcription
 - Developers and researchers who want a scriptable, configuration-driven transcription tool
 
+## Supported Input Formats
+
+VoxFlow accepts the following audio and video formats as input. All formats are converted to WAV via ffmpeg before transcription.
+
+| Format | Extension |
+|---|---|
+| MPEG-4 Audio | `.m4a` |
+| Waveform Audio | `.wav` |
+| MP3 | `.mp3` |
+| Advanced Audio Coding | `.aac` |
+| Free Lossless Audio Codec | `.flac` |
+| Ogg Vorbis | `.ogg` |
+| Audio Interchange File Format | `.aif`, `.aiff` |
+| MPEG-4 Video (audio track) | `.mp4` |
+
 ## Key Business Capabilities
 
 - **Single-file transcription** -- point the tool at one audio file and get a timestamped transcript

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ## Executive Summary
 
-VoxFlow is a fully local, privacy-first audio transcription system that converts speech recordings into timestamped text transcripts without sending data to any external service. It ships as a shared .NET 9 transcription core with three hosts: CLI, macOS Desktop, and MCP. Transcription runs entirely on-device via Whisper.net, and the Desktop app can fall back to the same local CLI pipeline on Intel Mac Catalyst when the in-process Whisper runtime is not viable.
+VoxFlow is a fully local, privacy-first audio transcription system that converts speech recordings into timestamped text transcripts without sending data to any external service. It ships as a shared .NET 9 transcription core with three hosts: CLI, macOS Desktop, and MCP. By default, transcription runs entirely on-device via the local Whisper Base model through Whisper.net, and the Desktop app can fall back to the same local CLI pipeline on Intel Mac Catalyst when the in-process Whisper runtime is not viable.
 
 ## Demo
 
@@ -15,7 +15,7 @@ VoxFlow is a fully local, privacy-first audio transcription system that converts
 
 **Problem:** Transcribing audio recordings manually is time-consuming and error-prone. Cloud-based transcription services raise privacy and compliance concerns, especially for sensitive recordings such as interviews, meetings, or legal proceedings.
 
-**Solution:** This utility runs the entire transcription pipeline locally on the user's machine. Audio files are preprocessed, noise-filtered, and transcribed using a local Whisper model. The result is a clean, timestamped transcript file ready for review or downstream processing.
+**Solution:** This utility runs the entire transcription pipeline locally on the user's machine. Audio files are preprocessed, noise-filtered, and transcribed using a local Whisper model, with Whisper Base configured by default. The result is a clean, timestamped transcript file ready for review or downstream processing.
 
 ## Target Audience
 
@@ -58,7 +58,7 @@ VoxFlow is a .NET 9 solution with one shared processing library and three hosts:
 - `VoxFlow.Desktop` -- macOS MAUI Blazor Hybrid desktop host for single-file transcription workflow; on Intel Mac Catalyst it delegates transcription to a local CLI bridge
 - `VoxFlow.McpServer` -- stdio MCP host exposing transcription tools to AI clients
 
-The shared pipeline remains configuration loading, startup validation, ffmpeg-based audio conversion, local Whisper inference via Whisper.net 1.9.0, post-processing filters, and file output.
+The shared pipeline remains configuration loading, startup validation, ffmpeg-based audio conversion, local Whisper Base inference via Whisper.net 1.9.0 by default, post-processing filters, and file output.
 
 ## Current Repository Status
 

--- a/appsettings.example.json
+++ b/appsettings.example.json
@@ -10,7 +10,7 @@
       "inputDirectory": "artifacts/input",
       "outputDirectory": "artifacts/output",
       "tempDirectory": "",
-      "filePattern": "*.m4a",
+      "filePattern": "*",
       "stopOnFirstError": false,
       "keepIntermediateFiles": false,
       "summaryFilePath": "artifacts/batch-summary.txt"

--- a/appsettings.json
+++ b/appsettings.json
@@ -10,7 +10,7 @@
       "inputDirectory": "artifacts/input",
       "outputDirectory": "artifacts/output",
       "tempDirectory": "",
-      "filePattern": "*.m4a",
+      "filePattern": "*",
       "stopOnFirstError": false,
       "keepIntermediateFiles": false,
       "summaryFilePath": "artifacts/batch-summary.txt"

--- a/docs/architecture/03-component-view.md
+++ b/docs/architecture/03-component-view.md
@@ -206,7 +206,7 @@ All 13 interfaces are registered through `AddVoxFlowCore()`. Hosts consume them 
 | Check | Mode | What it validates |
 |-------|------|-------------------|
 | Settings file | Both | Resolved configuration path |
-| Input file | Single | Input .m4a exists |
+| Input file | Single | Input file exists and has a supported format (M4A, WAV, MP3, AAC, FLAC, OGG, AIF/AIFF, MP4) |
 | Output directory | Single | Output directory exists and is writable |
 | ffmpeg availability | Both | `ffmpeg -version` succeeds |
 | Model type | Both | Configured model type is a valid GGML type |
@@ -234,7 +234,7 @@ All 13 interfaces are registered through `AddVoxFlowCore()`. Hosts consume them 
 **Responsibility:** Invoke ffmpeg to convert input audio to filtered mono 16kHz WAV.
 
 **Key behaviors:**
-- Validates input file existence before conversion
+- Validates input file format against `SupportedInputFormats` before conversion; rejects unsupported formats with a clear error listing accepted extensions
 - Validates ffmpeg availability (separate from startup validation — can be called independently)
 - Builds ffmpeg command line from configuration (audio filters, codec settings)
 - Manages ffmpeg child process lifecycle including cancellation (kills process on token cancellation)
@@ -365,7 +365,7 @@ Model file missing?          → Download
 **Responsibility:** Discover input files for batch processing.
 
 **Key behaviors:**
-- Scans configured input directory with file pattern (e.g., `*.m4a`)
+- Scans configured input directory with file pattern; the default wildcard pattern (`*`) discovers all formats listed in `SupportedInputFormats` (M4A, WAV, MP3, AAC, FLAC, OGG, AIF/AIFF, MP4). A specific pattern (e.g., `*.mp3`) narrows discovery to that format.
 - Computes output path and temp WAV path for each file
 - Alphabetical sorting for deterministic processing order
 - Filters empty files (marked as Skipped)

--- a/docs/architecture/05-quality-attributes.md
+++ b/docs/architecture/05-quality-attributes.md
@@ -66,12 +66,12 @@
 
 ## Maintainability
 
-**Scenario:** A developer needs to add support for a new audio format (e.g., `.mp3` input).
+**Scenario:** A developer needs to add support for a new audio format.
 
-**Response:** The change is localized:
-1. Add the format to FileDiscoveryService's pattern matching
-2. Ensure ffmpeg supports the format (it already does)
-3. No changes needed to inference, filtering, or output — those stages work with WAV samples regardless of the original format
+**Response:** The change is localized to a single file:
+1. Add the extension to `SupportedInputFormats.Extensions` in `VoxFlow.Core/Configuration/SupportedInputFormats.cs`
+2. Ensure ffmpeg supports the format (it already does for all common audio/video containers)
+3. No changes needed to inference, filtering, output, CLI, Desktop, or MCP — all surfaces consume the shared format registry automatically
 
 **Scenario:** A developer needs to add a fourth host (e.g., a web API).
 

--- a/docs/architecture/09-frontend-architecture.md
+++ b/docs/architecture/09-frontend-architecture.md
@@ -125,9 +125,9 @@ File input uses three parallel mechanisms for maximum compatibility:
 
 ### 3. Mac Catalyst Native UIDropInteraction
 
-Under `#if MACCATALYST`, `MainPage.xaml.cs` attaches `UIDropInteraction` with a `NativeFileDropDelegate` to WKWebView and its ScrollView. Supports multiple UTI type identifiers (`public.file-url`, `com.apple.file-url`, `public.audio`, etc.) for drag sources. Resolves file paths from `NSItemProvider` and validates against supported audio formats.
+Under `#if MACCATALYST`, `MainPage.xaml.cs` attaches `UIDropInteraction` with a `NativeFileDropDelegate` to WKWebView and its ScrollView. Supports multiple UTI type identifiers (`public.file-url`, `com.apple.file-url`, `public.audio`, etc.) for drag sources. Resolves file paths from `NSItemProvider` and validates against the shared `SupportedInputFormats` registry in VoxFlow.Core.
 
-**Supported audio formats:** `.m4a`, `.wav`, `.mp3`, `.aac`, `.flac`, `.ogg`, `.aif`, `.aiff`, `.mp4`, `.m4b`
+**Supported audio formats:** M4A, WAV, MP3, AAC, FLAC, OGG, AIF/AIFF, MP4 (defined centrally in `VoxFlow.Core/Configuration/SupportedInputFormats.cs`)
 
 Browser-dropped files are staged into a temp directory (`voxflow-drop-{guid}/`) before transcription. Native drops resolve the file path directly.
 

--- a/docs/product/PRD.md
+++ b/docs/product/PRD.md
@@ -224,18 +224,25 @@ The application must run a configurable preflight validation stage before transc
 
 The application must convert input audio files to WAV format before transcription.
 
+**Supported input formats:** M4A, WAV, MP3, AAC, FLAC, OGG, AIF/AIFF, MP4.
+
+All supported formats are defined centrally in `SupportedInputFormats` and shared across CLI (single and batch), Desktop, and MCP surfaces. ffmpeg performs conversion to the normalized WAV format required by Whisper.
+
 **Requirements:**
 
 - Output WAV must be mono, 16000 Hz, WAV container.
 - Conversion must use a configurable ffmpeg audio-filter chain for noise reduction and silence removal.
 - The default filter chain applies noise filtering (`afftdn=nf=-25`) and silence removal (`silenceremove=stop_periods=-1:stop_threshold=-50dB:stop_duration=1`).
 - Conversion errors must produce clear, actionable diagnostics.
+- Unsupported input formats must be rejected with a clear error message listing accepted formats.
+- Batch mode discovers all supported formats by default (filePattern: `*`). A specific pattern (e.g. `*.mp3`) can still be configured to narrow discovery.
 
 **Acceptance criteria:**
 
 - The pipeline does not proceed to inference if audio conversion fails.
 - Applied audio filters are logged for diagnostic visibility.
 - The filter chain can be customized entirely through configuration without code changes.
+- Passing an unsupported file format produces an actionable error naming the supported formats.
 
 ---
 

--- a/docs/product/PRD.md
+++ b/docs/product/PRD.md
@@ -390,7 +390,7 @@ The application must support processing multiple audio files from a configured i
 **Requirements:**
 
 - Batch mode is activated by setting `processingMode` to `"batch"` in configuration.
-- File discovery scans the configured input directory for files matching a configurable pattern (default: `*.m4a`), sorted alphabetically for deterministic ordering.
+- File discovery scans the configured input directory for audio files. The default pattern (`*`) discovers all supported formats (M4A, WAV, MP3, AAC, FLAC, OGG, AIF/AIFF, MP4). A specific pattern (e.g. `*.mp3`) can be configured to narrow discovery. Results are sorted alphabetically for deterministic ordering.
 - Empty or unreadable files are skipped. An empty match set is a failure.
 - Each file follows the full pipeline: convert, load WAV, transcribe, filter, write output.
 - Each input file produces its own result `.txt` file in the configured output directory.
@@ -611,7 +611,7 @@ The following settings must be configurable:
 | Dependency | Role | Acquisition |
 |---|---|---|
 | **.NET 9 runtime** | Application host | Pre-installed or bundled |
-| **ffmpeg** | Audio preprocessing (format conversion, noise filtering, silence removal) | Must be available on PATH or at the configured path. Not bundled. |
+| **ffmpeg** | Audio preprocessing — converts supported input formats (M4A, WAV, MP3, AAC, FLAC, OGG, AIF/AIFF, MP4) to normalized WAV, applies noise filtering and silence removal | Must be available on PATH or at the configured path. Not bundled. |
 | **Whisper model file** | Local speech-to-text inference | Downloaded automatically on first use if not already present. This is the only network operation. |
 | **Whisper.net** | .NET binding for Whisper inference | NuGet dependency, bundled at build time |
 

--- a/src/VoxFlow.Cli/appsettings.json
+++ b/src/VoxFlow.Cli/appsettings.json
@@ -10,7 +10,7 @@
       "inputDirectory": "artifacts/input",
       "outputDirectory": "artifacts/output",
       "tempDirectory": "",
-      "filePattern": "*.m4a",
+      "filePattern": "*",
       "stopOnFirstError": false,
       "keepIntermediateFiles": false,
       "summaryFilePath": "artifacts/batch-summary.txt"

--- a/src/VoxFlow.Core/Configuration/SupportedInputFormats.cs
+++ b/src/VoxFlow.Core/Configuration/SupportedInputFormats.cs
@@ -1,0 +1,62 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace VoxFlow.Core.Configuration;
+
+/// <summary>
+/// Defines the audio file formats that the transcription pipeline can accept as input.
+/// All listed formats are convertible to WAV via ffmpeg before Whisper inference.
+/// </summary>
+public static class SupportedInputFormats
+{
+    /// <summary>
+    /// File extensions (with leading dot, lowercase) accepted by the pipeline.
+    /// </summary>
+    public static IReadOnlyList<string> Extensions { get; } = new[]
+    {
+        ".m4a",
+        ".wav",
+        ".mp3",
+        ".aac",
+        ".flac",
+        ".ogg",
+        ".aif",
+        ".aiff",
+        ".mp4"
+    };
+
+    /// <summary>
+    /// Glob patterns matching all supported extensions, suitable for batch file discovery.
+    /// </summary>
+    public static IReadOnlyList<string> GlobPatterns { get; } =
+        Extensions.Select(ext => $"*{ext}").ToArray();
+
+    /// <summary>
+    /// Comma-separated accept string for HTML file inputs (e.g. ".m4a,.wav,.mp3").
+    /// </summary>
+    public static string HtmlAcceptString { get; } =
+        string.Join(",", Extensions) + ",audio/*";
+
+    private static readonly HashSet<string> ExtensionSet =
+        new(Extensions, StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Returns true when the file extension is a recognized input format.
+    /// </summary>
+    public static bool IsSupported(string filePath)
+    {
+        var extension = Path.GetExtension(filePath);
+        return !string.IsNullOrEmpty(extension) && ExtensionSet.Contains(extension);
+    }
+
+    /// <summary>
+    /// Returns a human-readable summary of all supported formats.
+    /// </summary>
+    public static string GetDisplaySummary()
+    {
+        return string.Join(", ", Extensions.Select(ext => ext.TrimStart('.').ToUpperInvariant()));
+    }
+}

--- a/src/VoxFlow.Core/Configuration/TranscriptionOptions.cs
+++ b/src/VoxFlow.Core/Configuration/TranscriptionOptions.cs
@@ -273,7 +273,7 @@ public sealed class TranscriptionOptions
 
         var inputDirectory = RequireValue(configuration.InputDirectory, nameof(configuration.InputDirectory));
         var outputDirectory = RequireValue(configuration.OutputDirectory, nameof(configuration.OutputDirectory));
-        var filePattern = string.IsNullOrWhiteSpace(configuration.FilePattern) ? "*.m4a" : configuration.FilePattern.Trim();
+        var filePattern = string.IsNullOrWhiteSpace(configuration.FilePattern) ? "*" : configuration.FilePattern.Trim();
         var tempDirectory = string.IsNullOrWhiteSpace(configuration.TempDirectory)
             ? Path.GetTempPath()
             : configuration.TempDirectory.Trim();
@@ -484,7 +484,7 @@ public sealed record BatchOptions(
         InputDirectory: string.Empty,
         OutputDirectory: string.Empty,
         TempDirectory: string.Empty,
-        FilePattern: "*.m4a",
+        FilePattern: "*",
         StopOnFirstError: false,
         KeepIntermediateFiles: false,
         SummaryFilePath: string.Empty);

--- a/src/VoxFlow.Core/Services/AudioConversionService.cs
+++ b/src/VoxFlow.Core/Services/AudioConversionService.cs
@@ -3,7 +3,6 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using VoxFlow.Core.Configuration;
@@ -26,6 +25,13 @@ internal sealed class AudioConversionService : IAudioConversionService
         CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
+
+        if (!SupportedInputFormats.IsSupported(inputPath))
+        {
+            var extension = Path.GetExtension(inputPath);
+            throw new InvalidOperationException(
+                $"Unsupported input format '{extension}'. Supported formats: {SupportedInputFormats.GetDisplaySummary()}.");
+        }
 
         var startInfo = CreateFfmpegStartInfo(options.FfmpegExecutablePath);
 

--- a/src/VoxFlow.Core/Services/FileDiscoveryService.cs
+++ b/src/VoxFlow.Core/Services/FileDiscoveryService.cs
@@ -16,6 +16,8 @@ internal sealed class FileDiscoveryService : IFileDiscoveryService
 {
     /// <summary>
     /// Scans the configured input directory for files matching the batch file pattern.
+    /// When the file pattern is the multi-format wildcard ("*"), all supported audio
+    /// formats are discovered automatically using <see cref="SupportedInputFormats"/>.
     /// </summary>
     public IReadOnlyList<DiscoveredFile> DiscoverInputFiles(BatchOptions batchOptions, int? maxFiles = null)
     {
@@ -31,7 +33,7 @@ internal sealed class FileDiscoveryService : IFileDiscoveryService
             throw new InvalidOperationException($"Batch input directory not found: {batchOptions.InputDirectory}");
         }
 
-        IEnumerable<string> matchingFiles = Directory.EnumerateFiles(batchOptions.InputDirectory, batchOptions.FilePattern)
+        IEnumerable<string> matchingFiles = EnumerateMatchingFiles(batchOptions)
             .OrderBy(path => path, StringComparer.OrdinalIgnoreCase);
 
         if (maxFiles.HasValue)
@@ -66,5 +68,22 @@ internal sealed class FileDiscoveryService : IFileDiscoveryService
         }
 
         return discoveredFiles;
+    }
+
+    /// <summary>
+    /// Returns matching file paths for the configured batch options.
+    /// The special pattern "*" triggers multi-format discovery across all
+    /// extensions defined in <see cref="SupportedInputFormats"/>.
+    /// </summary>
+    private static IEnumerable<string> EnumerateMatchingFiles(BatchOptions batchOptions)
+    {
+        if (batchOptions.FilePattern == "*")
+        {
+            return SupportedInputFormats.GlobPatterns
+                .SelectMany(pattern => Directory.EnumerateFiles(batchOptions.InputDirectory, pattern))
+                .Distinct(StringComparer.OrdinalIgnoreCase);
+        }
+
+        return Directory.EnumerateFiles(batchOptions.InputDirectory, batchOptions.FilePattern);
     }
 }

--- a/src/VoxFlow.Core/Services/ValidationService.cs
+++ b/src/VoxFlow.Core/Services/ValidationService.cs
@@ -92,6 +92,15 @@ internal sealed class ValidationService : IValidationService
             return new ValidationCheck("Input file", ValidationCheckStatus.Failed, $"Not found: {inputFilePath}");
         }
 
+        if (!SupportedInputFormats.IsSupported(inputFilePath))
+        {
+            var extension = Path.GetExtension(inputFilePath);
+            return new ValidationCheck(
+                "Input file",
+                ValidationCheckStatus.Failed,
+                $"Unsupported input format '{extension}'. Supported formats: {SupportedInputFormats.GetDisplaySummary()}.");
+        }
+
         return new ValidationCheck("Input file", ValidationCheckStatus.Passed, $"{inputFilePath} ({fileInfo.Length} bytes)");
     }
 

--- a/src/VoxFlow.Desktop/Components/Shared/DropZone.razor
+++ b/src/VoxFlow.Desktop/Components/Shared/DropZone.razor
@@ -1,3 +1,4 @@
+@using VoxFlow.Core.Configuration
 @using VoxFlow.Desktop.Platform
 @inject IJSRuntime JS
 
@@ -41,7 +42,7 @@
            class="drop-zone-file-input"
            aria-hidden="true"
            tabindex="-1"
-           accept=".m4a,.wav,.mp3,.aac,.flac,.ogg,.aif,.aiff,.mp4,.m4b,audio/*"
+           accept="@SupportedInputFormats.HtmlAcceptString"
            OnChange="HandleBrowserFilesSelected" />
 
 @if (!string.IsNullOrWhiteSpace(_selectionError))
@@ -116,7 +117,7 @@
         try
         {
             var file = args.File;
-            if (!IsSupportedAudioFile(file.Name))
+            if (!SupportedInputFormats.IsSupported(file.Name))
             {
                 _selectionError = $"Unsupported audio file: {file.Name}";
                 return;
@@ -131,21 +132,6 @@
             _selectionError = $"File drop failed: {ex.Message}";
             System.Diagnostics.Debug.WriteLine($"[DropZone] Browser file drop failed: {ex}");
         }
-    }
-
-    private static bool IsSupportedAudioFile(string fileName)
-    {
-        var extension = Path.GetExtension(fileName);
-        return extension.Equals(".m4a", StringComparison.OrdinalIgnoreCase) ||
-               extension.Equals(".wav", StringComparison.OrdinalIgnoreCase) ||
-               extension.Equals(".mp3", StringComparison.OrdinalIgnoreCase) ||
-               extension.Equals(".aac", StringComparison.OrdinalIgnoreCase) ||
-               extension.Equals(".flac", StringComparison.OrdinalIgnoreCase) ||
-               extension.Equals(".ogg", StringComparison.OrdinalIgnoreCase) ||
-               extension.Equals(".aif", StringComparison.OrdinalIgnoreCase) ||
-               extension.Equals(".aiff", StringComparison.OrdinalIgnoreCase) ||
-               extension.Equals(".mp4", StringComparison.OrdinalIgnoreCase) ||
-               extension.Equals(".m4b", StringComparison.OrdinalIgnoreCase);
     }
 
     private static async Task<string> SaveBrowserFileToTemporaryPathAsync(IBrowserFile file)

--- a/src/VoxFlow.Desktop/MainPage.xaml.cs
+++ b/src/VoxFlow.Desktop/MainPage.xaml.cs
@@ -2,6 +2,7 @@ using Foundation;
 using Microsoft.AspNetCore.Components.WebView;
 using Microsoft.Maui.Controls;
 using System.Linq;
+using VoxFlow.Core.Configuration;
 using VoxFlow.Desktop.Services;
 using VoxFlow.Desktop.ViewModels;
 
@@ -403,18 +404,5 @@ public partial class MainPage : ContentPage
         return File.Exists(value) ? Path.GetFullPath(value) : null;
     }
 
-    private static bool IsSupportedAudioFile(string filePath)
-    {
-        var extension = Path.GetExtension(filePath);
-        return extension.Equals(".m4a", StringComparison.OrdinalIgnoreCase) ||
-               extension.Equals(".wav", StringComparison.OrdinalIgnoreCase) ||
-               extension.Equals(".mp3", StringComparison.OrdinalIgnoreCase) ||
-               extension.Equals(".aac", StringComparison.OrdinalIgnoreCase) ||
-               extension.Equals(".flac", StringComparison.OrdinalIgnoreCase) ||
-               extension.Equals(".ogg", StringComparison.OrdinalIgnoreCase) ||
-               extension.Equals(".aif", StringComparison.OrdinalIgnoreCase) ||
-               extension.Equals(".aiff", StringComparison.OrdinalIgnoreCase) ||
-               extension.Equals(".mp4", StringComparison.OrdinalIgnoreCase) ||
-               extension.Equals(".m4b", StringComparison.OrdinalIgnoreCase);
-    }
+    private static bool IsSupportedAudioFile(string filePath) => SupportedInputFormats.IsSupported(filePath);
 }

--- a/src/VoxFlow.Desktop/appsettings.json
+++ b/src/VoxFlow.Desktop/appsettings.json
@@ -10,7 +10,7 @@
       "inputDirectory": "~/Documents/VoxFlow/input",
       "outputDirectory": "~/Documents/VoxFlow/output",
       "tempDirectory": "~/Library/Application Support/VoxFlow/temp",
-      "filePattern": "*.m4a",
+      "filePattern": "*",
       "stopOnFirstError": false,
       "keepIntermediateFiles": false,
       "summaryFilePath": "~/Documents/VoxFlow/batch-summary.txt"

--- a/tests/VoxFlow.Core.Tests/BatchConfigurationTests.cs
+++ b/tests/VoxFlow.Core.Tests/BatchConfigurationTests.cs
@@ -148,7 +148,7 @@ public sealed class BatchConfigurationTests
         var options = TranscriptionOptions.LoadFromPath(settingsPath);
 
         Assert.True(options.IsBatchMode);
-        Assert.Equal("*.m4a", options.Batch.FilePattern);
+        Assert.Equal("*", options.Batch.FilePattern);
         Assert.False(options.Batch.StopOnFirstError);
         Assert.False(options.Batch.KeepIntermediateFiles);
         Assert.Equal("batch-summary.txt", options.Batch.SummaryFilePath);

--- a/tests/VoxFlow.Core.Tests/FileDiscoveryServiceTests.cs
+++ b/tests/VoxFlow.Core.Tests/FileDiscoveryServiceTests.cs
@@ -222,4 +222,115 @@ public sealed class FileDiscoveryServiceTests
         var exception = Assert.Throws<InvalidOperationException>(() => service.DiscoverInputFiles(options));
         Assert.Contains("not found", exception.Message, StringComparison.OrdinalIgnoreCase);
     }
+
+    [Fact]
+    public void DiscoverInputFiles_WildcardPattern_DiscoversAllSupportedFormats()
+    {
+        using var directory = new TemporaryDirectory();
+        var inputDir = Path.Combine(directory.Path, "input");
+        var outputDir = Path.Combine(directory.Path, "output");
+        Directory.CreateDirectory(inputDir);
+        Directory.CreateDirectory(outputDir);
+
+        File.WriteAllText(Path.Combine(inputDir, "audio.m4a"), "data");
+        File.WriteAllText(Path.Combine(inputDir, "audio.wav"), "data");
+        File.WriteAllText(Path.Combine(inputDir, "audio.mp3"), "data");
+        File.WriteAllText(Path.Combine(inputDir, "audio.aac"), "data");
+        File.WriteAllText(Path.Combine(inputDir, "audio.flac"), "data");
+        File.WriteAllText(Path.Combine(inputDir, "audio.ogg"), "data");
+        File.WriteAllText(Path.Combine(inputDir, "audio.aiff"), "data");
+        File.WriteAllText(Path.Combine(inputDir, "audio.mp4"), "data");
+        File.WriteAllText(Path.Combine(inputDir, "readme.txt"), "not audio");
+        File.WriteAllText(Path.Combine(inputDir, "notes.pdf"), "not audio");
+
+        var options = new BatchOptions(
+            InputDirectory: inputDir,
+            OutputDirectory: outputDir,
+            TempDirectory: directory.Path,
+            FilePattern: "*",
+            StopOnFirstError: false,
+            KeepIntermediateFiles: false,
+            SummaryFilePath: "summary.txt");
+
+        var service = new FileDiscoveryService();
+        var files = service.DiscoverInputFiles(options);
+
+        Assert.Equal(8, files.Count);
+        Assert.All(files, f => Assert.Equal(DiscoveryStatus.Ready, f.Status));
+        Assert.DoesNotContain(files, f => f.InputPath.EndsWith(".txt"));
+        Assert.DoesNotContain(files, f => f.InputPath.EndsWith(".pdf"));
+    }
+
+    [Fact]
+    public void DiscoverInputFiles_WildcardPattern_DoesNotDuplicateFiles()
+    {
+        using var directory = new TemporaryDirectory();
+        var inputDir = Path.Combine(directory.Path, "input");
+        Directory.CreateDirectory(inputDir);
+
+        File.WriteAllText(Path.Combine(inputDir, "recording.mp3"), "data");
+
+        var options = new BatchOptions(
+            InputDirectory: inputDir,
+            OutputDirectory: directory.Path,
+            TempDirectory: directory.Path,
+            FilePattern: "*",
+            StopOnFirstError: false,
+            KeepIntermediateFiles: false,
+            SummaryFilePath: "summary.txt");
+
+        var service = new FileDiscoveryService();
+        var files = service.DiscoverInputFiles(options);
+
+        Assert.Single(files);
+    }
+
+    [Fact]
+    public void DiscoverInputFiles_WildcardPattern_NoSupportedFiles_Throws()
+    {
+        using var directory = new TemporaryDirectory();
+        var inputDir = Path.Combine(directory.Path, "input");
+        Directory.CreateDirectory(inputDir);
+
+        File.WriteAllText(Path.Combine(inputDir, "readme.txt"), "not audio");
+
+        var options = new BatchOptions(
+            InputDirectory: inputDir,
+            OutputDirectory: directory.Path,
+            TempDirectory: directory.Path,
+            FilePattern: "*",
+            StopOnFirstError: false,
+            KeepIntermediateFiles: false,
+            SummaryFilePath: "summary.txt");
+
+        var service = new FileDiscoveryService();
+        var exception = Assert.Throws<InvalidOperationException>(() => service.DiscoverInputFiles(options));
+        Assert.Contains("No files matching", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DiscoverInputFiles_WildcardPattern_RespectsMaxFiles()
+    {
+        using var directory = new TemporaryDirectory();
+        var inputDir = Path.Combine(directory.Path, "input");
+        Directory.CreateDirectory(inputDir);
+
+        File.WriteAllText(Path.Combine(inputDir, "a.mp3"), "data");
+        File.WriteAllText(Path.Combine(inputDir, "b.wav"), "data");
+        File.WriteAllText(Path.Combine(inputDir, "c.flac"), "data");
+
+        var options = new BatchOptions(
+            InputDirectory: inputDir,
+            OutputDirectory: directory.Path,
+            TempDirectory: directory.Path,
+            FilePattern: "*",
+            StopOnFirstError: false,
+            KeepIntermediateFiles: false,
+            SummaryFilePath: "summary.txt");
+
+        var service = new FileDiscoveryService();
+        var files = service.DiscoverInputFiles(options, maxFiles: 2);
+
+        Assert.Equal(2, files.Count);
+    }
 }

--- a/tests/VoxFlow.Core.Tests/SupportedInputFormatsTests.cs
+++ b/tests/VoxFlow.Core.Tests/SupportedInputFormatsTests.cs
@@ -1,0 +1,102 @@
+using System.IO;
+using System.Linq;
+using VoxFlow.Core.Configuration;
+using Xunit;
+
+namespace VoxFlow.Core.Tests;
+
+public sealed class SupportedInputFormatsTests
+{
+    [Theory]
+    [InlineData(".m4a")]
+    [InlineData(".wav")]
+    [InlineData(".mp3")]
+    [InlineData(".aac")]
+    [InlineData(".flac")]
+    [InlineData(".ogg")]
+    [InlineData(".aif")]
+    [InlineData(".aiff")]
+    [InlineData(".mp4")]
+    public void IsSupported_RecognizesAllDeclaredFormats(string extension)
+    {
+        Assert.True(SupportedInputFormats.IsSupported($"recording{extension}"));
+    }
+
+    [Theory]
+    [InlineData(".M4A")]
+    [InlineData(".WAV")]
+    [InlineData(".Mp3")]
+    [InlineData(".FLAC")]
+    [InlineData(".OGG")]
+    [InlineData(".MP4")]
+    public void IsSupported_IsCaseInsensitive(string extension)
+    {
+        Assert.True(SupportedInputFormats.IsSupported($"recording{extension}"));
+    }
+
+    [Theory]
+    [InlineData(".txt")]
+    [InlineData(".pdf")]
+    [InlineData(".doc")]
+    [InlineData(".json")]
+    [InlineData(".exe")]
+    [InlineData("")]
+    public void IsSupported_RejectsUnsupportedFormats(string extension)
+    {
+        Assert.False(SupportedInputFormats.IsSupported($"file{extension}"));
+    }
+
+    [Fact]
+    public void IsSupported_HandlesFullPathCorrectly()
+    {
+        Assert.True(SupportedInputFormats.IsSupported("/users/test/recordings/meeting.mp3"));
+        Assert.False(SupportedInputFormats.IsSupported("/users/test/documents/notes.txt"));
+    }
+
+    [Fact]
+    public void Extensions_ContainsAllExpectedFormats()
+    {
+        var expected = new[] { ".m4a", ".wav", ".mp3", ".aac", ".flac", ".ogg", ".aif", ".aiff", ".mp4" };
+        Assert.Equal(expected.Length, SupportedInputFormats.Extensions.Count);
+        foreach (var ext in expected)
+        {
+            Assert.Contains(ext, SupportedInputFormats.Extensions);
+        }
+    }
+
+    [Fact]
+    public void GlobPatterns_MatchExtensions()
+    {
+        Assert.Equal(SupportedInputFormats.Extensions.Count, SupportedInputFormats.GlobPatterns.Count);
+        for (var i = 0; i < SupportedInputFormats.Extensions.Count; i++)
+        {
+            Assert.Equal($"*{SupportedInputFormats.Extensions[i]}", SupportedInputFormats.GlobPatterns[i]);
+        }
+    }
+
+    [Fact]
+    public void HtmlAcceptString_ContainsAllExtensionsAndAudioWildcard()
+    {
+        var accept = SupportedInputFormats.HtmlAcceptString;
+        foreach (var ext in SupportedInputFormats.Extensions)
+        {
+            Assert.Contains(ext, accept);
+        }
+        Assert.Contains("audio/*", accept);
+    }
+
+    [Fact]
+    public void GetDisplaySummary_ReturnsUppercaseCommaSeparated()
+    {
+        var summary = SupportedInputFormats.GetDisplaySummary();
+        Assert.Contains("M4A", summary);
+        Assert.Contains("WAV", summary);
+        Assert.Contains("MP3", summary);
+        Assert.Contains("AAC", summary);
+        Assert.Contains("FLAC", summary);
+        Assert.Contains("OGG", summary);
+        Assert.Contains("AIF", summary);
+        Assert.Contains("AIFF", summary);
+        Assert.Contains("MP4", summary);
+    }
+}

--- a/tests/VoxFlow.Core.Tests/ValidationServiceTests.cs
+++ b/tests/VoxFlow.Core.Tests/ValidationServiceTests.cs
@@ -1,9 +1,11 @@
 using System;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using VoxFlow.Core.Configuration;
 using VoxFlow.Core.Interfaces;
+using VoxFlow.Core.Models;
 using VoxFlow.Core.Services;
 using Xunit;
 
@@ -34,6 +36,62 @@ public sealed class ValidationServiceTests
 
         await Assert.ThrowsAnyAsync<OperationCanceledException>(
             () => service.ValidateAsync(options, cancellationTokenSource.Token));
+    }
+
+    [Fact]
+    public async Task ValidateAsync_UnsupportedInputFormat_ReportsFailure()
+    {
+        using var directory = new TemporaryDirectory();
+        var inputPath = Path.Combine(directory.Path, "input.txt");
+        await File.WriteAllTextAsync(inputPath, "not audio");
+
+        var settingsPath = TestSettingsFileFactory.Write(
+            directory.Path,
+            inputFilePath: inputPath,
+            wavFilePath: Path.Combine(directory.Path, "output.wav"),
+            resultFilePath: Path.Combine(directory.Path, "result.txt"),
+            modelFilePath: Path.Combine(directory.Path, "model.bin"),
+            ffmpegExecutablePath: "ffmpeg");
+
+        var options = TranscriptionOptions.LoadFromPath(settingsPath);
+        var service = new ValidationService(new StubAudioConversionService());
+        var result = await service.ValidateAsync(options);
+
+        Assert.False(result.CanStart);
+        var inputCheck = result.Checks.First(c => c.Name == "Input file");
+        Assert.Equal(ValidationCheckStatus.Failed, inputCheck.Status);
+        Assert.Contains("Unsupported input format", inputCheck.Details);
+    }
+
+    [Theory]
+    [InlineData("input.m4a")]
+    [InlineData("input.wav")]
+    [InlineData("input.mp3")]
+    [InlineData("input.aac")]
+    [InlineData("input.flac")]
+    [InlineData("input.ogg")]
+    [InlineData("input.aiff")]
+    [InlineData("input.mp4")]
+    public async Task ValidateAsync_SupportedInputFormat_PassesInputFileCheck(string fileName)
+    {
+        using var directory = new TemporaryDirectory();
+        var inputPath = Path.Combine(directory.Path, fileName);
+        await File.WriteAllTextAsync(inputPath, "audio data");
+
+        var settingsPath = TestSettingsFileFactory.Write(
+            directory.Path,
+            inputFilePath: inputPath,
+            wavFilePath: Path.Combine(directory.Path, "output.wav"),
+            resultFilePath: Path.Combine(directory.Path, "result.txt"),
+            modelFilePath: Path.Combine(directory.Path, "model.bin"),
+            ffmpegExecutablePath: "ffmpeg");
+
+        var options = TranscriptionOptions.LoadFromPath(settingsPath);
+        var service = new ValidationService(new StubAudioConversionService());
+        var result = await service.ValidateAsync(options);
+
+        var inputCheck = result.Checks.First(c => c.Name == "Input file");
+        Assert.Equal(ValidationCheckStatus.Passed, inputCheck.Status);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

VoxFlow previously treated `.m4a` as the default batch input pattern and repeated the supported-format list in multiple places, which made multi-format support harder to maintain and document consistently. This PR centralizes supported input extensions in `SupportedInputFormats`, uses that shared registry for validation, audio conversion checks, batch discovery, and Desktop file selection, and changes the default batch `filePattern` from `*.m4a` to `*` so all supported formats are discovered by default. It also updates the README, PRD, architecture docs, and config examples to document the supported formats explicitly and clarify that Whisper Base is the default local model. This PR stands alone as a self-contained supported-input-formats and documentation update.

## Testing

- `dotnet test tests/VoxFlow.Core.Tests/VoxFlow.Core.Tests.csproj` (`Passed: 105, Failed: 0, Skipped: 0`)
- Manual diff review of README, config defaults, Desktop accept list, and product/architecture docs for consistency with the shared supported-format registry

## Checklist

- [x] The change is scoped to one problem or one closely related slice of work.
- [x] I linked the relevant issue or explained why this PR stands alone.
- [x] I added or updated tests when behavior changed.
- [x] I updated docs, configuration examples, or screenshots when needed.
- [x] I did not include secrets, sensitive transcripts, or private recordings.
