### PR TITLE
feat(core): add ManagedVenvRuntime for speaker-labeling sidecar

### DIFF
--- a/src/VoxFlow.Core/Resources/python-requirements.txt
+++ b/src/VoxFlow.Core/Resources/python-requirements.txt
@@ -1,0 +1,7 @@
+# VoxFlow local speaker-labeling sidecar dependencies (ADR-024 Phase 1).
+# Pinned versions — update deliberately and re-verify against voxflow_diarize.py.
+# Torch wheels are resolved from PyPI defaults; override via pip --extra-index-url
+# if a CUDA/ROCm build is required at runtime.
+pyannote.audio==3.3.2
+torch==2.4.0
+torchaudio==2.4.0

--- a/src/VoxFlow.Core/Services/Python/DefaultVenvPaths.cs
+++ b/src/VoxFlow.Core/Services/Python/DefaultVenvPaths.cs
@@ -1,0 +1,30 @@
+namespace VoxFlow.Core.Services.Python;
+
+/// <summary>
+/// Production <see cref="IVenvPaths"/> implementation. Roots the managed
+/// virtual environment under the OS application-support directory
+/// (<c>~/Library/Application Support/VoxFlow/python-runtime/</c> on macOS;
+/// <c>%AppData%\VoxFlow\python-runtime\</c> on Windows) and points
+/// <see cref="RequirementsFilePath"/> at the embedded requirements file.
+/// </summary>
+public sealed class DefaultVenvPaths : IVenvPaths
+{
+    public DefaultVenvPaths()
+    {
+        var appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+        Root = Path.Combine(appData, "VoxFlow", "python-runtime");
+        RequirementsFilePath = Path.Combine(Root, "requirements.txt");
+    }
+
+    public string Root { get; }
+
+    public string InterpreterPath => OperatingSystem.IsWindows()
+        ? Path.Combine(Root, "Scripts", "python.exe")
+        : Path.Combine(Root, "bin", "python3");
+
+    public string PipPath => OperatingSystem.IsWindows()
+        ? Path.Combine(Root, "Scripts", "pip.exe")
+        : Path.Combine(Root, "bin", "pip");
+
+    public string RequirementsFilePath { get; }
+}

--- a/src/VoxFlow.Core/Services/Python/IVenvPaths.cs
+++ b/src/VoxFlow.Core/Services/Python/IVenvPaths.cs
@@ -1,0 +1,14 @@
+namespace VoxFlow.Core.Services.Python;
+
+/// <summary>
+/// Abstraction over the on-disk layout of a managed Python virtual environment.
+/// Injected so tests can point at a temp directory instead of the real
+/// app-support location.
+/// </summary>
+public interface IVenvPaths
+{
+    string Root { get; }
+    string InterpreterPath { get; }
+    string PipPath { get; }
+    string RequirementsFilePath { get; }
+}

