### PR TITLE
feat(core): add IPythonRuntime abstraction and SystemPythonRuntime

### DIFF
--- a/src/VoxFlow.Core/Interfaces/IProcessLauncher.cs
+++ b/src/VoxFlow.Core/Interfaces/IProcessLauncher.cs
@@ -1,0 +1,14 @@
+using System.Diagnostics;
+using VoxFlow.Core.Services.Python;
+
+namespace VoxFlow.Core.Interfaces;
+
+/// <summary>
+/// Thin abstraction over <see cref="System.Diagnostics.Process"/> that launches
+/// a child process, waits for it to exit, and returns captured stdout/stderr.
+/// Injected so tests can fake Python without spawning real interpreters.
+/// </summary>
+public interface IProcessLauncher
+{
+    Task<ProcessExecutionResult> RunAsync(ProcessStartInfo startInfo, CancellationToken cancellationToken);
+}

--- a/src/VoxFlow.Core/Interfaces/IPythonRuntime.cs
+++ b/src/VoxFlow.Core/Interfaces/IPythonRuntime.cs
@@ -1,0 +1,17 @@
+using System.Diagnostics;
+using VoxFlow.Core.Services.Python;
+
+namespace VoxFlow.Core.Interfaces;
+
+/// <summary>
+/// Abstracts how VoxFlow discovers and launches a Python interpreter for the
+/// diarization sidecar. Implementations include <c>SystemPythonRuntime</c>
+/// (resolves <c>python3</c> from PATH) and <c>ManagedVenvRuntime</c> (uses an
+/// app-managed virtual environment).
+/// </summary>
+public interface IPythonRuntime
+{
+    Task<PythonRuntimeStatus> GetStatusAsync(CancellationToken cancellationToken);
+
+    ProcessStartInfo CreateStartInfo(string scriptPath, IEnumerable<string> arguments);
+}

--- a/src/VoxFlow.Core/Services/Python/DefaultProcessLauncher.cs
+++ b/src/VoxFlow.Core/Services/Python/DefaultProcessLauncher.cs
@@ -1,0 +1,51 @@
+using System.Diagnostics;
+using VoxFlow.Core.Interfaces;
+
+namespace VoxFlow.Core.Services.Python;
+
+/// <summary>
+/// Production <see cref="IProcessLauncher"/> implementation backed by
+/// <see cref="System.Diagnostics.Process"/>. Launches the requested child
+/// process, captures stdout and stderr to memory, and returns once the
+/// process exits. Cancellation kills the child process.
+/// </summary>
+public sealed class DefaultProcessLauncher : IProcessLauncher
+{
+    public async Task<ProcessExecutionResult> RunAsync(ProcessStartInfo startInfo, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(startInfo);
+
+        startInfo.RedirectStandardOutput = true;
+        startInfo.RedirectStandardError = true;
+        startInfo.UseShellExecute = false;
+        startInfo.CreateNoWindow = true;
+
+        using var process = new Process { StartInfo = startInfo };
+        process.Start();
+
+        using var registration = cancellationToken.Register(() =>
+        {
+            try
+            {
+                if (!process.HasExited)
+                {
+                    process.Kill(entireProcessTree: true);
+                }
+            }
+            catch
+            {
+                // Process may have exited between HasExited check and Kill; swallow.
+            }
+        });
+
+        var stdOutTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
+        var stdErrTask = process.StandardError.ReadToEndAsync(cancellationToken);
+
+        await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+
+        var stdOut = await stdOutTask.ConfigureAwait(false);
+        var stdErr = await stdErrTask.ConfigureAwait(false);
+
+        return new ProcessExecutionResult(process.ExitCode, stdOut, stdErr);
+    }
+}

