### PR TITLE
Output formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,37 @@ VoxFlow accepts the following audio and video formats as input. All formats are 
 
 - **Single-file transcription** -- point the tool at one audio file and get a timestamped transcript
 - **Batch processing** -- point the tool at a directory and transcribe all matching files in one run, with a completion summary report
+- **Configurable output formats** -- choose from TXT (default), SRT, VTT, JSON, or Markdown output via the `resultFormat` setting
 - **Multi-language support** -- configure one or more candidate languages; the tool auto-selects the best match when multiple are provided
 - **Audio preprocessing** -- built-in noise reduction and silence removal improve transcript quality before the model runs
 - **Configurable quality controls** -- fine-tune segment filtering, hallucination suppression, and confidence thresholds to match your audio characteristics
 - **Startup validation** -- a preflight check verifies all paths, dependencies, and model availability before processing begins
 - **MCP server integration** -- expose transcription capabilities to AI clients (Claude, ChatGPT, GitHub Copilot, VS Code) via the Model Context Protocol
 - **Fully offline** -- no network calls, no API keys, no data leaves the machine
+
+## Output Formats
+
+VoxFlow supports multiple transcript output formats, configured via the `resultFormat` field in `appsettings.json`. The default is `txt` for backward compatibility.
+
+| Format | Extension | Description |
+|---|---|---|
+| `txt` | `.txt` | Legacy timestamped text (default). Preserves the original `{start}->{end}: {text}` format. |
+| `srt` | `.srt` | SubRip subtitle format with numbered cues and `HH:mm:ss,mmm` timestamps. |
+| `vtt` | `.vtt` | WebVTT subtitle format with `WEBVTT` header and `HH:mm:ss.mmm` timestamps. |
+| `json` | `.json` | Structured JSON with metadata (language, segment counts, warnings) and transcript segments. |
+| `md` | `.md` | Human-readable Markdown with metadata header and timestamped transcript entries. |
+
+To change the format, set `transcription.resultFormat` in your configuration:
+
+```json
+{
+  "transcription": {
+    "resultFormat": "srt"
+  }
+}
+```
+
+Desktop users can also change the output format from the Settings panel on the Ready screen.
 
 ## High-Level Architecture
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ VoxFlow accepts the following audio and video formats as input. All formats are 
 
 ## Output Formats
 
-VoxFlow supports multiple transcript output formats, configured via the `resultFormat` field in `appsettings.json`. The default is `txt` for backward compatibility.
+VoxFlow supports multiple transcript output formats. The default is `txt` for backward compatibility.
 
 | Format | Extension | Description |
 |---|---|---|