--- a/src/VoxFlow.Core/Services/Python/ManagedVenvRuntime.cs
+++ b/src/VoxFlow.Core/Services/Python/ManagedVenvRuntime.cs
@@ -1,0 +1,128 @@
+using System.Diagnostics;
+using VoxFlow.Core.Interfaces;
+
+namespace VoxFlow.Core.Services.Python;
+
+/// <summary>
+/// Default <see cref="IPythonRuntime"/> for Phase 1+: bootstraps a managed
+/// virtual environment under an app-support directory, installs pinned
+/// pyannote dependencies, and serves the venv interpreter to the sidecar
+/// client. Bootstrap is explicit via <see cref="CreateVenvAsync"/>;
+/// <see cref="GetStatusAsync"/> never spawns a process.
+/// </summary>
+public sealed class ManagedVenvRuntime : IPythonRuntime
+{
+    private readonly IProcessLauncher _launcher;
+    private readonly IVenvPaths _paths;
+
+    public ManagedVenvRuntime(IProcessLauncher launcher, IVenvPaths paths)
+    {
+        ArgumentNullException.ThrowIfNull(launcher);
+        ArgumentNullException.ThrowIfNull(paths);
+        _launcher = launcher;
+        _paths = paths;
+    }
+
+    public Task<PythonRuntimeStatus> GetStatusAsync(CancellationToken cancellationToken)
+    {
+        if (File.Exists(_paths.InterpreterPath))
+        {
+            return Task.FromResult(PythonRuntimeStatus.Ready(_paths.InterpreterPath, version: "managed"));
+        }
+
+        return Task.FromResult(PythonRuntimeStatus.NotReady(
+            $"Managed venv not yet created at '{_paths.Root}'. Call CreateVenvAsync to bootstrap."));
+    }
+
+    public ProcessStartInfo CreateStartInfo(string scriptPath, IEnumerable<string> arguments)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(scriptPath);
+        ArgumentNullException.ThrowIfNull(arguments);
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = _paths.InterpreterPath,
+            RedirectStandardInput = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+        psi.ArgumentList.Add(scriptPath);
+        foreach (var arg in arguments)
+        {
+            psi.ArgumentList.Add(arg);
+        }
+        return psi;
+    }
+
+    public async Task CreateVenvAsync(IProgress<VenvBootstrapStage>? progress, CancellationToken cancellationToken)
+    {
+        try
+        {
+            progress?.Report(VenvBootstrapStage.CreatingVenv);
+            var createVenv = BuildStartInfo("python3", ["-m", "venv", _paths.Root]);
+            var venvResult = await _launcher.RunAsync(createVenv, cancellationToken).ConfigureAwait(false);
+            if (venvResult.ExitCode != 0)
+            {
+                throw new InvalidOperationException(
+                    $"python3 -m venv failed with exit code {venvResult.ExitCode}: {venvResult.StdErr}");
+            }
+
+            progress?.Report(VenvBootstrapStage.InstallingRequirements);
+            var pipInstall = BuildStartInfo(_paths.PipPath, ["install", "-r", _paths.RequirementsFilePath]);
+            var pipResult = await _launcher.RunAsync(pipInstall, cancellationToken).ConfigureAwait(false);
+            if (pipResult.ExitCode != 0)
+            {
+                throw new InvalidOperationException(
+                    $"pip install failed with exit code {pipResult.ExitCode}: {pipResult.StdErr}");
+            }
+
+            progress?.Report(VenvBootstrapStage.Verifying);
+            if (!File.Exists(_paths.InterpreterPath))
+            {
+                throw new InvalidOperationException(
+                    $"venv verification failed: interpreter not found at '{_paths.InterpreterPath}'.");
+            }
+
+            progress?.Report(VenvBootstrapStage.Complete);
+        }
+        catch
+        {
+            TryDeleteVenv();
+            throw;
+        }
+    }
+
+    private void TryDeleteVenv()
+    {
+        try
+        {
+            if (Directory.Exists(_paths.Root))
+            {
+                Directory.Delete(_paths.Root, recursive: true);
+            }
+        }
+        catch
+        {
+            // best-effort cleanup; tests assert directory absence, real runs may race.
+        }
+    }
+
+    private static ProcessStartInfo BuildStartInfo(string fileName, IEnumerable<string> arguments)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = fileName,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+        foreach (var arg in arguments)
+        {
+            psi.ArgumentList.Add(arg);
+        }
+        return psi;
+    }
+}

--- a/src/VoxFlow.Core/Services/Python/VenvBootstrapStage.cs
+++ b/src/VoxFlow.Core/Services/Python/VenvBootstrapStage.cs
@@ -1,0 +1,12 @@
+namespace VoxFlow.Core.Services.Python;
+
+/// <summary>
+/// Progress checkpoints emitted during <see cref="ManagedVenvRuntime.CreateVenvAsync"/>.
+/// </summary>
+public enum VenvBootstrapStage
+{
+    CreatingVenv,
+    InstallingRequirements,
+    Verifying,
+    Complete
+}

