### PR TITLE
feat(core): add TranscriptDocument model and sidecar JSON schemas

### DIFF
--- a/docs/contracts/sidecar-diarization-v1.schema.json
+++ b/docs/contracts/sidecar-diarization-v1.schema.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://voxflow.app/schemas/sidecar-diarization-v1.schema.json",
+  "title": "VoxFlow Diarization Sidecar Contract v1",
+  "description": "JSON contract exchanged between VoxFlow Core and the Python diarization sidecar. Defines both the request envelope (Core -> sidecar stdin) and the response envelope (sidecar stdout -> Core). Time values are seconds (double).",
+  "oneOf": [
+    { "$ref": "#/definitions/request" },
+    { "$ref": "#/definitions/response" }
+  ],
+  "definitions": {
+    "request": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["version", "wavPath"],
+      "properties": {
+        "version": { "type": "integer", "const": 1 },
+        "wavPath": { "type": "string", "minLength": 1 }
+      }
+    },
+    "response": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["version", "status", "speakers", "segments"],
+      "properties": {
+        "version": { "type": "integer", "const": 1 },
+        "status": { "type": "string", "enum": ["ok", "error"] },
+        "error": { "type": "string" },
+        "speakers": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/speaker" }
+        },
+        "segments": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/segment" }
+        }
+      }
+    },
+    "speaker": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "totalDuration"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "totalDuration": { "type": "number", "minimum": 0 }
+      }
+    },
+    "segment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["speaker", "start", "end"],
+      "properties": {
+        "speaker": { "type": "string", "minLength": 1 },
+        "start": { "type": "number", "minimum": 0 },
+        "end": { "type": "number", "minimum": 0 }
+      }
+    }
+  }
+}

--- a/docs/contracts/voxflow-transcript-v1.schema.json
+++ b/docs/contracts/voxflow-transcript-v1.schema.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://voxflow.app/schemas/voxflow-transcript-v1.schema.json",
+  "title": "VoxFlow Transcript Document v1",
+  "description": "Speaker-aware transcript produced by VoxFlow's local speaker-labeling pipeline. This is the on-disk shape of .voxflow.json companion artifacts.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["speakers", "words", "turns", "metadata"],
+  "properties": {
+    "speakers": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/speakerInfo" }
+    },
+    "words": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/transcriptWord" }
+    },
+    "turns": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/speakerTurn" }
+    },
+    "metadata": { "$ref": "#/definitions/transcriptMetadata" }
+  },
+  "definitions": {
+    "duration": {
+      "type": "string",
+      "description": "ISO 8601 duration as emitted by System.Text.Json for TimeSpan (e.g. 'PT1M23.456S' or '00:00:01.5000000')."
+    },
+    "speakerInfo": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "displayName", "totalSpeechDuration"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "displayName": { "type": "string", "minLength": 1 },
+        "totalSpeechDuration": { "$ref": "#/definitions/duration" }
+      }
+    },
+    "transcriptWord": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["start", "end", "text", "speakerId"],
+      "properties": {
+        "start": { "$ref": "#/definitions/duration" },
+        "end": { "$ref": "#/definitions/duration" },
+        "text": { "type": "string" },
+        "speakerId": { "type": "string", "minLength": 1 }
+      }
+    },
+    "speakerTurn": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["speakerId", "startTime", "endTime", "words"],
+      "properties": {
+        "speakerId": { "type": "string", "minLength": 1 },
+        "startTime": { "$ref": "#/definitions/duration" },
+        "endTime": { "$ref": "#/definitions/duration" },
+        "words": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/transcriptWord" }
+        }
+      }
+    },
+    "transcriptMetadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["schemaVersion", "diarizationModel", "sidecarVersion"],
+      "properties": {
+        "schemaVersion": { "type": "integer", "const": 1 },
+        "diarizationModel": { "type": "string", "minLength": 1 },
+        "sidecarVersion": { "type": "integer", "minimum": 1 }
+      }
+    }
+  }
+}