--- a/src/VoxFlow.Core/Services/Python/ProcessExecutionResult.cs
+++ b/src/VoxFlow.Core/Services/Python/ProcessExecutionResult.cs
@@ -1,0 +1,6 @@
+namespace VoxFlow.Core.Services.Python;
+
+/// <summary>
+/// Result of running a child process: exit code plus captured stdout/stderr.
+/// </summary>
+public sealed record ProcessExecutionResult(int ExitCode, string StdOut, string StdErr);

--- a/src/VoxFlow.Core/Services/Python/PythonRuntimeStatus.cs
+++ b/src/VoxFlow.Core/Services/Python/PythonRuntimeStatus.cs
@@ -1,0 +1,19 @@
+namespace VoxFlow.Core.Services.Python;
+
+/// <summary>
+/// Outcome of probing an <see cref="IPythonRuntime"/>. A ready status has a
+/// non-null <see cref="InterpreterPath"/> and <see cref="Version"/>; a
+/// not-ready status has a non-null <see cref="Error"/> explaining why.
+/// </summary>
+public sealed record PythonRuntimeStatus(
+    bool IsReady,
+    string? InterpreterPath,
+    string? Version,
+    string? Error)
+{
+    public static PythonRuntimeStatus Ready(string interpreterPath, string version)
+        => new(IsReady: true, interpreterPath, version, Error: null);
+
+    public static PythonRuntimeStatus NotReady(string error)
+        => new(IsReady: false, InterpreterPath: null, Version: null, error);
+}