--- a/tests/VoxFlow.Core.Tests/Services/Python/FakeVenvPaths.cs
+++ b/tests/VoxFlow.Core.Tests/Services/Python/FakeVenvPaths.cs
@@ -1,0 +1,50 @@
+using System;
+using System.IO;
+using VoxFlow.Core.Services.Python;
+
+namespace VoxFlow.Core.Tests.Services.Python;
+
+/// <summary>
+/// Test double for <see cref="IVenvPaths"/>. Points at a unique temp directory
+/// that callers can inspect, create files in, or let the runtime populate.
+/// The root is NOT created on construction — tests decide when it appears.
+/// </summary>
+internal sealed class FakeVenvPaths : IVenvPaths, IDisposable
+{
+    public FakeVenvPaths()
+    {
+        Root = Path.Combine(Path.GetTempPath(), "voxflow-venv-tests", Guid.NewGuid().ToString("N"));
+        RequirementsFilePath = Path.Combine(Root, "requirements.txt");
+    }
+
+    public string Root { get; }
+
+    public string InterpreterPath => Path.Combine(Root, "bin", "python3");
+
+    public string PipPath => Path.Combine(Root, "bin", "pip");
+
+    public string RequirementsFilePath { get; }
+
+    /// <summary>Simulates successful venv creation by materializing the interpreter file.</summary>
+    public void MaterializeVenv()
+    {
+        Directory.CreateDirectory(Path.Combine(Root, "bin"));
+        File.WriteAllText(InterpreterPath, "#!/usr/bin/env fake-python\n");
+        File.WriteAllText(PipPath, "#!/usr/bin/env fake-pip\n");
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(Root))
+            {
+                Directory.Delete(Root, recursive: true);
+            }
+        }
+        catch
+        {
+            // best-effort cleanup
+        }
+    }
+}