--- a/src/VoxFlow.Core/Models/SpeakerInfo.cs
+++ b/src/VoxFlow.Core/Models/SpeakerInfo.cs
@@ -1,0 +1,9 @@
+namespace VoxFlow.Core.Models;
+
+/// <summary>
+/// Represents one speaker in a <see cref="TranscriptDocument"/>.
+/// </summary>
+public sealed record SpeakerInfo(
+    string Id,
+    string DisplayName,
+    TimeSpan TotalSpeechDuration);

--- a/src/VoxFlow.Core/Models/SpeakerTurn.cs
+++ b/src/VoxFlow.Core/Models/SpeakerTurn.cs
@@ -1,0 +1,53 @@
+namespace VoxFlow.Core.Models;
+
+/// <summary>
+/// A contiguous run of words spoken by one speaker. Derived from
+/// <see cref="TranscriptDocument.Words"/> by grouping consecutive
+/// same-speaker words.
+/// </summary>
+public sealed record SpeakerTurn(
+    string SpeakerId,
+    TimeSpan StartTime,
+    TimeSpan EndTime,
+    IReadOnlyList<TranscriptWord> Words)
+{
+    /// <summary>
+    /// Groups a chronologically-ordered word list into speaker turns by
+    /// collapsing consecutive words that share the same speaker.
+    /// </summary>
+    public static IReadOnlyList<SpeakerTurn> GroupConsecutive(IReadOnlyList<TranscriptWord> words)
+    {
+        ArgumentNullException.ThrowIfNull(words);
+
+        var turns = new List<SpeakerTurn>();
+        if (words.Count == 0)
+        {
+            return turns;
+        }
+
+        var currentSpeakerId = words[0].SpeakerId;
+        var currentStart = words[0].Start;
+        var currentEnd = words[0].End;
+        var currentWords = new List<TranscriptWord> { words[0] };
+
+        for (var i = 1; i < words.Count; i++)
+        {
+            var word = words[i];
+            if (word.SpeakerId == currentSpeakerId)
+            {
+                currentWords.Add(word);
+                currentEnd = word.End;
+                continue;
+            }
+
+            turns.Add(new SpeakerTurn(currentSpeakerId, currentStart, currentEnd, currentWords));
+            currentSpeakerId = word.SpeakerId;
+            currentStart = word.Start;
+            currentEnd = word.End;
+            currentWords = new List<TranscriptWord> { word };
+        }
+
+        turns.Add(new SpeakerTurn(currentSpeakerId, currentStart, currentEnd, currentWords));
+        return turns;
+    }
+}

--- a/src/VoxFlow.Core/Models/TranscriptDocument.cs
+++ b/src/VoxFlow.Core/Models/TranscriptDocument.cs
@@ -1,0 +1,21 @@
+using System.Text.Json;
+
+namespace VoxFlow.Core.Models;
+
+/// <summary>
+/// Speaker-aware transcript produced by the speaker-labeling pipeline.
+/// Top-level container with a speaker roster, per-word speaker references,
+/// and a derived list of speaker turns.
+/// </summary>
+public sealed record TranscriptDocument(
+    IReadOnlyList<SpeakerInfo> Speakers,
+    IReadOnlyList<TranscriptWord> Words,
+    IReadOnlyList<SpeakerTurn> Turns,
+    TranscriptMetadata Metadata)
+{
+    public static JsonSerializerOptions JsonSerializerOptions { get; } = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = false
+    };
+}

--- a/src/VoxFlow.Core/Models/TranscriptMetadata.cs
+++ b/src/VoxFlow.Core/Models/TranscriptMetadata.cs
@@ -1,0 +1,9 @@
+namespace VoxFlow.Core.Models;
+
+/// <summary>
+/// Provenance metadata for a <see cref="TranscriptDocument"/>.
+/// </summary>
+public sealed record TranscriptMetadata(
+    int SchemaVersion,
+    string DiarizationModel,
+    int SidecarVersion);