@@ -61,18 +61,6 @@ VoxFlow supports multiple transcript output formats, configured via the `resultF
 | `vtt` | `.vtt` | WebVTT subtitle format with `WEBVTT` header and `HH:mm:ss.mmm` timestamps. |
 | `json` | `.json` | Structured JSON with metadata (language, segment counts, warnings) and transcript segments. |
 | `md` | `.md` | Human-readable Markdown with metadata header and timestamped transcript entries. |
-
-To change the format, set `transcription.resultFormat` in your configuration:
-
-```json
-{
-  "transcription": {
-    "resultFormat": "srt"
-  }
-}
-```
-
-Desktop users can also change the output format from the Settings panel on the Ready screen.
 
 ## High-Level Architecture
 

--- a/appsettings.example.json
+++ b/appsettings.example.json
@@ -1,6 +1,7 @@
 {
   "transcription": {
     "processingMode": "single",
+    "resultFormat": "txt",
 
     "inputFilePath": "artifacts/input.m4a",
     "wavFilePath": "artifacts/output.wav",

--- a/appsettings.json
+++ b/appsettings.json
@@ -1,6 +1,7 @@
 {
   "transcription": {
     "processingMode": "batch",
+    "resultFormat": "txt",
 
     "inputFilePath": "artifacts/input.m4a",
     "wavFilePath": "artifacts/output.wav",

--- a/docs/product/PRD.md
+++ b/docs/product/PRD.md
@@ -118,7 +118,7 @@ The following are explicitly out of scope:
 - HTTP or SSE MCP transport (stdio only, for local-first security)
 - MCP server as a long-lived daemon (it runs only when launched by an MCP client)
 - Batch-processing UI in the Desktop app (batch processing exists in the pipeline but Desktop is a single-file workflow)
-- Desktop settings editor UI (configuration overrides remain file-based)
+- Full-featured Desktop settings editor UI (only output format selection is available; other overrides remain file-based)
 
 ---
 
@@ -144,7 +144,7 @@ The following are explicitly out of scope:
 ### Deferred to Future Phases
 
 - Desktop batch-processing UI
-- Desktop settings editor
+- Full Desktop settings editor (output format selection is implemented; other settings remain file-based)
 - Multi-file Desktop workflow
 - Windows and Linux desktop
 - Additional MCP transports
@@ -356,30 +356,36 @@ The application must support graceful cancellation of long-running work.
 
 ### FR-08: Result Output
 
-The application must write accepted transcript segments to the configured result file.
+The application must write accepted transcript segments to the configured result file in the selected output format.
+
+**Supported output formats:**
+
+| Format | Extension | Description |
+|---|---|---|
+| `txt` | `.txt` | Legacy timestamped text (default). Each line: `{start}->{end}: {text}` |
+| `srt` | `.srt` | SubRip subtitle format with numbered cues and `HH:mm:ss,mmm` timestamps |
+| `vtt` | `.vtt` | WebVTT subtitle format with `WEBVTT` header and `HH:mm:ss.mmm` timestamps |
+| `json` | `.json` | Structured JSON with metadata (language, counts, warnings) and transcript segments |
+| `md` | `.md` | Human-readable Markdown with metadata header and timestamped entries |
 
 **Requirements:**
 
-- Output encoding must be UTF-8.
-- Each transcript line must use the following timestamped format:
-
-```text
-{start}->{end}: {text}
-```
-
-Example:
-
-```text
-00:00:01.2000000->00:00:03.8000000: Hello, this is a test.
-```
-
+- Output encoding must be UTF-8 for all formats.
+- The output format is selected via `transcription.resultFormat` in configuration. If missing, defaults to `txt`.
+- Parsing must be case-insensitive. Unsupported values must be rejected with a clear, actionable error message.
+- The `txt` format preserves the existing legacy timestamped format exactly for backward compatibility.
+- The output file extension must match the selected format. Mismatched extensions are normalized automatically.
+- In batch mode, all per-file outputs use the selected format's extension.
+- Desktop users can select the output format from the Settings panel on the Ready screen. The selection persists through the Desktop user override mechanism.
 - If the run is rejected due to unsupported or ambiguous language, the application must not produce misleading transcript output.
-- This output format is a stable external contract and must not change without a versioned migration.
+- The `txt` output format remains a stable external contract and must not change without a versioned migration.
 
 **Acceptance criteria:**
 
-- Output files are valid UTF-8 with consistent timestamp formatting.
+- Output files are valid UTF-8 with format-appropriate content and consistent timestamp formatting.
+- All five formats produce correct, well-formed output.
 - Rejected runs produce no output file rather than an empty or misleading one.
+- Existing workflows using the default `txt` format continue to work without configuration changes.
 
 ---
 
@@ -491,7 +497,7 @@ The Desktop app is a .NET 9 MAUI Blazor Hybrid application targeting macOS (Mac 
 - On Apple Silicon, the Desktop app uses the shared core transcription pipeline directly.
 - On Intel Mac Catalyst, the Desktop app routes transcription through a local CLI bridge to maintain the same working pipeline behavior.
 - Dark theme consistent with macOS design conventions.
-- No settings editor UI is required in the current phase. Persistent configuration overrides remain file-based.
+- A Settings panel on the Ready screen allows the user to select the transcript output format. The selection persists through the Desktop user override mechanism. Other configuration overrides remain file-based.
 
 **Acceptance criteria:**
 
@@ -590,6 +596,7 @@ The following settings must be configurable:
 
 | Category | Configurable settings |
 |---|---|
+| **Output format** | Transcript result format (`txt`, `srt`, `vtt`, `json`, `md`; default `txt`) |
 | **Paths** | Input file, WAV output, result file, model file, ffmpeg executable |
 | **Model** | Model type (e.g., Base, Small, Medium) |
 | **Audio** | Output sample rate, channel count, container format, ffmpeg audio-filter chain |

--- a/src/VoxFlow.Cli/appsettings.json
+++ b/src/VoxFlow.Cli/appsettings.json
@@ -1,6 +1,7 @@
 {
   "transcription": {
     "processingMode": "batch",
+    "resultFormat": "txt",
 
     "inputFilePath": "artifacts/input.m4a",
     "wavFilePath": "artifacts/output.wav",

--- a/src/VoxFlow.Core/Configuration/ResultFormat.cs
+++ b/src/VoxFlow.Core/Configuration/ResultFormat.cs
@@ -1,0 +1,85 @@
+namespace VoxFlow.Core.Configuration;
+
+/// <summary>
+/// Supported transcript output formats.
+/// </summary>
+public enum ResultFormat
+{
+    /// <summary>Legacy timestamped text (default).</summary>
+    Txt,
+
+    /// <summary>SubRip subtitle format.</summary>
+    Srt,
+
+    /// <summary>WebVTT subtitle format.</summary>
+    Vtt,
+
+    /// <summary>Structured JSON output.</summary>
+    Json,
+
+    /// <summary>Human-readable Markdown.</summary>
+    Md
+}
+
+/// <summary>
+/// Extension methods for <see cref="ResultFormat"/>.
+/// </summary>
+public static class ResultFormatExtensions
+{
+    /// <summary>
+    /// Returns the file extension (including the leading dot) for the given format.
+    /// </summary>
+    public static string ToFileExtension(this ResultFormat format) => format switch
+    {
+        ResultFormat.Txt => ".txt",
+        ResultFormat.Srt => ".srt",
+        ResultFormat.Vtt => ".vtt",
+        ResultFormat.Json => ".json",
+        ResultFormat.Md => ".md",
+        _ => ".txt"
+    };
+
+    /// <summary>
+    /// Parses a format string (case-insensitive) into a <see cref="ResultFormat"/>.
+    /// Returns null if the value is not recognized.
+    /// </summary>
+    public static ResultFormat? TryParseFormat(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return null;
+
+        return value.Trim().ToLowerInvariant() switch
+        {
+            "txt" => ResultFormat.Txt,
+            "srt" => ResultFormat.Srt,
+            "vtt" => ResultFormat.Vtt,
+            "json" => ResultFormat.Json,
+            "md" => ResultFormat.Md,
+            _ => null
+        };
+    }
+
+    /// <summary>
+    /// Parses a format string (case-insensitive) into a <see cref="ResultFormat"/>.
+    /// Throws <see cref="InvalidOperationException"/> if the value is not recognized.
+    /// </summary>
+    public static ResultFormat ParseFormat(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return ResultFormat.Txt;
+
+        return TryParseFormat(value)
+            ?? throw new InvalidOperationException(
+                $"Unsupported result format '{value.Trim()}'. Allowed values are: txt, srt, vtt, json, md.");
+    }
+
+    /// <summary>
+    /// Normalizes an output file path so its extension matches the selected format.
+    /// </summary>
+    public static string NormalizeOutputPath(string outputPath, ResultFormat format)
+    {
+        var directory = Path.GetDirectoryName(outputPath) ?? string.Empty;
+        var stem = Path.GetFileNameWithoutExtension(outputPath);
+        return Path.Combine(directory, stem + format.ToFileExtension());
+    }
+}

--- a/src/VoxFlow.Core/Configuration/TranscriptionOptions.cs
+++ b/src/VoxFlow.Core/Configuration/TranscriptionOptions.cs
@@ -45,6 +45,7 @@ public sealed class TranscriptionOptions
     public int MaxDuplicateSegmentTextLength { get; }
     public StartupValidationOptions StartupValidation { get; }
     public ConsoleProgressOptions ConsoleProgress { get; }
+    public ResultFormat ResultFormat { get; }
     public BatchOptions Batch { get; }
 
     /// <summary>
@@ -100,6 +101,7 @@ public sealed class TranscriptionOptions
         MaxDuplicateSegmentTextLength = EnsurePositive(
             configuration.MaxDuplicateSegmentTextLength,
             nameof(configuration.MaxDuplicateSegmentTextLength));
+        ResultFormat = ResultFormatExtensions.ParseFormat(configuration.ResultFormat);
         StartupValidation = CreateStartupValidationOptions(configuration.StartupValidation);
         ConsoleProgress = CreateConsoleProgressOptions(configuration.ConsoleProgress);
         Batch = IsBatchMode ? CreateBatchOptions(configuration.Batch) : BatchOptions.Disabled;
@@ -372,6 +374,7 @@ public sealed class TranscriptionSettingsRoot
 public sealed class TranscriptionConfiguration
 {
     public string? ProcessingMode { get; set; }
+    public string? ResultFormat { get; set; }
     public string? InputFilePath { get; set; }
     public string? WavFilePath { get; set; }
     public string? ResultFilePath { get; set; }

--- a/src/VoxFlow.Core/Interfaces/IFileDiscoveryService.cs
+++ b/src/VoxFlow.Core/Interfaces/IFileDiscoveryService.cs
@@ -11,5 +11,8 @@ public interface IFileDiscoveryService
     /// <summary>
     /// Discovers input files for a batch run, optionally limiting the number of files that will be processed.
     /// </summary>
-    IReadOnlyList<DiscoveredFile> DiscoverInputFiles(BatchOptions batchOptions, int? maxFiles = null);
+    /// <param name="batchOptions">Batch configuration options.</param>
+    /// <param name="maxFiles">Optional maximum file count.</param>
+    /// <param name="outputExtension">File extension for output files (e.g. ".txt", ".srt"). Defaults to ".txt".</param>
+    IReadOnlyList<DiscoveredFile> DiscoverInputFiles(BatchOptions batchOptions, int? maxFiles = null, string outputExtension = ".txt");
 }

--- a/src/VoxFlow.Core/Interfaces/IOutputWriter.cs
+++ b/src/VoxFlow.Core/Interfaces/IOutputWriter.cs
@@ -8,15 +8,16 @@ namespace VoxFlow.Core.Interfaces;
 public interface IOutputWriter
 {
     /// <summary>
-    /// Persists the transcript to disk.
+    /// Persists the transcript to disk using the format specified in the context.
     /// </summary>
     Task WriteAsync(
         string outputPath,
         IReadOnlyList<FilteredSegment> segments,
+        TranscriptOutputContext context,
         CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Builds the text representation of the supplied transcript segments without writing to disk.
     /// </summary>
-    string BuildOutputText(IReadOnlyList<FilteredSegment> segments);
+    string BuildOutputText(IReadOnlyList<FilteredSegment> segments, TranscriptOutputContext context);
 }

--- a/src/VoxFlow.Core/Interfaces/ITranscriptFormatter.cs
+++ b/src/VoxFlow.Core/Interfaces/ITranscriptFormatter.cs
@@ -1,0 +1,14 @@
+using VoxFlow.Core.Models;
+
+namespace VoxFlow.Core.Interfaces;
+
+/// <summary>
+/// Serializes filtered transcript segments into a specific output format.
+/// </summary>
+public interface ITranscriptFormatter
+{
+    /// <summary>
+    /// Builds the formatted transcript text from the supplied segments and context.
+    /// </summary>
+    string Format(IReadOnlyList<FilteredSegment> segments, TranscriptOutputContext context);
+}

--- a/src/VoxFlow.Core/Models/TranscriptOutputContext.cs
+++ b/src/VoxFlow.Core/Models/TranscriptOutputContext.cs
@@ -1,0 +1,13 @@
+using VoxFlow.Core.Configuration;
+
+namespace VoxFlow.Core.Models;
+
+/// <summary>
+/// Carries format selection and metadata used by format-specific transcript writers.
+/// </summary>
+public sealed record TranscriptOutputContext(
+    ResultFormat Format,
+    string? DetectedLanguage = null,
+    int AcceptedSegmentCount = 0,
+    int SkippedSegmentCount = 0,
+    IReadOnlyList<string>? Warnings = null);

--- a/src/VoxFlow.Core/Services/BatchTranscriptionService.cs
+++ b/src/VoxFlow.Core/Services/BatchTranscriptionService.cs
@@ -81,7 +81,8 @@ internal sealed class BatchTranscriptionService : IBatchTranscriptionService
         var factory = await _modelService.GetOrCreateFactoryAsync(options, cancellationToken);
 
         // 3. Discover files
-        var discoveredFiles = _fileDiscovery.DiscoverInputFiles(batchOptions, request.MaxFiles);
+        var outputExtension = options.ResultFormat.ToFileExtension();
+        var discoveredFiles = _fileDiscovery.DiscoverInputFiles(batchOptions, request.MaxFiles, outputExtension);
         var results = new List<BatchFileResult>(discoveredFiles.Count);
 
         // 4. Process each file
@@ -134,13 +135,21 @@ internal sealed class BatchTranscriptionService : IBatchTranscriptionService
                     ProgressStage.Writing,
                     95,
                     "Writing transcript...");
-                await _outputWriter.WriteAsync(file.OutputPath, selection.AcceptedSegments, cancellationToken);
+
+                var detectedLanguage = $"{selection.Language.DisplayName} ({selection.Language.Code})";
+                var outputContext = new TranscriptOutputContext(
+                    Format: options.ResultFormat,
+                    DetectedLanguage: detectedLanguage,
+                    AcceptedSegmentCount: selection.AcceptedSegments.Count,
+                    SkippedSegmentCount: selection.SkippedSegments.Count);
+
+                await _outputWriter.WriteAsync(file.OutputPath, selection.AcceptedSegments, outputContext, cancellationToken);
 
                 fileStopwatch.Stop();
                 results.Add(new BatchFileResult(
                     file.InputPath, file.OutputPath, "Success",
                     null, fileStopwatch.Elapsed,
-                    $"{selection.Language.DisplayName} ({selection.Language.Code})"));
+                    detectedLanguage));
             }
             catch (OperationCanceledException) { throw; }
             catch (Exception ex)

--- a/src/VoxFlow.Core/Services/FileDiscoveryService.cs
+++ b/src/VoxFlow.Core/Services/FileDiscoveryService.cs
@@ -19,7 +19,7 @@ internal sealed class FileDiscoveryService : IFileDiscoveryService
     /// When the file pattern is the multi-format wildcard ("*"), all supported audio
     /// formats are discovered automatically using <see cref="SupportedInputFormats"/>.
     /// </summary>
-    public IReadOnlyList<DiscoveredFile> DiscoverInputFiles(BatchOptions batchOptions, int? maxFiles = null)
+    public IReadOnlyList<DiscoveredFile> DiscoverInputFiles(BatchOptions batchOptions, int? maxFiles = null, string outputExtension = ".txt")
     {
         ArgumentNullException.ThrowIfNull(batchOptions);
 
@@ -54,7 +54,7 @@ internal sealed class FileDiscoveryService : IFileDiscoveryService
         foreach (var inputPath in discoveredPaths)
         {
             var fileNameWithoutExtension = Path.GetFileNameWithoutExtension(inputPath);
-            var outputPath = Path.Combine(batchOptions.OutputDirectory, $"{fileNameWithoutExtension}.txt");
+            var outputPath = Path.Combine(batchOptions.OutputDirectory, $"{fileNameWithoutExtension}{outputExtension}");
             var tempWavPath = Path.Combine(batchOptions.TempDirectory, $"{fileNameWithoutExtension}_{Guid.NewGuid():N}.wav");
 
             var fileInfo = new FileInfo(inputPath);

--- a/src/VoxFlow.Core/Services/Formatters/JsonTranscriptFormatter.cs
+++ b/src/VoxFlow.Core/Services/Formatters/JsonTranscriptFormatter.cs
@@ -1,0 +1,75 @@
+using System.Text;
+using System.Text.Json;
+using VoxFlow.Core.Interfaces;
+using VoxFlow.Core.Models;
+
+namespace VoxFlow.Core.Services.Formatters;
+
+/// <summary>
+/// Formats transcript segments as structured JSON output.
+/// Includes metadata (format, language, counts, warnings) and segment data.
+/// </summary>
+internal sealed class JsonTranscriptFormatter : ITranscriptFormatter
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    public string Format(IReadOnlyList<FilteredSegment> segments, TranscriptOutputContext context)
+    {
+        var output = new JsonTranscriptOutput
+        {
+            Format = context.Format.ToString().ToLowerInvariant(),
+            DetectedLanguage = context.DetectedLanguage,
+            AcceptedSegmentCount = context.AcceptedSegmentCount,
+            SkippedSegmentCount = context.SkippedSegmentCount,
+            Warnings = context.Warnings ?? Array.Empty<string>(),
+            Segments = segments.Select(s => new JsonTranscriptSegment
+            {
+                Start = FormatTimestamp(s.Start),
+                End = FormatTimestamp(s.End),
+                Text = s.Text
+            }).ToArray(),
+            Transcript = BuildPlainTranscript(segments)
+        };
+
+        return JsonSerializer.Serialize(output, SerializerOptions);
+    }
+
+    private static string FormatTimestamp(TimeSpan ts)
+    {
+        return $"{(int)ts.TotalHours:D2}:{ts.Minutes:D2}:{ts.Seconds:D2}.{ts.Milliseconds:D3}";
+    }
+
+    private static string BuildPlainTranscript(IReadOnlyList<FilteredSegment> segments)
+    {
+        var builder = new StringBuilder();
+        foreach (var segment in segments)
+        {
+            if (builder.Length > 0)
+                builder.Append(' ');
+            builder.Append(segment.Text.Trim());
+        }
+        return builder.ToString();
+    }
+
+    private sealed class JsonTranscriptOutput
+    {
+        public string Format { get; set; } = string.Empty;
+        public string? DetectedLanguage { get; set; }
+        public int AcceptedSegmentCount { get; set; }
+        public int SkippedSegmentCount { get; set; }
+        public IReadOnlyList<string> Warnings { get; set; } = Array.Empty<string>();
+        public JsonTranscriptSegment[] Segments { get; set; } = Array.Empty<JsonTranscriptSegment>();
+        public string Transcript { get; set; } = string.Empty;
+    }
+
+    private sealed class JsonTranscriptSegment
+    {
+        public string Start { get; set; } = string.Empty;
+        public string End { get; set; } = string.Empty;
+        public string Text { get; set; } = string.Empty;
+    }
+}

--- a/src/VoxFlow.Core/Services/Formatters/MdTranscriptFormatter.cs
+++ b/src/VoxFlow.Core/Services/Formatters/MdTranscriptFormatter.cs
@@ -1,0 +1,58 @@
+using System.Globalization;
+using System.Text;
+using VoxFlow.Core.Interfaces;
+using VoxFlow.Core.Models;
+
+namespace VoxFlow.Core.Services.Formatters;
+
+/// <summary>
+/// Formats transcript segments as human-readable Markdown.
+/// Includes a metadata header and timestamped transcript entries.
+/// </summary>
+internal sealed class MdTranscriptFormatter : ITranscriptFormatter
+{
+    public string Format(IReadOnlyList<FilteredSegment> segments, TranscriptOutputContext context)
+    {
+        var builder = new StringBuilder();
+
+        builder.AppendLine("# Transcript");
+        builder.AppendLine();
+
+        // Metadata block
+        if (context.DetectedLanguage is not null || context.AcceptedSegmentCount > 0)
+        {
+            if (context.DetectedLanguage is not null)
+                builder.AppendLine(string.Create(CultureInfo.InvariantCulture, $"- **Language:** {context.DetectedLanguage}"));
+            builder.AppendLine(string.Create(CultureInfo.InvariantCulture, $"- **Segments:** {context.AcceptedSegmentCount} accepted, {context.SkippedSegmentCount} skipped"));
+
+            if (context.Warnings is { Count: > 0 })
+            {
+                builder.AppendLine(string.Create(CultureInfo.InvariantCulture, $"- **Warnings:** {string.Join("; ", context.Warnings)}"));
+            }
+
+            builder.AppendLine();
+        }
+
+        builder.AppendLine("---");
+        builder.AppendLine();
+
+        foreach (var segment in segments)
+        {
+            var timestamp = FormatTimestamp(segment.Start);
+            builder.AppendLine(string.Create(CultureInfo.InvariantCulture, $"**[{timestamp}]** {segment.Text.Trim()}"));
+            builder.AppendLine();
+        }
+
+        return builder.ToString();
+    }
+
+    private static string FormatTimestamp(TimeSpan ts)
+    {
+        return string.Format(
+            CultureInfo.InvariantCulture,
+            "{0:D2}:{1:D2}:{2:D2}",
+            (int)ts.TotalHours,
+            ts.Minutes,
+            ts.Seconds);
+    }
+}

--- a/src/VoxFlow.Core/Services/Formatters/SrtTranscriptFormatter.cs
+++ b/src/VoxFlow.Core/Services/Formatters/SrtTranscriptFormatter.cs
@@ -1,0 +1,44 @@
+using System.Globalization;
+using System.Text;
+using VoxFlow.Core.Interfaces;
+using VoxFlow.Core.Models;
+
+namespace VoxFlow.Core.Services.Formatters;
+
+/// <summary>
+/// Formats transcript segments as SubRip (SRT) subtitles.
+/// Uses HH:mm:ss,mmm timestamps with --> separator.
+/// </summary>
+internal sealed class SrtTranscriptFormatter : ITranscriptFormatter
+{
+    public string Format(IReadOnlyList<FilteredSegment> segments, TranscriptOutputContext context)
+    {
+        var builder = new StringBuilder();
+
+        for (var i = 0; i < segments.Count; i++)
+        {
+            if (i > 0)
+                builder.AppendLine();
+
+            var segment = segments[i];
+            builder.AppendLine((i + 1).ToString(CultureInfo.InvariantCulture));
+            builder.Append(FormatSrtTimestamp(segment.Start));
+            builder.Append(" --> ");
+            builder.AppendLine(FormatSrtTimestamp(segment.End));
+            builder.AppendLine(segment.Text.Trim());
+        }
+
+        return builder.ToString();
+    }
+
+    internal static string FormatSrtTimestamp(TimeSpan ts)
+    {
+        return string.Format(
+            CultureInfo.InvariantCulture,
+            "{0:D2}:{1:D2}:{2:D2},{3:D3}",
+            (int)ts.TotalHours,
+            ts.Minutes,
+            ts.Seconds,
+            ts.Milliseconds);
+    }
+}

--- a/src/VoxFlow.Core/Services/Formatters/TranscriptFormatterFactory.cs
+++ b/src/VoxFlow.Core/Services/Formatters/TranscriptFormatterFactory.cs
@@ -1,0 +1,26 @@
+using VoxFlow.Core.Configuration;
+using VoxFlow.Core.Interfaces;
+
+namespace VoxFlow.Core.Services.Formatters;
+
+/// <summary>
+/// Resolves the correct <see cref="ITranscriptFormatter"/> for a given <see cref="ResultFormat"/>.
+/// </summary>
+internal static class TranscriptFormatterFactory
+{
+    private static readonly TxtTranscriptFormatter Txt = new();
+    private static readonly SrtTranscriptFormatter Srt = new();
+    private static readonly VttTranscriptFormatter Vtt = new();
+    private static readonly JsonTranscriptFormatter Json = new();
+    private static readonly MdTranscriptFormatter Md = new();
+
+    public static ITranscriptFormatter GetFormatter(ResultFormat format) => format switch
+    {
+        ResultFormat.Txt => Txt,
+        ResultFormat.Srt => Srt,
+        ResultFormat.Vtt => Vtt,
+        ResultFormat.Json => Json,
+        ResultFormat.Md => Md,
+        _ => Txt
+    };
+}

--- a/src/VoxFlow.Core/Services/Formatters/TxtTranscriptFormatter.cs
+++ b/src/VoxFlow.Core/Services/Formatters/TxtTranscriptFormatter.cs
@@ -1,0 +1,28 @@
+using System.Text;
+using VoxFlow.Core.Interfaces;
+using VoxFlow.Core.Models;
+
+namespace VoxFlow.Core.Services.Formatters;
+
+/// <summary>
+/// Formats transcript segments in the legacy timestamped text format.
+/// This preserves exact backward compatibility with the original output.
+/// </summary>
+internal sealed class TxtTranscriptFormatter : ITranscriptFormatter
+{
+    public string Format(IReadOnlyList<FilteredSegment> segments, TranscriptOutputContext context)
+    {
+        var builder = new StringBuilder();
+
+        foreach (var segment in segments)
+        {
+            builder.Append(segment.Start);
+            builder.Append("->");
+            builder.Append(segment.End);
+            builder.Append(": ");
+            builder.AppendLine(segment.Text);
+        }
+
+        return builder.ToString();
+    }
+}

--- a/src/VoxFlow.Core/Services/Formatters/VttTranscriptFormatter.cs
+++ b/src/VoxFlow.Core/Services/Formatters/VttTranscriptFormatter.cs
@@ -1,0 +1,45 @@
+using System.Globalization;
+using System.Text;
+using VoxFlow.Core.Interfaces;
+using VoxFlow.Core.Models;
+
+namespace VoxFlow.Core.Services.Formatters;
+
+/// <summary>
+/// Formats transcript segments as WebVTT subtitles.
+/// Includes the WEBVTT header and uses HH:mm:ss.mmm timestamps with --> separator.
+/// </summary>
+internal sealed class VttTranscriptFormatter : ITranscriptFormatter
+{
+    public string Format(IReadOnlyList<FilteredSegment> segments, TranscriptOutputContext context)
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine("WEBVTT");
+        builder.AppendLine();
+
+        for (var i = 0; i < segments.Count; i++)
+        {
+            if (i > 0)
+                builder.AppendLine();
+
+            var segment = segments[i];
+            builder.Append(FormatVttTimestamp(segment.Start));
+            builder.Append(" --> ");
+            builder.AppendLine(FormatVttTimestamp(segment.End));
+            builder.AppendLine(segment.Text.Trim());
+        }
+
+        return builder.ToString();
+    }
+
+    internal static string FormatVttTimestamp(TimeSpan ts)
+    {
+        return string.Format(
+            CultureInfo.InvariantCulture,
+            "{0:D2}:{1:D2}:{2:D2}.{3:D3}",
+            (int)ts.TotalHours,
+            ts.Minutes,
+            ts.Seconds,
+            ts.Milliseconds);
+    }
+}

--- a/src/VoxFlow.Core/Services/OutputWriter.cs
+++ b/src/VoxFlow.Core/Services/OutputWriter.cs
@@ -1,59 +1,43 @@
-using System.Collections.Generic;
-using System.IO;
 using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 using VoxFlow.Core.Interfaces;
 using VoxFlow.Core.Models;
+using VoxFlow.Core.Services.Formatters;
 
 namespace VoxFlow.Core.Services;
 
 /// <summary>
-/// Writes filtered transcript segments to the configured text output format.
+/// Writes filtered transcript segments to disk in the configured output format.
+/// Delegates format-specific serialization to <see cref="ITranscriptFormatter"/> implementations.
 /// </summary>
 internal sealed class OutputWriter : IOutputWriter
 {
     private static readonly UTF8Encoding Utf8NoBom = new(encoderShouldEmitUTF8Identifier: false);
 
     /// <summary>
-    /// Writes transcript lines to the target file using UTF-8 without a BOM.
+    /// Writes the formatted transcript to the target file using UTF-8 without a BOM.
+    /// The output path extension is normalized to match the selected format.
     /// </summary>
     public async Task WriteAsync(
         string outputPath,
         IReadOnlyList<FilteredSegment> segments,
+        TranscriptOutputContext context,
         CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
-        await using var writer = new StreamWriter(outputPath, append: false, Utf8NoBom);
 
-        foreach (var segment in segments)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            await writer.WriteAsync(segment.Start.ToString().AsMemory(), cancellationToken).ConfigureAwait(false);
-            await writer.WriteAsync("->".AsMemory(), cancellationToken).ConfigureAwait(false);
-            await writer.WriteAsync(segment.End.ToString().AsMemory(), cancellationToken).ConfigureAwait(false);
-            await writer.WriteAsync(": ".AsMemory(), cancellationToken).ConfigureAwait(false);
-            await writer.WriteLineAsync(segment.Text.AsMemory(), cancellationToken).ConfigureAwait(false);
-        }
+        var content = BuildOutputText(segments, context);
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await using var writer = new StreamWriter(outputPath, append: false, Utf8NoBom);
+        await writer.WriteAsync(content.AsMemory(), cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
-    /// Builds the output file content in the legacy timestamped text format.
-    /// Used by tests to verify formatting without writing to disk.
+    /// Builds the formatted output text using the format specified in the context.
     /// </summary>
-    public string BuildOutputText(IReadOnlyList<FilteredSegment> segments)
+    public string BuildOutputText(IReadOnlyList<FilteredSegment> segments, TranscriptOutputContext context)
     {
-        var builder = new StringBuilder();
-
-        foreach (var segment in segments)
-        {
-            builder.Append(segment.Start);
-            builder.Append("->");
-            builder.Append(segment.End);
-            builder.Append(": ");
-            builder.AppendLine(segment.Text);
-        }
-
-        return builder.ToString();
+        var formatter = TranscriptFormatterFactory.GetFormatter(context.Format);
+        return formatter.Format(segments, context);
     }
 }

--- a/src/VoxFlow.Core/Services/TranscriptionService.cs
+++ b/src/VoxFlow.Core/Services/TranscriptionService.cs
@@ -51,6 +51,9 @@ internal sealed class TranscriptionService : ITranscriptionService
         var resultPath = request.ResultFilePath ?? options.ResultFilePath;
         var wavPath = options.WavFilePath;
 
+        // Normalize the result path extension to match the configured format.
+        resultPath = ResultFormatExtensions.NormalizeOutputPath(resultPath, options.ResultFormat);
+
         // 2. Validate
         progress?.Report(new ProgressUpdate(ProgressStage.Validating, 0, stopwatch.Elapsed, "Validating environment..."));
 
@@ -98,19 +101,29 @@ internal sealed class TranscriptionService : ITranscriptionService
 
         // 7. Write output
         progress?.Report(new ProgressUpdate(ProgressStage.Writing, 90, stopwatch.Elapsed, "Writing transcript..."));
-        await _outputWriter.WriteAsync(resultPath, selectionResult.AcceptedSegments, cancellationToken);
+
+        var detectedLanguage = $"{selectionResult.Language.DisplayName} ({selectionResult.Language.Code})";
+        var outputContext = new TranscriptOutputContext(
+            Format: options.ResultFormat,
+            DetectedLanguage: detectedLanguage,
+            AcceptedSegmentCount: selectionResult.AcceptedSegments.Count,
+            SkippedSegmentCount: selectionResult.SkippedSegments.Count,
+            Warnings: warnings);
+
+        await _outputWriter.WriteAsync(resultPath, selectionResult.AcceptedSegments, outputContext, cancellationToken);
 
         stopwatch.Stop();
 
-        // 8. Build preview
+        // 8. Build preview (always as TXT for display)
+        var previewContext = new TranscriptOutputContext(Format: ResultFormat.Txt);
         var preview = _outputWriter.BuildOutputText(
-            selectionResult.AcceptedSegments.Take(10).ToList());
+            selectionResult.AcceptedSegments.Take(10).ToList(), previewContext);
 
         progress?.Report(new ProgressUpdate(ProgressStage.Complete, 100, stopwatch.Elapsed, "Complete"));
 
         return new TranscribeFileResult(
             true,
-            $"{selectionResult.Language.DisplayName} ({selectionResult.Language.Code})",
+            detectedLanguage,
             resultPath,
             selectionResult.AcceptedSegments.Count,
             selectionResult.SkippedSegments.Count,

--- a/src/VoxFlow.Desktop/Components/Pages/ReadyView.razor
+++ b/src/VoxFlow.Desktop/Components/Pages/ReadyView.razor
@@ -28,6 +28,8 @@
     M4A, WAV, MP3, AAC, FLAC, OGG, AIFF, MP4
 </p>
 
+<SettingsPanel IsDisabled="ViewModel.HasBlockingValidationErrors" />
+
 @code {
     private async Task HandleFileSelected(string filePath)
     {

--- a/src/VoxFlow.Desktop/Components/Shared/SettingsPanel.razor
+++ b/src/VoxFlow.Desktop/Components/Shared/SettingsPanel.razor
@@ -1,0 +1,107 @@
+@using VoxFlow.Core.Configuration
+@inject AppViewModel ViewModel
+@inject DesktopConfigurationService ConfigService
+
+<div class="settings-panel" id="settings-panel" aria-label="Settings Panel">
+    <button class="settings-toggle" id="settings-toggle-button"
+            aria-label="@(_isExpanded ? "Close settings" : "Open settings")"
+            aria-expanded="@_isExpanded.ToString().ToLowerInvariant()"
+            title="Settings"
+            @onclick="ToggleSettings">
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+            <path d="M6.5 1.5h3l.4 1.8.5.2 1.6-.8 2.1 2.1-.8 1.6.2.5 1.8.4v3l-1.8.4-.2.5.8 1.6-2.1 2.1-1.6-.8-.5.2-.4 1.8h-3l-.4-1.8-.5-.2-1.6.8-2.1-2.1.8-1.6-.2-.5L.7 9.5v-3l1.8-.4.2-.5-.8-1.6L4 1.9l1.6.8.5-.2.4-1.2z"
+                  stroke="currentColor" stroke-width="1.1" stroke-linejoin="round" />
+            <circle cx="8" cy="8" r="2" stroke="currentColor" stroke-width="1.1" />
+        </svg>
+        <span class="settings-toggle-label">Settings</span>
+        <svg class="settings-chevron @(_isExpanded ? "settings-chevron-open" : "")"
+             width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
+            <path d="M3 4.5l3 3 3-3" stroke="currentColor" stroke-width="1.2"
+                  stroke-linecap="round" stroke-linejoin="round" />
+        </svg>
+    </button>
+
+    @if (_isExpanded)
+    {
+        <div class="settings-content" id="settings-content">
+            <div class="settings-field">
+                <label class="settings-label" for="result-format-select">Output Format</label>
+                <select id="result-format-select"
+                        class="settings-select"
+                        aria-label="Transcript output format"
+                        disabled="@IsDisabled"
+                        value="@ViewModel.SelectedResultFormat.ToString().ToLowerInvariant()"
+                        @onchange="HandleFormatChanged">
+                    <option value="txt">TXT (Plain text)</option>
+                    <option value="srt">SRT (Subtitles)</option>
+                    <option value="vtt">VTT (WebVTT)</option>
+                    <option value="json">JSON (Structured)</option>
+                    <option value="md">MD (Markdown)</option>
+                </select>
+            </div>
+
+            @if (!string.IsNullOrWhiteSpace(_saveStatus))
+            {
+                <div class="settings-save-status" id="settings-save-status"
+                     aria-live="polite">@_saveStatus</div>
+            }
+        </div>
+    }
+</div>
+
+@code {
+    [Parameter]
+    public bool IsDisabled { get; set; }
+
+    private bool _isExpanded;
+    private string? _saveStatus;
+    private CancellationTokenSource? _statusResetCts;
+
+    private void ToggleSettings()
+    {
+        _isExpanded = !_isExpanded;
+        _saveStatus = null;
+    }
+
+    private async Task HandleFormatChanged(ChangeEventArgs e)
+    {
+        var value = e.Value?.ToString();
+        var format = ResultFormatExtensions.TryParseFormat(value);
+        if (format is null) return;
+
+        ViewModel.SelectedResultFormat = format.Value;
+
+        try
+        {
+            await ConfigService.SaveUserOverridesAsync(new Dictionary<string, object>
+            {
+                ["resultFormat"] = format.Value.ToString().ToLowerInvariant()
+            });
+            ShowSaveStatus("Saved");
+        }
+        catch (Exception ex)
+        {
+            ShowSaveStatus($"Save failed: {ex.Message}");
+        }
+    }
+
+    private void ShowSaveStatus(string message)
+    {
+        _saveStatus = message;
+        _statusResetCts?.Cancel();
+        _statusResetCts?.Dispose();
+        _statusResetCts = new CancellationTokenSource();
+        _ = ResetSaveStatusAsync(_statusResetCts.Token);
+    }
+
+    private async Task ResetSaveStatusAsync(CancellationToken ct)
+    {
+        try
+        {
+            await Task.Delay(2000, ct);
+            _saveStatus = null;
+            await InvokeAsync(StateHasChanged);
+        }
+        catch (OperationCanceledException) { }
+    }
+}

--- a/src/VoxFlow.Desktop/Components/Shared/SettingsPanel.razor
+++ b/src/VoxFlow.Desktop/Components/Shared/SettingsPanel.razor
@@ -2,106 +2,58 @@
 @inject AppViewModel ViewModel
 @inject DesktopConfigurationService ConfigService
 
-<div class="settings-panel" id="settings-panel" aria-label="Settings Panel">
-    <button class="settings-toggle" id="settings-toggle-button"
-            aria-label="@(_isExpanded ? "Close settings" : "Open settings")"
-            aria-expanded="@_isExpanded.ToString().ToLowerInvariant()"
-            title="Settings"
-            @onclick="ToggleSettings">
-        <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-            <path d="M6.5 1.5h3l.4 1.8.5.2 1.6-.8 2.1 2.1-.8 1.6.2.5 1.8.4v3l-1.8.4-.2.5.8 1.6-2.1 2.1-1.6-.8-.5.2-.4 1.8h-3l-.4-1.8-.5-.2-1.6.8-2.1-2.1.8-1.6-.2-.5L.7 9.5v-3l1.8-.4.2-.5-.8-1.6L4 1.9l1.6.8.5-.2.4-1.2z"
-                  stroke="currentColor" stroke-width="1.1" stroke-linejoin="round" />
-            <circle cx="8" cy="8" r="2" stroke="currentColor" stroke-width="1.1" />
-        </svg>
-        <span class="settings-toggle-label">Settings</span>
-        <svg class="settings-chevron @(_isExpanded ? "settings-chevron-open" : "")"
-             width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
-            <path d="M3 4.5l3 3 3-3" stroke="currentColor" stroke-width="1.2"
-                  stroke-linecap="round" stroke-linejoin="round" />
-        </svg>
-    </button>
-
-    @if (_isExpanded)
-    {
-        <div class="settings-content" id="settings-content">
-            <div class="settings-field">
-                <label class="settings-label" for="result-format-select">Output Format</label>
-                <select id="result-format-select"
-                        class="settings-select"
-                        aria-label="Transcript output format"
-                        disabled="@IsDisabled"
-                        value="@ViewModel.SelectedResultFormat.ToString().ToLowerInvariant()"
-                        @onchange="HandleFormatChanged">
-                    <option value="txt">TXT (Plain text)</option>
-                    <option value="srt">SRT (Subtitles)</option>
-                    <option value="vtt">VTT (WebVTT)</option>
-                    <option value="json">JSON (Structured)</option>
-                    <option value="md">MD (Markdown)</option>
-                </select>
-            </div>
-
-            @if (!string.IsNullOrWhiteSpace(_saveStatus))
-            {
-                <div class="settings-save-status" id="settings-save-status"
-                     aria-live="polite">@_saveStatus</div>
-            }
-        </div>
-    }
+<div class="format-picker" id="format-picker" aria-label="Output format">
+    <span class="format-picker-label">Output Format</span>
+    <div class="format-picker-segments" role="radiogroup" aria-label="Transcript output format">
+        @foreach (var option in _options)
+        {
+            var isActive = ViewModel.SelectedResultFormat == option.Format;
+            <button class="format-segment @(isActive ? "format-segment-active" : "")"
+                    id="format-option-@option.Format.ToString().ToLowerInvariant()"
+                    role="radio"
+                    aria-checked="@isActive.ToString().ToLowerInvariant()"
+                    aria-label="@option.Label"
+                    title="@option.Tooltip"
+                    disabled="@IsDisabled"
+                    @onclick="() => SelectFormat(option.Format)">
+                @option.Label
+            </button>
+        }
+    </div>
 </div>
 
 @code {
     [Parameter]
     public bool IsDisabled { get; set; }
 
-    private bool _isExpanded;
-    private string? _saveStatus;
-    private CancellationTokenSource? _statusResetCts;
+    private static readonly FormatOption[] _options =
+    [
+        new(ResultFormat.Txt, "TXT", "Plain text"),
+        new(ResultFormat.Srt, "SRT", "SubRip subtitles"),
+        new(ResultFormat.Vtt, "VTT", "WebVTT subtitles"),
+        new(ResultFormat.Json, "JSON", "Structured JSON"),
+        new(ResultFormat.Md, "MD", "Markdown")
+    ];
 
-    private void ToggleSettings()
+    private async Task SelectFormat(ResultFormat format)
     {
-        _isExpanded = !_isExpanded;
-        _saveStatus = null;
-    }
+        if (IsDisabled || format == ViewModel.SelectedResultFormat)
+            return;
 
-    private async Task HandleFormatChanged(ChangeEventArgs e)
-    {
-        var value = e.Value?.ToString();
-        var format = ResultFormatExtensions.TryParseFormat(value);
-        if (format is null) return;
-
-        ViewModel.SelectedResultFormat = format.Value;
+        ViewModel.SelectedResultFormat = format;
 
         try
         {
             await ConfigService.SaveUserOverridesAsync(new Dictionary<string, object>
             {
-                ["resultFormat"] = format.Value.ToString().ToLowerInvariant()
+                ["resultFormat"] = format.ToString().ToLowerInvariant()
             });
-            ShowSaveStatus("Saved");
         }
-        catch (Exception ex)
+        catch
         {
-            ShowSaveStatus($"Save failed: {ex.Message}");
+            // Save is best-effort; the in-memory selection is already applied.
         }
     }
 
-    private void ShowSaveStatus(string message)
-    {
-        _saveStatus = message;
-        _statusResetCts?.Cancel();
-        _statusResetCts?.Dispose();
-        _statusResetCts = new CancellationTokenSource();
-        _ = ResetSaveStatusAsync(_statusResetCts.Token);
-    }
-
-    private async Task ResetSaveStatusAsync(CancellationToken ct)
-    {
-        try
-        {
-            await Task.Delay(2000, ct);
-            _saveStatus = null;
-            await InvokeAsync(StateHasChanged);
-        }
-        catch (OperationCanceledException) { }
-    }
+    private sealed record FormatOption(ResultFormat Format, string Label, string Tooltip);
 }

--- a/src/VoxFlow.Desktop/ViewModels/AppViewModel.cs
+++ b/src/VoxFlow.Desktop/ViewModels/AppViewModel.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using VoxFlow.Core.Configuration;
 using VoxFlow.Core.Interfaces;
 using VoxFlow.Core.Models;
 using VoxFlow.Desktop.Services;
@@ -23,6 +24,7 @@ public class AppViewModel : INotifyPropertyChanged
     private string? _errorMessage;
     private string? _lastFilePath;
     private CancellationTokenSource? _cts;
+    private ResultFormat _selectedResultFormat = ResultFormat.Txt;
 
     public AppViewModel(
         ITranscriptionService transcriptionService,
@@ -36,6 +38,20 @@ public class AppViewModel : INotifyPropertyChanged
         _transcriptionService = transcriptionService;
         _validationService = validationService;
         _configService = configService;
+    }
+
+    /// <summary>
+    /// The currently selected transcript output format.
+    /// </summary>
+    public ResultFormat SelectedResultFormat
+    {
+        get => _selectedResultFormat;
+        set
+        {
+            if (_selectedResultFormat == value) return;
+            _selectedResultFormat = value;
+            OnPropertyChanged();
+        }
     }
 
     public AppState CurrentState
@@ -132,6 +148,7 @@ public class AppViewModel : INotifyPropertyChanged
     public async Task InitializeAsync()
     {
         var options = await _configService.LoadAsync();
+        SelectedResultFormat = options.ResultFormat;
         var result = await _validationService.ValidateAsync(options);
         ValidationResult = result;
         CurrentState = AppState.Ready;
@@ -165,12 +182,13 @@ public class AppViewModel : INotifyPropertyChanged
         var options = await _configService.LoadAsync();
         var wavPath = options.WavFilePath;
 
-        // Place result in ~/Documents/VoxFlow/output/{inputName}.txt
+        // Place result in ~/Documents/VoxFlow/output/{inputName}.{ext}
         var outputDir = Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments),
             "VoxFlow", "output");
         Directory.CreateDirectory(outputDir);
-        var resultFileName = Path.GetFileNameWithoutExtension(filePath) + ".txt";
+        var resultExtension = options.ResultFormat.ToFileExtension();
+        var resultFileName = Path.GetFileNameWithoutExtension(filePath) + resultExtension;
         var resultFilePath = Path.Combine(outputDir, resultFileName);
 
         try

--- a/src/VoxFlow.Desktop/_Imports.razor
+++ b/src/VoxFlow.Desktop/_Imports.razor
@@ -6,6 +6,7 @@
 @using VoxFlow.Core.Models
 @using VoxFlow.Desktop
 @using VoxFlow.Desktop.Components
+@using VoxFlow.Desktop.Configuration
 @using VoxFlow.Desktop.Components.Layout
 @using VoxFlow.Desktop.Components.Pages
 @using VoxFlow.Desktop.Components.Shared

--- a/src/VoxFlow.Desktop/appsettings.json
+++ b/src/VoxFlow.Desktop/appsettings.json
@@ -1,6 +1,7 @@
 {
   "transcription": {
     "processingMode": "single",
+    "resultFormat": "txt",
 
     "inputFilePath": "~/Documents/VoxFlow/input.m4a",
     "wavFilePath": "~/Library/Application Support/VoxFlow/artifacts/output.wav",

--- a/src/VoxFlow.Desktop/wwwroot/css/app.css
+++ b/src/VoxFlow.Desktop/wwwroot/css/app.css
@@ -927,6 +927,119 @@ button {
     to { transform: scale(1); }
 }
 
+/* ---------- Settings Panel ---------- */
+.settings-panel {
+    width: 100%;
+    max-width: 400px;
+    margin-top: 20px;
+}
+
+.settings-toggle {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    width: 100%;
+    padding: 8px 12px;
+    background: transparent;
+    border: 1px solid var(--border);
+    border-radius: var(--border-radius);
+    color: var(--text-muted);
+    font-size: 12px;
+    font-family: var(--font-family);
+    cursor: pointer;
+    transition: color var(--transition-fast), border-color var(--transition-fast), background var(--transition-fast);
+}
+
+.settings-toggle:hover {
+    color: var(--text-secondary);
+    border-color: var(--drop-zone-border);
+    background: rgba(255, 255, 255, 0.02);
+}
+
+.settings-toggle-label {
+    flex: 1;
+    text-align: left;
+}
+
+.settings-chevron {
+    transition: transform var(--transition-fast);
+}
+
+.settings-chevron-open {
+    transform: rotate(180deg);
+}
+
+.settings-content {
+    margin-top: 8px;
+    padding: 16px;
+    background: rgba(22, 33, 62, 0.5);
+    border: 1px solid var(--border);
+    border-radius: var(--border-radius);
+    animation: settings-slide 0.15s ease-out;
+}
+
+@keyframes settings-slide {
+    from { opacity: 0; transform: translateY(-4px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+.settings-field {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+}
+
+.settings-label {
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--text-secondary);
+    white-space: nowrap;
+}
+
+.settings-select {
+    flex: 1;
+    max-width: 200px;
+    padding: 6px 10px;
+    background: var(--bg-primary);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    color: var(--text-primary);
+    font-size: 13px;
+    font-family: var(--font-family);
+    cursor: pointer;
+    outline: none;
+    transition: border-color var(--transition-fast);
+    -webkit-appearance: none;
+    appearance: none;
+}
+
+.settings-select:hover:not(:disabled) {
+    border-color: var(--drop-zone-border);
+}
+
+.settings-select:focus {
+    border-color: var(--accent);
+}
+
+.settings-select:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+.settings-save-status {
+    margin-top: 8px;
+    font-size: 11px;
+    color: var(--success);
+    text-align: right;
+    animation: settings-fade 0.2s ease-out;
+}
+
+@keyframes settings-fade {
+    from { opacity: 0; }
+    to { opacity: 1; }
+}
+
 /* ---------- Blazor Error UI ---------- */
 #blazor-error-ui {
     background: var(--bg-secondary);

--- a/src/VoxFlow.Desktop/wwwroot/css/app.css
+++ b/src/VoxFlow.Desktop/wwwroot/css/app.css
@@ -927,117 +927,68 @@ button {
     to { transform: scale(1); }
 }
 
-/* ---------- Settings Panel ---------- */
-.settings-panel {
+/* ---------- Format Picker ---------- */
+.format-picker {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+    margin-top: 20px;
     width: 100%;
     max-width: 400px;
-    margin-top: 20px;
 }
 
-.settings-toggle {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    width: 100%;
-    padding: 8px 12px;
-    background: transparent;
-    border: 1px solid var(--border);
-    border-radius: var(--border-radius);
-    color: var(--text-muted);
-    font-size: 12px;
-    font-family: var(--font-family);
-    cursor: pointer;
-    transition: color var(--transition-fast), border-color var(--transition-fast), background var(--transition-fast);
-}
-
-.settings-toggle:hover {
-    color: var(--text-secondary);
-    border-color: var(--drop-zone-border);
-    background: rgba(255, 255, 255, 0.02);
-}
-
-.settings-toggle-label {
-    flex: 1;
-    text-align: left;
-}
-
-.settings-chevron {
-    transition: transform var(--transition-fast);
-}
-
-.settings-chevron-open {
-    transform: rotate(180deg);
-}
-
-.settings-content {
-    margin-top: 8px;
-    padding: 16px;
-    background: rgba(22, 33, 62, 0.5);
-    border: 1px solid var(--border);
-    border-radius: var(--border-radius);
-    animation: settings-slide 0.15s ease-out;
-}
-
-@keyframes settings-slide {
-    from { opacity: 0; transform: translateY(-4px); }
-    to { opacity: 1; transform: translateY(0); }
-}
-
-.settings-field {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 12px;
-}
-
-.settings-label {
-    font-size: 13px;
+.format-picker-label {
+    font-size: 11px;
     font-weight: 500;
-    color: var(--text-secondary);
-    white-space: nowrap;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
 }
 
-.settings-select {
-    flex: 1;
-    max-width: 200px;
-    padding: 6px 10px;
-    background: var(--bg-primary);
+.format-picker-segments {
+    display: flex;
+    background: rgba(22, 33, 62, 0.6);
     border: 1px solid var(--border);
-    border-radius: 6px;
-    color: var(--text-primary);
-    font-size: 13px;
+    border-radius: 8px;
+    padding: 3px;
+    gap: 2px;
+}
+
+.format-segment {
+    position: relative;
+    padding: 6px 16px;
+    font-size: 12px;
+    font-weight: 500;
     font-family: var(--font-family);
+    letter-spacing: 0.3px;
+    color: var(--text-muted);
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: 6px;
     cursor: pointer;
     outline: none;
-    transition: border-color var(--transition-fast);
-    -webkit-appearance: none;
-    appearance: none;
+    transition: color var(--transition-fast),
+                background var(--transition-fast),
+                border-color var(--transition-fast),
+                box-shadow var(--transition-fast);
 }
 
-.settings-select:hover:not(:disabled) {
-    border-color: var(--drop-zone-border);
+.format-segment:hover:not(:disabled):not(.format-segment-active) {
+    color: var(--text-secondary);
+    background: rgba(255, 255, 255, 0.04);
 }
 
-.settings-select:focus {
-    border-color: var(--accent);
+.format-segment-active {
+    color: var(--text-primary);
+    background: rgba(74, 74, 255, 0.12);
+    border-color: rgba(74, 74, 255, 0.25);
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.2);
 }
 
-.settings-select:disabled {
-    opacity: 0.5;
+.format-segment:disabled {
+    opacity: 0.4;
     cursor: not-allowed;
-}
-
-.settings-save-status {
-    margin-top: 8px;
-    font-size: 11px;
-    color: var(--success);
-    text-align: right;
-    animation: settings-fade 0.2s ease-out;
-}
-
-@keyframes settings-fade {
-    from { opacity: 0; }
-    to { opacity: 1; }
 }
 
 /* ---------- Blazor Error UI ---------- */

--- a/tests/TestSupport/TestSettingsFileFactory.cs
+++ b/tests/TestSupport/TestSettingsFileFactory.cs
@@ -37,7 +37,8 @@ internal static class TestSettingsFileFactory
         int maxConsecutiveDuplicateSegments = 2,
         int maxDuplicateSegmentTextLength = 32,
         string processingMode = "single",
-        object? batch = null)
+        object? batch = null,
+        string? resultFormat = null)
     {
         supportedLanguages ??=
         [
@@ -80,6 +81,7 @@ internal static class TestSettingsFileFactory
         var transcription = new Dictionary<string, object?>
         {
             ["processingMode"] = processingMode,
+            ["resultFormat"] = resultFormat,
             ["inputFilePath"] = inputFilePath,
             ["wavFilePath"] = wavFilePath,
             ["resultFilePath"] = resultFilePath,

--- a/tests/VoxFlow.Core.Tests/BatchOutputExtensionTests.cs
+++ b/tests/VoxFlow.Core.Tests/BatchOutputExtensionTests.cs
@@ -1,0 +1,69 @@
+using System.IO;
+using System.Linq;
+using VoxFlow.Core.Configuration;
+using VoxFlow.Core.Services;
+using Xunit;
+
+namespace VoxFlow.Core.Tests;
+
+public sealed class BatchOutputExtensionTests
+{
+    [Theory]
+    [InlineData(".txt")]
+    [InlineData(".srt")]
+    [InlineData(".vtt")]
+    [InlineData(".json")]
+    [InlineData(".md")]
+    public void DiscoverInputFiles_UsesConfiguredOutputExtension(string extension)
+    {
+        using var directory = new TemporaryDirectory();
+        var inputDir = Path.Combine(directory.Path, "input");
+        var outputDir = Path.Combine(directory.Path, "output");
+        Directory.CreateDirectory(inputDir);
+        Directory.CreateDirectory(outputDir);
+
+        File.WriteAllText(Path.Combine(inputDir, "recording.m4a"), "audio data");
+
+        var options = new BatchOptions(
+            InputDirectory: inputDir,
+            OutputDirectory: outputDir,
+            TempDirectory: directory.Path,
+            FilePattern: "*.m4a",
+            StopOnFirstError: false,
+            KeepIntermediateFiles: false,
+            SummaryFilePath: "summary.txt");
+
+        var service = new FileDiscoveryService();
+        var files = service.DiscoverInputFiles(options, outputExtension: extension);
+
+        Assert.Single(files);
+        Assert.EndsWith($"recording{extension}", files[0].OutputPath);
+    }
+
+    [Fact]
+    public void DiscoverInputFiles_DefaultExtensionIsTxt()
+    {
+        using var directory = new TemporaryDirectory();
+        var inputDir = Path.Combine(directory.Path, "input");
+        var outputDir = Path.Combine(directory.Path, "output");
+        Directory.CreateDirectory(inputDir);
+        Directory.CreateDirectory(outputDir);
+
+        File.WriteAllText(Path.Combine(inputDir, "test.m4a"), "audio data");
+
+        var options = new BatchOptions(
+            InputDirectory: inputDir,
+            OutputDirectory: outputDir,
+            TempDirectory: directory.Path,
+            FilePattern: "*.m4a",
+            StopOnFirstError: false,
+            KeepIntermediateFiles: false,
+            SummaryFilePath: "summary.txt");
+
+        var service = new FileDiscoveryService();
+        var files = service.DiscoverInputFiles(options);
+
+        Assert.Single(files);
+        Assert.EndsWith(".txt", files[0].OutputPath);
+    }
+}

--- a/tests/VoxFlow.Core.Tests/BatchTranscriptionServiceTests.cs
+++ b/tests/VoxFlow.Core.Tests/BatchTranscriptionServiceTests.cs
@@ -151,7 +151,7 @@ public sealed class BatchTranscriptionServiceTests
     {
         public int? RecordedMaxFiles { get; private set; }
 
-        public IReadOnlyList<DiscoveredFile> DiscoverInputFiles(BatchOptions batchOptions, int? maxFiles = null)
+        public IReadOnlyList<DiscoveredFile> DiscoverInputFiles(BatchOptions batchOptions, int? maxFiles = null, string outputExtension = ".txt")
         {
             RecordedMaxFiles = maxFiles;
             return files;
@@ -296,12 +296,13 @@ public sealed class BatchTranscriptionServiceTests
         public Task WriteAsync(
             string outputPath,
             IReadOnlyList<FilteredSegment> segments,
+            TranscriptOutputContext context,
             CancellationToken cancellationToken = default)
         {
             throw new NotSupportedException("Skipped files should not write transcripts.");
         }
 
-        public string BuildOutputText(IReadOnlyList<FilteredSegment> segments)
+        public string BuildOutputText(IReadOnlyList<FilteredSegment> segments, TranscriptOutputContext context)
             => string.Empty;
     }
 
@@ -310,13 +311,14 @@ public sealed class BatchTranscriptionServiceTests
         public Task WriteAsync(
             string outputPath,
             IReadOnlyList<FilteredSegment> segments,
+            TranscriptOutputContext context,
             CancellationToken cancellationToken = default)
         {
             File.WriteAllText(outputPath, string.Join(Environment.NewLine, segments.Select(segment => segment.Text)));
             return Task.CompletedTask;
         }
 
-        public string BuildOutputText(IReadOnlyList<FilteredSegment> segments)
+        public string BuildOutputText(IReadOnlyList<FilteredSegment> segments, TranscriptOutputContext context)
             => string.Join(Environment.NewLine, segments.Select(segment => segment.Text));
     }
 

--- a/tests/VoxFlow.Core.Tests/OutputWriterFormatTests.cs
+++ b/tests/VoxFlow.Core.Tests/OutputWriterFormatTests.cs
@@ -1,0 +1,121 @@
+using System;
+using System.IO;
+using System.Text.Json;
+using System.Threading.Tasks;
+using VoxFlow.Core.Configuration;
+using VoxFlow.Core.Models;
+using VoxFlow.Core.Services;
+using Xunit;
+
+namespace VoxFlow.Core.Tests;
+
+/// <summary>
+/// Tests the OutputWriter end-to-end with different formats to verify
+/// that format dispatch, file writing, and UTF-8 encoding work correctly.
+/// </summary>
+public sealed class OutputWriterFormatTests
+{
+    private static readonly FilteredSegment[] Segments =
+    [
+        new(TimeSpan.FromMilliseconds(1200), TimeSpan.FromMilliseconds(3800), "Hello, world.", 0.95),
+        new(TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(8500), "Second segment.", 0.88)
+    ];
+
+    private static readonly TranscriptOutputContext MetadataContext = new(
+        Format: ResultFormat.Txt,
+        DetectedLanguage: "English (en)",
+        AcceptedSegmentCount: 2,
+        SkippedSegmentCount: 1,
+        Warnings: ["test warning"]);
+
+    [Fact]
+    public async Task WriteAsync_SrtFormat_WritesValidSrtFile()
+    {
+        using var directory = new TemporaryDirectory();
+        var path = Path.Combine(directory.Path, "result.srt");
+        var context = MetadataContext with { Format = ResultFormat.Srt };
+
+        var writer = new OutputWriter();
+        await writer.WriteAsync(path, Segments, context);
+
+        var content = await File.ReadAllTextAsync(path);
+        Assert.Contains("1", content);
+        Assert.Contains("00:00:01,200 --> 00:00:03,800", content);
+        Assert.Contains("Hello, world.", content);
+    }
+
+    [Fact]
+    public async Task WriteAsync_VttFormat_WritesValidVttFile()
+    {
+        using var directory = new TemporaryDirectory();
+        var path = Path.Combine(directory.Path, "result.vtt");
+        var context = MetadataContext with { Format = ResultFormat.Vtt };
+
+        var writer = new OutputWriter();
+        await writer.WriteAsync(path, Segments, context);
+
+        var content = await File.ReadAllTextAsync(path);
+        Assert.StartsWith("WEBVTT", content);
+        Assert.Contains("00:00:01.200 --> 00:00:03.800", content);
+    }
+
+    [Fact]
+    public async Task WriteAsync_JsonFormat_WritesValidJsonFile()
+    {
+        using var directory = new TemporaryDirectory();
+        var path = Path.Combine(directory.Path, "result.json");
+        var context = MetadataContext with { Format = ResultFormat.Json };
+
+        var writer = new OutputWriter();
+        await writer.WriteAsync(path, Segments, context);
+
+        var content = await File.ReadAllTextAsync(path);
+        var doc = JsonDocument.Parse(content);
+        Assert.Equal(2, doc.RootElement.GetProperty("segments").GetArrayLength());
+    }
+
+    [Fact]
+    public async Task WriteAsync_MdFormat_WritesReadableMarkdown()
+    {
+        using var directory = new TemporaryDirectory();
+        var path = Path.Combine(directory.Path, "result.md");
+        var context = MetadataContext with { Format = ResultFormat.Md };
+
+        var writer = new OutputWriter();
+        await writer.WriteAsync(path, Segments, context);
+
+        var content = await File.ReadAllTextAsync(path);
+        Assert.StartsWith("# Transcript", content);
+        Assert.Contains("Hello, world.", content);
+    }
+
+    [Fact]
+    public async Task WriteAsync_AllFormats_ProduceUtf8WithoutBom()
+    {
+        foreach (var format in Enum.GetValues<ResultFormat>())
+        {
+            using var directory = new TemporaryDirectory();
+            var path = Path.Combine(directory.Path, $"result{format.ToFileExtension()}");
+            var context = MetadataContext with { Format = format };
+
+            var writer = new OutputWriter();
+            await writer.WriteAsync(path, Segments, context);
+
+            var bytes = await File.ReadAllBytesAsync(path);
+            Assert.False(bytes.Length >= 3 && bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF,
+                $"Format {format}: output file should not contain a UTF-8 BOM.");
+        }
+    }
+
+    [Fact]
+    public void BuildOutputText_TxtFormat_MatchesLegacyBehavior()
+    {
+        var context = new TranscriptOutputContext(ResultFormat.Txt);
+        var writer = new OutputWriter();
+        var output = writer.BuildOutputText(Segments, context);
+
+        // Verify it matches the exact legacy format
+        Assert.Contains("00:00:01.2000000->00:00:03.8000000: Hello, world.", output);
+        Assert.Contains("00:00:05->00:00:08.5000000: Second segment.", output);
+    }
+}

--- a/tests/VoxFlow.Core.Tests/OutputWriterTests.cs
+++ b/tests/VoxFlow.Core.Tests/OutputWriterTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using VoxFlow.Core.Configuration;
 using VoxFlow.Core.Models;
 using VoxFlow.Core.Services;
 using Xunit;
@@ -10,6 +11,8 @@ namespace VoxFlow.Core.Tests;
 
 public sealed class OutputWriterTests
 {
+    private static readonly TranscriptOutputContext TxtContext = new(ResultFormat.Txt);
+
     [Fact]
     public void BuildOutputText_UsesLegacyTimestampFormat()
     {
@@ -23,7 +26,7 @@ public sealed class OutputWriterTests
         };
 
         var writer = new OutputWriter();
-        var output = writer.BuildOutputText(segments);
+        var output = writer.BuildOutputText(segments, TxtContext);
 
         Assert.Equal("00:00:01->00:00:02: Hello" + Environment.NewLine, output);
     }
@@ -41,7 +44,7 @@ public sealed class OutputWriterTests
         };
 
         var writer = new OutputWriter();
-        var output = writer.BuildOutputText(segments);
+        var output = writer.BuildOutputText(segments, TxtContext);
 
         Assert.Contains("00:00:01.2000000->00:00:03.8000000: Test", output);
     }
@@ -50,7 +53,7 @@ public sealed class OutputWriterTests
     public void BuildOutputText_ReturnsEmptyStringForNoSegments()
     {
         var writer = new OutputWriter();
-        var output = writer.BuildOutputText(Array.Empty<FilteredSegment>());
+        var output = writer.BuildOutputText(Array.Empty<FilteredSegment>(), TxtContext);
 
         Assert.Equal(string.Empty, output);
     }
@@ -66,7 +69,7 @@ public sealed class OutputWriterTests
         };
 
         var writer = new OutputWriter();
-        var output = writer.BuildOutputText(segments);
+        var output = writer.BuildOutputText(segments, TxtContext);
 
         var lines = output.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
         Assert.Equal(3, lines.Length);
@@ -86,7 +89,7 @@ public sealed class OutputWriterTests
         };
 
         var writer = new OutputWriter();
-        await writer.WriteAsync(resultPath, segments);
+        await writer.WriteAsync(resultPath, segments, TxtContext);
 
         var bytes = await File.ReadAllBytesAsync(resultPath);
         // UTF-8 BOM is EF BB BF; verify it's absent.
@@ -111,7 +114,7 @@ public sealed class OutputWriterTests
         await cancellationTokenSource.CancelAsync();
 
         await Assert.ThrowsAnyAsync<OperationCanceledException>(
-            () => writer.WriteAsync(resultPath, segments, cancellationTokenSource.Token));
+            () => writer.WriteAsync(resultPath, segments, TxtContext, cancellationTokenSource.Token));
 
         Assert.False(File.Exists(resultPath));
     }

--- a/tests/VoxFlow.Core.Tests/ResultFormatTests.cs
+++ b/tests/VoxFlow.Core.Tests/ResultFormatTests.cs
@@ -1,0 +1,193 @@
+using VoxFlow.Core.Configuration;
+using Xunit;
+
+namespace VoxFlow.Core.Tests;
+
+public sealed class ResultFormatTests
+{
+    // -----------------------------------------------------------------------
+    // ParseFormat — supported values (case-insensitive)
+    // -----------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("txt", ResultFormat.Txt)]
+    [InlineData("TXT", ResultFormat.Txt)]
+    [InlineData("Txt", ResultFormat.Txt)]
+    [InlineData("srt", ResultFormat.Srt)]
+    [InlineData("SRT", ResultFormat.Srt)]
+    [InlineData("vtt", ResultFormat.Vtt)]
+    [InlineData("VTT", ResultFormat.Vtt)]
+    [InlineData("json", ResultFormat.Json)]
+    [InlineData("JSON", ResultFormat.Json)]
+    [InlineData("md", ResultFormat.Md)]
+    [InlineData("MD", ResultFormat.Md)]
+    public void ParseFormat_SupportedValues_ReturnsCorrectFormat(string input, ResultFormat expected)
+    {
+        Assert.Equal(expected, ResultFormatExtensions.ParseFormat(input));
+    }
+
+    // -----------------------------------------------------------------------
+    // ParseFormat — defaults to TXT when missing
+    // -----------------------------------------------------------------------
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("  ")]
+    public void ParseFormat_MissingOrEmpty_DefaultsToTxt(string? input)
+    {
+        Assert.Equal(ResultFormat.Txt, ResultFormatExtensions.ParseFormat(input));
+    }
+
+    // -----------------------------------------------------------------------
+    // ParseFormat — rejects unsupported values
+    // -----------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("pdf")]
+    [InlineData("docx")]
+    [InlineData("csv")]
+    [InlineData("xml")]
+    [InlineData("html")]
+    public void ParseFormat_UnsupportedValues_ThrowsWithActionableMessage(string input)
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() => ResultFormatExtensions.ParseFormat(input));
+        Assert.Contains(input, ex.Message);
+        Assert.Contains("txt, srt, vtt, json, md", ex.Message);
+    }
+
+    // -----------------------------------------------------------------------
+    // ParseFormat — handles whitespace
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void ParseFormat_TrimsWhitespace()
+    {
+        Assert.Equal(ResultFormat.Srt, ResultFormatExtensions.ParseFormat("  srt  "));
+    }
+
+    // -----------------------------------------------------------------------
+    // TryParseFormat
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void TryParseFormat_ValidValue_ReturnsFormat()
+    {
+        Assert.Equal(ResultFormat.Json, ResultFormatExtensions.TryParseFormat("json"));
+    }
+
+    [Fact]
+    public void TryParseFormat_InvalidValue_ReturnsNull()
+    {
+        Assert.Null(ResultFormatExtensions.TryParseFormat("pdf"));
+    }
+
+    [Fact]
+    public void TryParseFormat_NullValue_ReturnsNull()
+    {
+        Assert.Null(ResultFormatExtensions.TryParseFormat(null));
+    }
+
+    // -----------------------------------------------------------------------
+    // ToFileExtension
+    // -----------------------------------------------------------------------
+
+    [Theory]
+    [InlineData(ResultFormat.Txt, ".txt")]
+    [InlineData(ResultFormat.Srt, ".srt")]
+    [InlineData(ResultFormat.Vtt, ".vtt")]
+    [InlineData(ResultFormat.Json, ".json")]
+    [InlineData(ResultFormat.Md, ".md")]
+    public void ToFileExtension_ReturnsCorrectExtension(ResultFormat format, string expected)
+    {
+        Assert.Equal(expected, format.ToFileExtension());
+    }
+
+    // -----------------------------------------------------------------------
+    // NormalizeOutputPath
+    // -----------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("/output/result.txt", ResultFormat.Srt, "/output/result.srt")]
+    [InlineData("/output/result.txt", ResultFormat.Txt, "/output/result.txt")]
+    [InlineData("/output/result.txt", ResultFormat.Json, "/output/result.json")]
+    [InlineData("/output/result.srt", ResultFormat.Vtt, "/output/result.vtt")]
+    [InlineData("/output/result.md", ResultFormat.Md, "/output/result.md")]
+    public void NormalizeOutputPath_ChangesExtensionToMatchFormat(string input, ResultFormat format, string expected)
+    {
+        Assert.Equal(expected, ResultFormatExtensions.NormalizeOutputPath(input, format));
+    }
+
+    [Fact]
+    public void NormalizeOutputPath_PreservesDirectory()
+    {
+        var result = ResultFormatExtensions.NormalizeOutputPath("/long/path/to/file.txt", ResultFormat.Vtt);
+        Assert.StartsWith("/long/path/to/", result);
+        Assert.EndsWith(".vtt", result);
+    }
+
+    // -----------------------------------------------------------------------
+    // Configuration integration — TranscriptionOptions loads resultFormat
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void TranscriptionOptions_DefaultsToTxt_WhenFieldIsMissing()
+    {
+        using var directory = new TemporaryDirectory();
+
+        var settingsPath = TestSettingsFileFactory.Write(
+            directory.Path,
+            inputFilePath: "/tmp/input.m4a",
+            wavFilePath: "/tmp/output.wav",
+            resultFilePath: "/tmp/result.txt",
+            modelFilePath: "/tmp/model.bin",
+            ffmpegExecutablePath: "ffmpeg");
+
+        var options = TranscriptionOptions.LoadFromPath(settingsPath);
+
+        Assert.Equal(ResultFormat.Txt, options.ResultFormat);
+    }
+
+    [Theory]
+    [InlineData("srt", ResultFormat.Srt)]
+    [InlineData("vtt", ResultFormat.Vtt)]
+    [InlineData("json", ResultFormat.Json)]
+    [InlineData("md", ResultFormat.Md)]
+    [InlineData("SRT", ResultFormat.Srt)]
+    public void TranscriptionOptions_ParsesConfiguredResultFormat(string configValue, ResultFormat expected)
+    {
+        using var directory = new TemporaryDirectory();
+
+        var settingsPath = TestSettingsFileFactory.Write(
+            directory.Path,
+            inputFilePath: "/tmp/input.m4a",
+            wavFilePath: "/tmp/output.wav",
+            resultFilePath: "/tmp/result.txt",
+            modelFilePath: "/tmp/model.bin",
+            ffmpegExecutablePath: "ffmpeg",
+            resultFormat: configValue);
+
+        var options = TranscriptionOptions.LoadFromPath(settingsPath);
+
+        Assert.Equal(expected, options.ResultFormat);
+    }
+
+    [Fact]
+    public void TranscriptionOptions_RejectsUnsupportedResultFormat()
+    {
+        using var directory = new TemporaryDirectory();
+
+        var settingsPath = TestSettingsFileFactory.Write(
+            directory.Path,
+            inputFilePath: "/tmp/input.m4a",
+            wavFilePath: "/tmp/output.wav",
+            resultFilePath: "/tmp/result.txt",
+            modelFilePath: "/tmp/model.bin",
+            ffmpegExecutablePath: "ffmpeg",
+            resultFormat: "pdf");
+
+        var ex = Assert.Throws<InvalidOperationException>(() => TranscriptionOptions.LoadFromPath(settingsPath));
+        Assert.Contains("pdf", ex.Message);
+        Assert.Contains("txt, srt, vtt, json, md", ex.Message);
+    }
+}

--- a/tests/VoxFlow.Core.Tests/TranscriptFormatterTests.cs
+++ b/tests/VoxFlow.Core.Tests/TranscriptFormatterTests.cs
@@ -1,0 +1,257 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using VoxFlow.Core.Configuration;
+using VoxFlow.Core.Models;
+using VoxFlow.Core.Services.Formatters;
+using Xunit;
+
+namespace VoxFlow.Core.Tests;
+
+public sealed class TranscriptFormatterTests
+{
+    private static readonly IReadOnlyList<FilteredSegment> SampleSegments = new[]
+    {
+        new FilteredSegment(TimeSpan.FromMilliseconds(1200), TimeSpan.FromMilliseconds(3800), "Hello, this is a test.", 0.95),
+        new FilteredSegment(TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(8500), "Second line here.", 0.88)
+    };
+
+    private static readonly TranscriptOutputContext DefaultContext = new(
+        Format: ResultFormat.Txt,
+        DetectedLanguage: "English (en)",
+        AcceptedSegmentCount: 2,
+        SkippedSegmentCount: 1,
+        Warnings: new[] { "low quality" });
+
+    // -----------------------------------------------------------------------
+    // TXT formatter
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void TxtFormatter_ProducesLegacyTimestampedFormat()
+    {
+        var formatter = new TxtTranscriptFormatter();
+        var output = formatter.Format(SampleSegments, DefaultContext);
+
+        var lines = output.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+        Assert.Equal(2, lines.Length);
+        Assert.Contains("->", lines[0]);
+        Assert.Contains(": Hello, this is a test.", lines[0]);
+        Assert.Contains(": Second line here.", lines[1]);
+    }
+
+    [Fact]
+    public void TxtFormatter_EmptySegments_ReturnsEmptyString()
+    {
+        var formatter = new TxtTranscriptFormatter();
+        var output = formatter.Format(Array.Empty<FilteredSegment>(), DefaultContext);
+        Assert.Equal(string.Empty, output);
+    }
+
+    // -----------------------------------------------------------------------
+    // SRT formatter
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void SrtFormatter_ProducesNumberedCuesWithCorrectTimestamps()
+    {
+        var formatter = new SrtTranscriptFormatter();
+        var output = formatter.Format(SampleSegments, DefaultContext);
+
+        Assert.Contains("1", output);
+        Assert.Contains("2", output);
+        Assert.Contains("00:00:01,200 --> 00:00:03,800", output);
+        Assert.Contains("Hello, this is a test.", output);
+        Assert.Contains("00:00:05,000 --> 00:00:08,500", output);
+        Assert.Contains("Second line here.", output);
+    }
+
+    [Fact]
+    public void SrtFormatter_TimestampFormat_UsesCommaMilliseconds()
+    {
+        var ts = TimeSpan.FromMilliseconds(3723456); // 1h 2m 3s 456ms
+        var formatted = SrtTranscriptFormatter.FormatSrtTimestamp(ts);
+        Assert.Equal("01:02:03,456", formatted);
+    }
+
+    [Fact]
+    public void SrtFormatter_TimestampFormat_ZeroTimestamp()
+    {
+        var formatted = SrtTranscriptFormatter.FormatSrtTimestamp(TimeSpan.Zero);
+        Assert.Equal("00:00:00,000", formatted);
+    }
+
+    [Fact]
+    public void SrtFormatter_EmptySegments_ReturnsEmptyString()
+    {
+        var formatter = new SrtTranscriptFormatter();
+        var output = formatter.Format(Array.Empty<FilteredSegment>(), DefaultContext);
+        Assert.Equal(string.Empty, output);
+    }
+
+    // -----------------------------------------------------------------------
+    // VTT formatter
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void VttFormatter_StartsWithWebVttHeader()
+    {
+        var formatter = new VttTranscriptFormatter();
+        var output = formatter.Format(SampleSegments, DefaultContext);
+
+        Assert.StartsWith("WEBVTT", output);
+    }
+
+    [Fact]
+    public void VttFormatter_UsesDotMilliseconds()
+    {
+        var formatter = new VttTranscriptFormatter();
+        var output = formatter.Format(SampleSegments, DefaultContext);
+
+        Assert.Contains("00:00:01.200 --> 00:00:03.800", output);
+        Assert.Contains("00:00:05.000 --> 00:00:08.500", output);
+    }
+
+    [Fact]
+    public void VttFormatter_TimestampFormat_UsesDotSeparator()
+    {
+        var ts = TimeSpan.FromMilliseconds(3723456);
+        var formatted = VttTranscriptFormatter.FormatVttTimestamp(ts);
+        Assert.Equal("01:02:03.456", formatted);
+    }
+
+    [Fact]
+    public void VttFormatter_EmptySegments_StillProducesHeader()
+    {
+        var formatter = new VttTranscriptFormatter();
+        var output = formatter.Format(Array.Empty<FilteredSegment>(), DefaultContext);
+
+        Assert.StartsWith("WEBVTT", output);
+    }
+
+    // -----------------------------------------------------------------------
+    // JSON formatter
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void JsonFormatter_ProducesValidJson()
+    {
+        var formatter = new JsonTranscriptFormatter();
+        var output = formatter.Format(SampleSegments, DefaultContext);
+
+        // Should parse without error
+        var doc = JsonDocument.Parse(output);
+        Assert.NotNull(doc);
+    }
+
+    [Fact]
+    public void JsonFormatter_IncludesMetadata()
+    {
+        var formatter = new JsonTranscriptFormatter();
+        var output = formatter.Format(SampleSegments, DefaultContext);
+
+        using var doc = JsonDocument.Parse(output);
+        var root = doc.RootElement;
+
+        Assert.Equal("txt", root.GetProperty("format").GetString());
+        Assert.Equal("English (en)", root.GetProperty("detectedLanguage").GetString());
+        Assert.Equal(2, root.GetProperty("acceptedSegmentCount").GetInt32());
+        Assert.Equal(1, root.GetProperty("skippedSegmentCount").GetInt32());
+        Assert.Single(root.GetProperty("warnings").EnumerateArray());
+    }
+
+    [Fact]
+    public void JsonFormatter_IncludesSegments()
+    {
+        var formatter = new JsonTranscriptFormatter();
+        var output = formatter.Format(SampleSegments, DefaultContext);
+
+        using var doc = JsonDocument.Parse(output);
+        var segments = doc.RootElement.GetProperty("segments");
+
+        Assert.Equal(2, segments.GetArrayLength());
+        var first = segments[0];
+        Assert.Equal("00:00:01.200", first.GetProperty("start").GetString());
+        Assert.Equal("00:00:03.800", first.GetProperty("end").GetString());
+        Assert.Equal("Hello, this is a test.", first.GetProperty("text").GetString());
+    }
+
+    [Fact]
+    public void JsonFormatter_IncludesPlainTranscript()
+    {
+        var formatter = new JsonTranscriptFormatter();
+        var output = formatter.Format(SampleSegments, DefaultContext);
+
+        using var doc = JsonDocument.Parse(output);
+        var transcript = doc.RootElement.GetProperty("transcript").GetString();
+        Assert.Contains("Hello, this is a test.", transcript);
+        Assert.Contains("Second line here.", transcript);
+    }
+
+    // -----------------------------------------------------------------------
+    // MD formatter
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void MdFormatter_StartsWithTranscriptHeader()
+    {
+        var formatter = new MdTranscriptFormatter();
+        var output = formatter.Format(SampleSegments, DefaultContext);
+
+        Assert.StartsWith("# Transcript", output);
+    }
+
+    [Fact]
+    public void MdFormatter_IncludesMetadata()
+    {
+        var formatter = new MdTranscriptFormatter();
+        var output = formatter.Format(SampleSegments, DefaultContext);
+
+        Assert.Contains("**Language:** English (en)", output);
+        Assert.Contains("**Segments:** 2 accepted, 1 skipped", output);
+        Assert.Contains("**Warnings:** low quality", output);
+    }
+
+    [Fact]
+    public void MdFormatter_IncludesTimestampedEntries()
+    {
+        var formatter = new MdTranscriptFormatter();
+        var output = formatter.Format(SampleSegments, DefaultContext);
+
+        Assert.Contains("**[00:00:01]** Hello, this is a test.", output);
+        Assert.Contains("**[00:00:05]** Second line here.", output);
+    }
+
+    [Fact]
+    public void MdFormatter_IsReadableMarkdown()
+    {
+        var formatter = new MdTranscriptFormatter();
+        var output = formatter.Format(SampleSegments, DefaultContext);
+
+        // Should contain horizontal rule separator
+        Assert.Contains("---", output);
+        // Should not contain raw JSON
+        Assert.DoesNotContain("{", output);
+    }
+
+    // -----------------------------------------------------------------------
+    // TranscriptFormatterFactory
+    // -----------------------------------------------------------------------
+
+    [Theory]
+    [InlineData(ResultFormat.Txt)]
+    [InlineData(ResultFormat.Srt)]
+    [InlineData(ResultFormat.Vtt)]
+    [InlineData(ResultFormat.Json)]
+    [InlineData(ResultFormat.Md)]
+    public void Factory_ReturnsFormatterForAllFormats(ResultFormat format)
+    {
+        var formatter = TranscriptFormatterFactory.GetFormatter(format);
+        Assert.NotNull(formatter);
+
+        // Should produce non-null output
+        var output = formatter.Format(SampleSegments, new TranscriptOutputContext(format));
+        Assert.NotNull(output);
+        Assert.NotEmpty(output);
+    }
+}

--- a/tests/VoxFlow.Desktop.Tests/Infrastructure/UiTestInfrastructure.cs
+++ b/tests/VoxFlow.Desktop.Tests/Infrastructure/UiTestInfrastructure.cs
@@ -11,6 +11,7 @@ using VoxFlow.Core.Configuration;
 using VoxFlow.Core.DependencyInjection;
 using VoxFlow.Core.Interfaces;
 using VoxFlow.Core.Models;
+using VoxFlow.Desktop.Configuration;
 using VoxFlow.Desktop.Services;
 using VoxFlow.Desktop.ViewModels;
 
@@ -64,6 +65,7 @@ internal sealed class DesktopUiTestContext : IAsyncDisposable
         services.AddSingleton<IJSRuntime>(jsRuntime);
         services.AddSingleton(viewModel);
         services.AddSingleton<IResultActionService>(resultActionService);
+        services.AddSingleton<DesktopConfigurationService>();
 
         var renderer = new TestRenderer(services.BuildServiceProvider());
         return new DesktopUiTestContext(renderer, viewModel, jsRuntime, transcription, resultActionService);
@@ -84,6 +86,7 @@ internal sealed class DesktopUiTestContext : IAsyncDisposable
         services.AddSingleton<AppViewModel>();
         var resultActionService = new RecordingResultActionService();
         services.AddSingleton<IResultActionService>(resultActionService);
+        services.AddSingleton<DesktopConfigurationService>();
 
         var provider = services.BuildServiceProvider();
         var renderer = new TestRenderer(provider);


### PR DESCRIPTION
## Summary

This PR adds configurable transcript output formats across VoxFlow and introduces a new Settings section in the Desktop app for selecting the desired format without editing configuration files manually.

Supported output formats now include:

- `txt`
- `srt`
- `vtt`
- `json`
- `md`

`txt` remains the default to preserve backward compatibility with existing configs and workflows.

## What changed

- Added `resultFormat` configuration support in the shared transcription settings
- Implemented format-aware transcript output in `VoxFlow.Core`
- Added serializers/writers for `SRT`, `VTT`, `JSON`, and `Markdown`
- Kept the existing legacy `TXT` output behavior unchanged as the default
- Updated output path handling so generated files use the correct extension for the selected format
- Applied the same format selection logic to both single-file and batch workflows
- Added a Desktop Settings section that allows users to choose the transcript output format from the UI
- Wired the Desktop selection into the existing persistent configuration flow so the chosen format survives app restarts
- Ensured CLI, Desktop, and MCP all honor the selected output format through shared core behavior

## Backward compatibility

- Existing configurations continue to work without changes
- If `resultFormat` is not specified, VoxFlow defaults to `txt`
- The legacy text output format is preserved for compatibility with current consumers and existing output expectations

## Why

This expands VoxFlow from a single fixed transcript format into a more flexible output pipeline that better supports:

- subtitle workflows (`srt`, `vtt`)
- automation and integrations (`json`)
- human-readable documentation and notes (`md`)

It also removes a Desktop usability gap by making output format selection available directly in the app.

## Validation

- Added/updated tests for configuration parsing and validation
- Added formatter coverage for all supported output formats
- Verified default fallback to `txt`
- Covered extension handling for generated output paths
- Covered Desktop settings behavior and persistence where applicable

## Notes

This change is additive and keeps the external output contract backward-compatible while enabling new export scenarios across all product surfaces.