--- a/src/VoxFlow.Core/Services/Python/SystemPythonRuntime.cs
+++ b/src/VoxFlow.Core/Services/Python/SystemPythonRuntime.cs
@@ -1,0 +1,102 @@
+using System.Diagnostics;
+using VoxFlow.Core.Interfaces;
+
+namespace VoxFlow.Core.Services.Python;
+
+/// <summary>
+/// Resolves the <c>python3</c> interpreter from <c>PATH</c>. Dev/CI escape
+/// hatch for local speaker labeling — production builds use
+/// <c>ManagedVenvRuntime</c>. Verifies the interpreter exists and meets the
+/// 3.10 minimum by shelling out to <c>python3 --version</c>.
+/// </summary>
+public sealed class SystemPythonRuntime : IPythonRuntime
+{
+    private const string InterpreterFileName = "python3";
+    private static readonly Version MinimumVersion = new(3, 10);
+
+    private readonly IProcessLauncher _launcher;
+
+    public SystemPythonRuntime(IProcessLauncher launcher)
+    {
+        ArgumentNullException.ThrowIfNull(launcher);
+        _launcher = launcher;
+    }
+
+    public async Task<PythonRuntimeStatus> GetStatusAsync(CancellationToken cancellationToken)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = InterpreterFileName,
+            RedirectStandardInput = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+        startInfo.ArgumentList.Add("--version");
+
+        ProcessExecutionResult result;
+        try
+        {
+            result = await _launcher.RunAsync(startInfo, cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            return PythonRuntimeStatus.NotReady($"python3 not found in PATH: {ex.Message}");
+        }
+
+        var combined = string.IsNullOrWhiteSpace(result.StdOut) ? result.StdErr : result.StdOut;
+        var versionString = ParseVersionString(combined);
+        if (versionString is null)
+        {
+            return PythonRuntimeStatus.NotReady($"Could not parse Python version from '{combined.Trim()}'.");
+        }
+
+        if (!Version.TryParse(versionString, out var parsed) || parsed < MinimumVersion)
+        {
+            return PythonRuntimeStatus.NotReady(
+                $"Python {versionString} is below the required minimum of {MinimumVersion}.");
+        }
+
+        return PythonRuntimeStatus.Ready(InterpreterFileName, versionString);
+    }
+
+    private static string? ParseVersionString(string raw)
+    {
+        var trimmed = raw.Trim();
+        const string prefix = "Python ";
+        if (!trimmed.StartsWith(prefix, StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        return trimmed[prefix.Length..].Trim();
+    }
+
+    public ProcessStartInfo CreateStartInfo(string scriptPath, IEnumerable<string> arguments)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(scriptPath);
+        ArgumentNullException.ThrowIfNull(arguments);
+
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = InterpreterFileName,
+            RedirectStandardInput = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+        startInfo.ArgumentList.Add(scriptPath);
+        foreach (var arg in arguments)
+        {
+            startInfo.ArgumentList.Add(arg);
+        }
+
+        return startInfo;
+    }
+}

--- a/tests/VoxFlow.Core.Tests/Services/Python/FakeProcessLauncher.cs
+++ b/tests/VoxFlow.Core.Tests/Services/Python/FakeProcessLauncher.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using VoxFlow.Core.Interfaces;
+using VoxFlow.Core.Services.Python;
+
+namespace VoxFlow.Core.Tests.Services.Python;
+
+/// <summary>
+/// Test double for <see cref="IProcessLauncher"/>. Canned responses are keyed by
+/// the requested <see cref="ProcessStartInfo.FileName"/>; tests can also throw
+/// from a scripted hook or simulate a never-returning process via cancellation.
+/// </summary>
+internal sealed class FakeProcessLauncher : IProcessLauncher
+{
+    private readonly Dictionary<string, Func<ProcessStartInfo, CancellationToken, Task<ProcessExecutionResult>>> _handlers = new();
+    public List<ProcessStartInfo> Invocations { get; } = new();
+
+    public void SetResponse(string fileName, int exitCode, string stdOut, string stdErr = "")
+    {
+        _handlers[fileName] = (_, _) => Task.FromResult(new ProcessExecutionResult(exitCode, stdOut, stdErr));
+    }
+
+    public void SetThrow(string fileName, Exception ex)
+    {
+        _handlers[fileName] = (_, _) => throw ex;
+    }
+
+    public void SetNeverReturns(string fileName)
+    {
+        _handlers[fileName] = async (_, ct) =>
+        {
+            await Task.Delay(Timeout.Infinite, ct).ConfigureAwait(false);
+            throw new InvalidOperationException("unreachable");
+        };
+    }
+
+    public Task<ProcessExecutionResult> RunAsync(ProcessStartInfo startInfo, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(startInfo);
+        Invocations.Add(startInfo);
+        if (!_handlers.TryGetValue(startInfo.FileName, out var handler))
+        {
+            throw new InvalidOperationException($"No fake response configured for '{startInfo.FileName}'.");
+        }
+
+        return handler(startInfo, cancellationToken);
+    }
+}

--- a/tests/VoxFlow.Core.Tests/Services/Python/SystemPythonRuntimeTests.cs
+++ b/tests/VoxFlow.Core.Tests/Services/Python/SystemPythonRuntimeTests.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using VoxFlow.Core.Services.Python;
+using Xunit;
+
+namespace VoxFlow.Core.Tests.Services.Python;
+
+public sealed class SystemPythonRuntimeTests
+{
+    [Fact]
+    public async Task GetStatus_PythonInPath_ReturnsReady()
+    {
+        var launcher = new FakeProcessLauncher();
+        launcher.SetResponse("python3", exitCode: 0, stdOut: "Python 3.11.5\n");
+
+        var runtime = new SystemPythonRuntime(launcher);
+
+        var status = await runtime.GetStatusAsync(CancellationToken.None);
+
+        Assert.True(status.IsReady);
+        Assert.Equal("3.11.5", status.Version);
+        Assert.Equal("python3", status.InterpreterPath);
+        Assert.Null(status.Error);
+    }
+
+    [Fact]
+    public async Task GetStatus_PythonNotFound_ReturnsNotReady()
+    {
+        var launcher = new FakeProcessLauncher();
+        launcher.SetThrow("python3", new System.ComponentModel.Win32Exception("command not found"));
+
+        var runtime = new SystemPythonRuntime(launcher);
+
+        var status = await runtime.GetStatusAsync(CancellationToken.None);
+
+        Assert.False(status.IsReady);
+        Assert.NotNull(status.Error);
+        Assert.Null(status.InterpreterPath);
+        Assert.Null(status.Version);
+    }
+
+    [Fact]
+    public async Task GetStatus_PythonTooOld_ReturnsNotReady()
+    {
+        var launcher = new FakeProcessLauncher();
+        launcher.SetResponse("python3", exitCode: 0, stdOut: "Python 3.8.10\n");
+
+        var runtime = new SystemPythonRuntime(launcher);
+
+        var status = await runtime.GetStatusAsync(CancellationToken.None);
+
+        Assert.False(status.IsReady);
+        Assert.NotNull(status.Error);
+        Assert.Contains("3.10", status.Error);
+    }
+
+    [Fact]
+    public void CreateStartInfo_ValidInputs_ProducesRunnableProcessInfo()
+    {
+        var runtime = new SystemPythonRuntime(new FakeProcessLauncher());
+
+        var psi = runtime.CreateStartInfo("/tmp/voxflow_diarize.py", new[] { "--input", "file.wav" });
+
+        Assert.Equal("python3", psi.FileName);
+        Assert.True(psi.RedirectStandardInput);
+        Assert.True(psi.RedirectStandardOutput);
+        Assert.True(psi.RedirectStandardError);
+        Assert.False(psi.UseShellExecute);
+        Assert.Contains("/tmp/voxflow_diarize.py", psi.ArgumentList.ToList());
+        Assert.Contains("--input", psi.ArgumentList.ToList());
+        Assert.Contains("file.wav", psi.ArgumentList.ToList());
+    }
+
+    [Fact]
+    public async Task GetStatus_Cancelled_ThrowsOperationCanceled()
+    {
+        var launcher = new FakeProcessLauncher();
+        launcher.SetNeverReturns("python3");
+
+        var runtime = new SystemPythonRuntime(launcher);
+        using var cts = new CancellationTokenSource();
+
+        var task = runtime.GetStatusAsync(cts.Token);
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => task);
+    }
+}