--- a/tests/VoxFlow.Core.Tests/Services/Python/ManagedVenvRuntimeTests.cs
+++ b/tests/VoxFlow.Core.Tests/Services/Python/ManagedVenvRuntimeTests.cs
@@ -1,0 +1,181 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using VoxFlow.Core.Services.Python;
+using Xunit;
+
+namespace VoxFlow.Core.Tests.Services.Python;
+
+public sealed class ManagedVenvRuntimeTests
+{
+    [Fact]
+    public async Task GetStatus_VenvNotYetCreated_ReturnsNotReady_WithCreateHint()
+    {
+        using var paths = new FakeVenvPaths();
+        var launcher = new FakeProcessLauncher();
+        var runtime = new ManagedVenvRuntime(launcher, paths);
+
+        var status = await runtime.GetStatusAsync(CancellationToken.None);
+
+        Assert.False(status.IsReady);
+        Assert.NotNull(status.Error);
+        Assert.Contains("CreateVenv", status.Error, StringComparison.OrdinalIgnoreCase);
+        Assert.Empty(launcher.Invocations);
+    }
+
+    [Fact]
+    public async Task CreateVenv_FreshDirectory_CallsPythonVenvCreate()
+    {
+        using var paths = new FakeVenvPaths();
+        var launcher = new FakeProcessLauncher();
+        launcher.SetResponse("python3", exitCode: 0, stdOut: string.Empty);
+        launcher.SetResponse(paths.PipPath, exitCode: 0, stdOut: string.Empty);
+        // Materialize the venv "after" python -m venv runs; FakeProcessLauncher
+        // doesn't care about ordering so create it up front for pip path lookup.
+        paths.MaterializeVenv();
+
+        var runtime = new ManagedVenvRuntime(launcher, paths);
+
+        await runtime.CreateVenvAsync(progress: null, CancellationToken.None);
+
+        Assert.NotEmpty(launcher.Invocations);
+        var first = launcher.Invocations[0];
+        Assert.Equal("python3", first.FileName);
+        var args = first.ArgumentList.ToList();
+        Assert.Contains("-m", args);
+        Assert.Contains("venv", args);
+        Assert.Contains(paths.Root, args);
+    }
+
+    [Fact]
+    public async Task CreateVenv_InstallsRequirements_AfterVenvCreated()
+    {
+        using var paths = new FakeVenvPaths();
+        var launcher = new FakeProcessLauncher();
+        launcher.SetResponse("python3", exitCode: 0, stdOut: string.Empty);
+        launcher.SetResponse(paths.PipPath, exitCode: 0, stdOut: string.Empty);
+        paths.MaterializeVenv();
+
+        var runtime = new ManagedVenvRuntime(launcher, paths);
+        await runtime.CreateVenvAsync(progress: null, CancellationToken.None);
+
+        Assert.True(launcher.Invocations.Count >= 2);
+        var second = launcher.Invocations[1];
+        Assert.Equal(paths.PipPath, second.FileName);
+        var args = second.ArgumentList.ToList();
+        Assert.Contains("install", args);
+        Assert.Contains("-r", args);
+        Assert.Contains(paths.RequirementsFilePath, args);
+    }
+
+    [Fact]
+    public async Task CreateVenv_FailureDuringPipInstall_PropagatesError_AndCleansUp()
+    {
+        using var paths = new FakeVenvPaths();
+        var launcher = new FakeProcessLauncher();
+        launcher.SetResponse("python3", exitCode: 0, stdOut: string.Empty);
+        // Simulate python -m venv creating the venv dir and bin/pip so the
+        // ManagedVenvRuntime's cleanup has real files to remove.
+        paths.MaterializeVenv();
+        launcher.SetResponse(paths.PipPath, exitCode: 1, stdOut: string.Empty, stdErr: "could not resolve torch==x.y.z");
+
+        var runtime = new ManagedVenvRuntime(launcher, paths);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => runtime.CreateVenvAsync(progress: null, CancellationToken.None));
+
+        Assert.Contains("pip install", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.False(Directory.Exists(paths.Root), "Partial venv should be cleaned up on failure.");
+    }
+
+    [Fact]
+    public async Task GetStatus_VenvExists_ReturnsReady_WithInterpreterPath()
+    {
+        using var paths = new FakeVenvPaths();
+        paths.MaterializeVenv();
+        var launcher = new FakeProcessLauncher();
+        var runtime = new ManagedVenvRuntime(launcher, paths);
+
+        var status = await runtime.GetStatusAsync(CancellationToken.None);
+
+        Assert.True(status.IsReady);
+        Assert.Equal(paths.InterpreterPath, status.InterpreterPath);
+        Assert.Empty(launcher.Invocations);
+    }
+
+    [Fact]
+    public void CreateStartInfo_UsesVenvInterpreter()
+    {
+        using var paths = new FakeVenvPaths();
+        var runtime = new ManagedVenvRuntime(new FakeProcessLauncher(), paths);
+
+        var psi = runtime.CreateStartInfo("/tmp/voxflow_diarize.py", new[] { "--input", "a.wav" });
+
+        Assert.Equal(paths.InterpreterPath, psi.FileName);
+        Assert.NotEqual("python3", psi.FileName);
+        Assert.True(psi.RedirectStandardInput);
+        Assert.True(psi.RedirectStandardOutput);
+        Assert.True(psi.RedirectStandardError);
+        Assert.False(psi.UseShellExecute);
+        Assert.Contains("/tmp/voxflow_diarize.py", psi.ArgumentList.ToList());
+        Assert.Contains("--input", psi.ArgumentList.ToList());
+        Assert.Contains("a.wav", psi.ArgumentList.ToList());
+    }
+
+    [Fact]
+    public async Task CreateVenv_WithProgressReporter_ReportsEachStage()
+    {
+        using var paths = new FakeVenvPaths();
+        var launcher = new FakeProcessLauncher();
+        launcher.SetResponse("python3", exitCode: 0, stdOut: string.Empty);
+        launcher.SetResponse(paths.PipPath, exitCode: 0, stdOut: string.Empty);
+        paths.MaterializeVenv();
+
+        var progress = new SynchronousProgress<VenvBootstrapStage>();
+
+        var runtime = new ManagedVenvRuntime(launcher, paths);
+        await runtime.CreateVenvAsync(progress, CancellationToken.None);
+
+        Assert.Equal(
+            new[]
+            {
+                VenvBootstrapStage.CreatingVenv,
+                VenvBootstrapStage.InstallingRequirements,
+                VenvBootstrapStage.Verifying,
+                VenvBootstrapStage.Complete
+            },
+            progress.Reports);
+    }
+
+    [Fact]
+    public async Task CreateVenv_Cancelled_StopsCleanly()
+    {
+        using var paths = new FakeVenvPaths();
+        var launcher = new FakeProcessLauncher();
+        launcher.SetResponse("python3", exitCode: 0, stdOut: string.Empty);
+        // Materialize the venv so pip has a target, then make pip hang until cancellation.
+        paths.MaterializeVenv();
+        launcher.SetNeverReturns(paths.PipPath);
+
+        var runtime = new ManagedVenvRuntime(launcher, paths);
+        using var cts = new CancellationTokenSource();
+
+        var task = runtime.CreateVenvAsync(progress: null, cts.Token);
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => task);
+
+        var status = await runtime.GetStatusAsync(CancellationToken.None);
+        Assert.False(status.IsReady);
+        Assert.False(Directory.Exists(paths.Root), "Cancellation should tear down the partial venv.");
+    }
+
+    private sealed class SynchronousProgress<T> : IProgress<T>
+    {
+        public List<T> Reports { get; } = new();
+        public void Report(T value) => Reports.Add(value);
+    }
+}