--- a/src/VoxFlow.Core/Models/TranscriptWord.cs
+++ b/src/VoxFlow.Core/Models/TranscriptWord.cs
@@ -1,0 +1,11 @@
+namespace VoxFlow.Core.Models;
+
+/// <summary>
+/// One word (or sub-word token) inside a <see cref="TranscriptDocument"/>,
+/// assigned to a speaker via <see cref="SpeakerId"/>.
+/// </summary>
+public sealed record TranscriptWord(
+    TimeSpan Start,
+    TimeSpan End,
+    string Text,
+    string SpeakerId);

--- a/tests/VoxFlow.Core.Tests/Models/SidecarContractTests.cs
+++ b/tests/VoxFlow.Core.Tests/Models/SidecarContractTests.cs
@@ -1,0 +1,87 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using NJsonSchema;
+using Xunit;
+
+namespace VoxFlow.Core.Tests.Models;
+
+public sealed class SidecarContractTests
+{
+    [Fact]
+    public async Task ValidResponse_ValidatesAgainstSchema()
+    {
+        var schema = await LoadSchemaAsync();
+
+        const string validResponse = """
+        {
+          "version": 1,
+          "status": "ok",
+          "speakers": [
+            { "id": "A", "totalDuration": 3.5 },
+            { "id": "B", "totalDuration": 2.0 }
+          ],
+          "segments": [
+            { "speaker": "A", "start": 0.0, "end": 3.5 },
+            { "speaker": "B", "start": 3.5, "end": 5.5 }
+          ]
+        }
+        """;
+
+        var errors = schema.Validate(validResponse);
+
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public async Task InvalidResponse_MissingVersion_FailsSchema()
+    {
+        var schema = await LoadSchemaAsync();
+
+        const string invalidResponse = """
+        {
+          "status": "ok",
+          "speakers": [
+            { "id": "A", "totalDuration": 3.5 }
+          ],
+          "segments": [
+            { "speaker": "A", "start": 0.0, "end": 3.5 }
+          ]
+        }
+        """;
+
+        var errors = schema.Validate(invalidResponse);
+
+        Assert.NotEmpty(errors);
+    }
+
+    [Fact]
+    public async Task ErrorResponse_WithErrorString_ValidatesAgainstSchema()
+    {
+        var schema = await LoadSchemaAsync();
+
+        const string errorResponse = """
+        {
+          "version": 1,
+          "status": "error",
+          "error": "failed to load model",
+          "speakers": [],
+          "segments": []
+        }
+        """;
+
+        var errors = schema.Validate(errorResponse);
+
+        Assert.Empty(errors);
+    }
+
+    private static async Task<JsonSchema> LoadSchemaAsync()
+    {
+        var schemaPath = Path.Combine(
+            AppContext.BaseDirectory,
+            "contracts",
+            "sidecar-diarization-v1.schema.json");
+        Assert.True(File.Exists(schemaPath), $"Schema not found at {schemaPath}");
+        return await JsonSchema.FromFileAsync(schemaPath);
+    }
+}

--- a/tests/VoxFlow.Core.Tests/Models/SpeakerTurnTests.cs
+++ b/tests/VoxFlow.Core.Tests/Models/SpeakerTurnTests.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using VoxFlow.Core.Models;
+using Xunit;
+
+namespace VoxFlow.Core.Tests.Models;
+
+public sealed class SpeakerTurnTests
+{
+    [Fact]
+    public void GroupConsecutive_TwoSpeakers_ProducesTwoTurns()
+    {
+        var words = new[]
+        {
+            Word(0, 1, "Hello", "A"),
+            Word(1, 2, "there", "A"),
+            Word(2, 3, "friend", "A"),
+            Word(3, 4, "Hi", "B"),
+            Word(4, 5, "to", "B"),
+            Word(5, 6, "you", "B")
+        };
+
+        var turns = SpeakerTurn.GroupConsecutive(words);
+
+        Assert.Equal(2, turns.Count);
+        Assert.Equal("A", turns[0].SpeakerId);
+        Assert.Equal(TimeSpan.FromSeconds(0), turns[0].StartTime);
+        Assert.Equal(TimeSpan.FromSeconds(3), turns[0].EndTime);
+        Assert.Equal(3, turns[0].Words.Count);
+        Assert.Equal("B", turns[1].SpeakerId);
+        Assert.Equal(TimeSpan.FromSeconds(3), turns[1].StartTime);
+        Assert.Equal(TimeSpan.FromSeconds(6), turns[1].EndTime);
+        Assert.Equal(3, turns[1].Words.Count);
+    }
+
+    [Fact]
+    public void GroupConsecutive_AlternatingSpeakers_ProducesOneTurnPerWord()
+    {
+        var words = new[]
+        {
+            Word(0, 1, "one", "A"),
+            Word(1, 2, "two", "B"),
+            Word(2, 3, "three", "A"),
+            Word(3, 4, "four", "B"),
+            Word(4, 5, "five", "A"),
+            Word(5, 6, "six", "B")
+        };
+
+        var turns = SpeakerTurn.GroupConsecutive(words);
+
+        Assert.Equal(6, turns.Count);
+        for (var i = 0; i < turns.Count; i++)
+        {
+            var expectedSpeaker = i % 2 == 0 ? "A" : "B";
+            Assert.Equal(expectedSpeaker, turns[i].SpeakerId);
+            Assert.Single(turns[i].Words);
+            Assert.Equal(TimeSpan.FromSeconds(i), turns[i].StartTime);
+            Assert.Equal(TimeSpan.FromSeconds(i + 1), turns[i].EndTime);
+        }
+    }
+
+    [Fact]
+    public void GroupConsecutive_SingleSpeaker_ProducesOneTurn()
+    {
+        var words = new[]
+        {
+            Word(0, 1, "just", "A"),
+            Word(1, 2, "one", "A"),
+            Word(2, 3, "speaker", "A")
+        };
+
+        var turns = SpeakerTurn.GroupConsecutive(words);
+
+        var only = Assert.Single(turns);
+        Assert.Equal("A", only.SpeakerId);
+        Assert.Equal(TimeSpan.FromSeconds(0), only.StartTime);
+        Assert.Equal(TimeSpan.FromSeconds(3), only.EndTime);
+        Assert.Equal(3, only.Words.Count);
+    }
+
+    [Fact]
+    public void GroupConsecutive_EmptyInput_ProducesEmptyList()
+    {
+        var turns = SpeakerTurn.GroupConsecutive(Array.Empty<TranscriptWord>());
+
+        Assert.Empty(turns);
+    }
+
+    private static TranscriptWord Word(double startSec, double endSec, string text, string speakerId)
+    {
+        return new TranscriptWord(
+            TimeSpan.FromSeconds(startSec),
+            TimeSpan.FromSeconds(endSec),
+            text,
+            speakerId);
+    }
+}

--- a/tests/VoxFlow.Core.Tests/Models/TranscriptDocumentTests.cs
+++ b/tests/VoxFlow.Core.Tests/Models/TranscriptDocumentTests.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using NJsonSchema;
+using VoxFlow.Core.Models;
+using Xunit;
+
+namespace VoxFlow.Core.Tests.Models;
+
+public sealed class TranscriptDocumentTests
+{
+    [Fact]
+    public void Construct_WithSpeakersAndWords_ExposesAllFields()
+    {
+        var speakers = new[]
+        {
+            new SpeakerInfo("A", "Speaker A", TimeSpan.FromSeconds(3)),
+            new SpeakerInfo("B", "Speaker B", TimeSpan.FromSeconds(2))
+        };
+
+        var words = new[]
+        {
+            new TranscriptWord(TimeSpan.FromSeconds(0), TimeSpan.FromSeconds(1), "Hello", "A"),
+            new TranscriptWord(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2), "world", "A"),
+            new TranscriptWord(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3), "good", "A"),
+            new TranscriptWord(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(4), "morning", "B")
+        };
+
+        var turns = new[]
+        {
+            new SpeakerTurn(
+                "A",
+                TimeSpan.FromSeconds(0),
+                TimeSpan.FromSeconds(3),
+                new[] { words[0], words[1], words[2] }),
+            new SpeakerTurn(
+                "B",
+                TimeSpan.FromSeconds(3),
+                TimeSpan.FromSeconds(4),
+                new[] { words[3] })
+        };
+
+        var metadata = new TranscriptMetadata(
+            SchemaVersion: 1,
+            DiarizationModel: "pyannote/speaker-diarization-community-1",
+            SidecarVersion: 1);
+
+        var document = new TranscriptDocument(speakers, words, turns, metadata);
+
+        Assert.NotNull(document.Speakers);
+        Assert.Equal(2, document.Speakers.Count);
+        Assert.Equal("A", document.Speakers[0].Id);
+        Assert.Equal("Speaker A", document.Speakers[0].DisplayName);
+        Assert.Equal(TimeSpan.FromSeconds(3), document.Speakers[0].TotalSpeechDuration);
+
+        Assert.NotNull(document.Words);
+        Assert.Equal(4, document.Words.Count);
+        Assert.Equal("Hello", document.Words[0].Text);
+        Assert.Equal(TimeSpan.FromSeconds(0), document.Words[0].Start);
+        Assert.Equal(TimeSpan.FromSeconds(1), document.Words[0].End);
+        Assert.Equal("A", document.Words[0].SpeakerId);
+        Assert.Equal("B", document.Words[3].SpeakerId);
+
+        Assert.NotNull(document.Turns);
+        Assert.Equal(2, document.Turns.Count);
+        Assert.Equal("A", document.Turns[0].SpeakerId);
+        Assert.Equal(TimeSpan.FromSeconds(0), document.Turns[0].StartTime);
+        Assert.Equal(TimeSpan.FromSeconds(3), document.Turns[0].EndTime);
+        Assert.Equal(3, document.Turns[0].Words.Count);
+
+        Assert.NotNull(document.Metadata);
+        Assert.Equal(1, document.Metadata.SchemaVersion);
+        Assert.Equal("pyannote/speaker-diarization-community-1", document.Metadata.DiarizationModel);
+        Assert.Equal(1, document.Metadata.SidecarVersion);
+    }
+
+    [Fact]
+    public void Serialize_RoundTrip_ProducesEqualDocument()
+    {
+        var original = BuildSampleDocument();
+        var options = TranscriptDocument.JsonSerializerOptions;
+
+        var json = JsonSerializer.Serialize(original, options);
+        var roundTripped = JsonSerializer.Deserialize<TranscriptDocument>(json, options);
+
+        Assert.NotNull(roundTripped);
+
+        // Structural equality: re-serializing the round-tripped document must
+        // produce byte-identical JSON. This catches naming/attribute issues
+        // without relying on record equality (which compares collection
+        // references, not contents).
+        var reserialized = JsonSerializer.Serialize(roundTripped, options);
+        Assert.Equal(json, reserialized);
+
+        Assert.Equal(original.Speakers.Count, roundTripped!.Speakers.Count);
+        Assert.Equal(original.Words.Count, roundTripped.Words.Count);
+        Assert.Equal(original.Turns.Count, roundTripped.Turns.Count);
+        Assert.Equal(original.Words[0].Text, roundTripped.Words[0].Text);
+        Assert.Equal(original.Words[0].Start, roundTripped.Words[0].Start);
+        Assert.Equal(original.Words[0].End, roundTripped.Words[0].End);
+        Assert.Equal(original.Words[0].SpeakerId, roundTripped.Words[0].SpeakerId);
+        Assert.Equal(original.Metadata.DiarizationModel, roundTripped.Metadata.DiarizationModel);
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task ValidatesAgainstVoxflowTranscriptSchema()
+    {
+        var schemaPath = Path.Combine(AppContext.BaseDirectory, "contracts", "voxflow-transcript-v1.schema.json");
+        Assert.True(File.Exists(schemaPath), $"Schema not found at {schemaPath}");
+
+        var schema = await JsonSchema.FromFileAsync(schemaPath);
+        var document = BuildSampleDocument();
+        var json = JsonSerializer.Serialize(document, TranscriptDocument.JsonSerializerOptions);
+
+        var errors = schema.Validate(json);
+
+        Assert.Empty(errors);
+    }
+
+    private static TranscriptDocument BuildSampleDocument()
+    {
+        var speakers = new[]
+        {
+            new SpeakerInfo("A", "Speaker A", TimeSpan.FromSeconds(3)),
+            new SpeakerInfo("B", "Speaker B", TimeSpan.FromSeconds(1))
+        };
+
+        var words = new[]
+        {
+            new TranscriptWord(TimeSpan.FromSeconds(0), TimeSpan.FromSeconds(1), "Hello", "A"),
+            new TranscriptWord(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2), "world", "A"),
+            new TranscriptWord(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3), "good", "A"),
+            new TranscriptWord(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(4), "morning", "B")
+        };
+
+        var turns = new[]
+        {
+            new SpeakerTurn("A", TimeSpan.FromSeconds(0), TimeSpan.FromSeconds(3), new[] { words[0], words[1], words[2] }),
+            new SpeakerTurn("B", TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(4), new[] { words[3] })
+        };
+
+        var metadata = new TranscriptMetadata(
+            SchemaVersion: 1,
+            DiarizationModel: "pyannote/speaker-diarization-community-1",
+            SidecarVersion: 1);
+
+        return new TranscriptDocument(speakers, words, turns, metadata);
+    }
+}