### PR DESCRIPTION
Add IPythonRuntime abstraction and SystemPythonRuntime

First piece of the speaker-labeling Python sidecar plumbing (ADR-024
Phase 0). `IPythonRuntime` decouples the .NET side from the packaging
strategy — `ManagedVenvRuntime` will plug in later at P0.4.
`SystemPythonRuntime` is the dev/CI escape hatch: resolves `python3`
from `PATH`, validates `>= 3.10`, returns a usable `ProcessStartInfo`.

## What's in this PR

- `IPythonRuntime` (`GetStatusAsync`, `CreateStartInfo`) and
  `IProcessLauncher` (thin injectable `Process` wrapper).
- `SystemPythonRuntime` — `python3 --version` probe, version parsing,
  `>= 3.10` gate, error-tolerant to `command not found`, cancellation
  propagates as `OperationCanceledException`.
- `PythonRuntimeStatus` result record with `Ready` / `NotReady` factories.
- `ProcessExecutionResult` record for launcher output.
- `DefaultProcessLauncher` — production `Process` wrapper that captures
  stdout/stderr and kills the child on cancellation. Not exercised in
  these tests (unit tests use the fake), but wired for later PRs.
- `FakeProcessLauncher` test double with canned responses, thrown
  exceptions, and never-returns-until-cancel behavior.

## Tests

New in `Services/Python/SystemPythonRuntimeTests`:

- `GetStatus_PythonInPath_ReturnsReady`
- `GetStatus_PythonNotFound_ReturnsNotReady`
- `GetStatus_PythonTooOld_ReturnsNotReady`
- `CreateStartInfo_ValidInputs_ProducesRunnableProcessInfo`
- `GetStatus_Cancelled_ThrowsOperationCanceled`

No `RequiresPython` tests yet — fully mocked.

## Test plan

- [x] `dotnet test VoxFlow.sln` — full suite green locally
      (199 Core, 35 McpServer, 6 Cli, 70 Desktop + 2 skipped).