### PR DESCRIPTION
Add ManagedVenvRuntime for speaker-labeling sidecar

Default runtime for ADR-024 Phase 1+ users: creates a managed Python
virtual environment under `~/Library/Application Support/VoxFlow/python-runtime/`
(macOS) or `%AppData%\VoxFlow\python-runtime\` (Windows), installs
pinned `pyannote.audio` + `torch` + `torchaudio`, caches for subsequent
runs, reports bootstrap progress, and cleans up the partial venv on
failure or cancellation.

## What's in this PR

- `ManagedVenvRuntime` — implements `IPythonRuntime`, adds
  `CreateVenvAsync(IProgress<VenvBootstrapStage>, CancellationToken)`
  with stage reporting (`CreatingVenv`, `InstallingRequirements`,
  `Verifying`, `Complete`) and best-effort cleanup on any failure.
- `IVenvPaths` abstraction + `DefaultVenvPaths` production
  implementation (OS-specific interpreter/pip paths).
- `VenvBootstrapStage` enum.
- `src/VoxFlow.Core/Resources/python-requirements.txt` pinning
  `pyannote.audio==3.3.2`, `torch==2.4.0`, `torchaudio==2.4.0`.
- Fully unit-tested via `FakeProcessLauncher` + `FakeVenvPaths`
  (temp dir) — no real Python executed.

## Tests

New in `Services/Python/ManagedVenvRuntimeTests`:

- `GetStatus_VenvNotYetCreated_ReturnsNotReady_WithCreateHint`
- `CreateVenv_FreshDirectory_CallsPythonVenvCreate`
- `CreateVenv_InstallsRequirements_AfterVenvCreated`
- `CreateVenv_FailureDuringPipInstall_PropagatesError_AndCleansUp`
- `GetStatus_VenvExists_ReturnsReady_WithInterpreterPath`
- `CreateStartInfo_UsesVenvInterpreter`
- `CreateVenv_WithProgressReporter_ReportsEachStage`
- `CreateVenv_Cancelled_StopsCleanly`

No `RequiresPython` tests in this PR.

## Test plan

- [x] `dotnet test VoxFlow.sln` — full suite green locally
      (207 Core, 35 McpServer, 6 Cli, 70 Desktop + 2 skipped).