--- a/tests/VoxFlow.Core.Tests/VoxFlow.Core.Tests.csproj
+++ b/tests/VoxFlow.Core.Tests/VoxFlow.Core.Tests.csproj
@@ -15,6 +15,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
+    <PackageReference Include="NJsonSchema" Version="11.1.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -30,5 +31,9 @@
 
   <ItemGroup>
     <Compile Include="..\TestSupport\*.cs" Link="TestSupport\%(Filename)%(Extension)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\docs\contracts\*.json" Link="contracts\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Add TranscriptDocument model + sidecar JSON schemas

Speaker-aware transcript model for ADR-024 Phase 0. Pure additions:
no existing types touched, nothing wired in yet. Model plus two
versioned JSON Schema files for the sidecar contract and the
.voxflow.json artifact. Round-trip and schema-validation unit tests.

## What's in this PR

- `TranscriptDocument`, `SpeakerInfo`, `TranscriptWord`, `SpeakerTurn`,
  `TranscriptMetadata` as `sealed record` types in `VoxFlow.Core.Models`.
- `SpeakerTurn.GroupConsecutive` pure static helper (consumed by merge
  service in a later PR).
- `docs/contracts/voxflow-transcript-v1.schema.json` — on-disk shape of
  `.voxflow.json` companion artifacts.
- `docs/contracts/sidecar-diarization-v1.schema.json` — request/response
  envelopes for the Python diarization sidecar.
- `NJsonSchema 11.1.0` added to `VoxFlow.Core.Tests` and schema files
  copied to the test output under `contracts/` for validation tests.

## Tests

New:
- `Models/TranscriptDocumentTests` — construction, round-trip JSON,
  schema validation.
- `Models/SpeakerTurnTests` — GroupConsecutive: two speakers,
  alternating, single speaker, empty input.
- `Models/SidecarContractTests` — valid response, error response,
  missing-version failure.

## Test plan

- [x] `dotnet test VoxFlow.sln` — full solution green locally
      (194 Core, 35 McpServer, 6 Cli, 70 Desktop + 2 skipped).
