### PR TITLE
feat(core): add voxflow_diarize.py sidecar script (ADR-024 P0.5)

### DIFF
--- a/src/VoxFlow.Core/Resources/voxflow_diarize.py
+++ b/src/VoxFlow.Core/Resources/voxflow_diarize.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""VoxFlow local diarization sidecar (ADR-024 Phase 0).
+
+Protocol (sidecar-diarization-v1):
+- Reads a single JSON request object from stdin.
+- Writes a single JSON response object to stdout.
+- Progress lines may be written as NDJSON to stderr (not yet emitted).
+- Exit code is 0 on every recoverable outcome (including error envelopes).
+- Exit code is non-zero only for unrecoverable framing failures
+  (malformed JSON on stdin) so the .NET client can distinguish a
+  well-formed error envelope from a crashed process.
+
+Request:  {"version": 1, "wavPath": "/abs/path.wav"}
+Response: {"version": 1, "status": "ok",    "speakers": [...], "segments": [...]}
+Error:    {"version": 1, "status": "error", "error": "<message>", "speakers": [], "segments": []}
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from typing import Any
+
+
+PROTOCOL_VERSION = 1
+PYANNOTE_MODEL = "pyannote/speaker-diarization-community-1"
+
+
+def _write_response(payload: dict[str, Any]) -> None:
+    sys.stdout.write(json.dumps(payload))
+    sys.stdout.flush()
+
+
+def _error_envelope(message: str) -> dict[str, Any]:
+    return {
+        "version": PROTOCOL_VERSION,
+        "status": "error",
+        "error": message,
+        "speakers": [],
+        "segments": [],
+    }
+
+
+def _parse_request() -> dict[str, Any]:
+    raw = sys.stdin.read()
+    return json.loads(raw)
+
+
+def _normalize_speaker_labels(diarization: Any) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Remap pyannote's arbitrary speaker labels to A, B, C... in first-appearance order."""
+    label_map: dict[str, str] = {}
+    next_ord = ord("A")
+    segments: list[dict[str, Any]] = []
+    durations: dict[str, float] = {}
+
+    for turn, _, raw_label in diarization.itertracks(yield_label=True):
+        if raw_label not in label_map:
+            label_map[raw_label] = chr(next_ord)
+            next_ord += 1
+        label = label_map[raw_label]
+        segments.append({"speaker": label, "start": float(turn.start), "end": float(turn.end)})
+        durations[label] = durations.get(label, 0.0) + float(turn.end - turn.start)
+
+    speakers = [
+        {"id": label, "totalDuration": round(duration, 6)}
+        for label, duration in sorted(durations.items())
+    ]
+    return speakers, segments
+
+
+def _run_diarization(wav_path: str) -> dict[str, Any]:
+    try:
+        from pyannote.audio import Pipeline  # type: ignore[import-not-found]
+    except Exception as exc:  # pragma: no cover - exercised in integration tests
+        return _error_envelope(f"failed to import pyannote.audio: {exc}")
+
+    try:
+        pipeline = Pipeline.from_pretrained(PYANNOTE_MODEL)
+    except Exception as exc:  # pragma: no cover - exercised in integration tests
+        return _error_envelope(f"failed to load pyannote pipeline '{PYANNOTE_MODEL}': {exc}")
+
+    try:
+        diarization = pipeline(wav_path)
+    except Exception as exc:  # pragma: no cover - exercised in integration tests
+        return _error_envelope(f"diarization failed: {exc}")
+
+    speakers, segments = _normalize_speaker_labels(diarization)
+    return {
+        "version": PROTOCOL_VERSION,
+        "status": "ok",
+        "speakers": speakers,
+        "segments": segments,
+    }
+
+
+def main() -> int:
+    try:
+        request = _parse_request()
+    except json.JSONDecodeError as exc:
+        _write_response(_error_envelope(f"malformed JSON request: {exc}"))
+        return 2
+
+    if not isinstance(request, dict):
+        _write_response(_error_envelope("request must be a JSON object"))
+        return 0
+
+    version = request.get("version")
+    if version != PROTOCOL_VERSION:
+        _write_response(_error_envelope(f"unsupported protocol version: {version}"))
+        return 0
+
+    wav_path = request.get("wavPath")
+    if not isinstance(wav_path, str) or not wav_path:
+        _write_response(_error_envelope("wavPath must be a non-empty string"))
+        return 0
+
+    if not os.path.isfile(wav_path):
+        _write_response(_error_envelope(f"wav file not found: {wav_path}"))
+        return 0
+
+    response = _run_diarization(wav_path)
+    _write_response(response)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/VoxFlow.Core/VoxFlow.Core.csproj
+++ b/src/VoxFlow.Core/VoxFlow.Core.csproj
@@ -23,4 +23,13 @@
     </Reference>
   </ItemGroup>
 
+  <!--
+    Resources\voxflow_diarize.py and python-requirements.txt live here because
+    VoxFlow.Core owns the Python sidecar contract. They are NOT CopyToOutputDirectory
+    at the Core level — that would flow them transitively into the MacCatalyst app
+    bundle, which doesn't know how to place them. Tests link them directly (see
+    tests/VoxFlow.Core.Tests/VoxFlow.Core.Tests.csproj). Production packaging will
+    wire them into the app bundle explicitly in a later phase (ADR-024 P1+).
+  -->
+
 </Project>

--- a/tests/VoxFlow.Core.Tests/Services/Python/SidecarScriptContractTests.cs
+++ b/tests/VoxFlow.Core.Tests/Services/Python/SidecarScriptContractTests.cs
@@ -1,0 +1,155 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace VoxFlow.Core.Tests.Services.Python;
+
+/// <summary>
+/// Contract tests for <c>voxflow_diarize.py</c> (ADR-024 Phase 0, P0.5).
+/// Exercises the sidecar script directly via python3, without the .NET client.
+/// The fixture-backed tests use <see cref="SkippableFactAttribute"/> so the suite
+/// stays green on machines that don't yet have the audio fixtures from P0.8
+/// or don't have python3/pyannote installed.
+/// </summary>
+[Trait("Category", "RequiresPython")]
+public sealed class SidecarScriptContractTests
+{
+    private static string ScriptPath => Path.Combine(
+        AppContext.BaseDirectory, "python", "voxflow_diarize.py");
+
+    private static string SingleSpeakerFixturePath => Path.Combine(
+        AppContext.BaseDirectory, "fixtures", "sidecar", "audio", "obama-speech-1spk-10s.wav");
+
+    private static string TwoSpeakerFixturePath => Path.Combine(
+        AppContext.BaseDirectory, "fixtures", "sidecar", "audio", "libricss-2spk-10s.wav");
+
+    [SkippableFact]
+    public async Task RunAgainstSingleSpeakerWav_ReturnsOkResponse_WithOneSpeaker()
+    {
+        Skip.IfNot(Python3Available(), "python3 not available on PATH");
+        Skip.IfNot(File.Exists(ScriptPath), $"sidecar script missing at {ScriptPath}");
+        Skip.IfNot(File.Exists(SingleSpeakerFixturePath),
+            "fixture not yet committed; will be enabled in P0.8");
+
+        var result = await RunSidecarAsync(
+            JsonSerializer.Serialize(new { version = 1, wavPath = SingleSpeakerFixturePath }));
+
+        Assert.Equal(0, result.ExitCode);
+        using var doc = JsonDocument.Parse(result.StdOut);
+        var root = doc.RootElement;
+        Assert.Equal(1, root.GetProperty("version").GetInt32());
+        Assert.Equal("ok", root.GetProperty("status").GetString());
+        Assert.Equal(1, root.GetProperty("speakers").GetArrayLength());
+    }
+
+    [SkippableFact]
+    public async Task RunAgainstTwoSpeakerWav_ReturnsOkResponse_WithTwoSpeakers()
+    {
+        Skip.IfNot(Python3Available(), "python3 not available on PATH");
+        Skip.IfNot(File.Exists(ScriptPath), $"sidecar script missing at {ScriptPath}");
+        Skip.IfNot(File.Exists(TwoSpeakerFixturePath),
+            "fixture not yet committed; will be enabled in P0.8");
+
+        var result = await RunSidecarAsync(
+            JsonSerializer.Serialize(new { version = 1, wavPath = TwoSpeakerFixturePath }));
+
+        Assert.Equal(0, result.ExitCode);
+        using var doc = JsonDocument.Parse(result.StdOut);
+        var root = doc.RootElement;
+        Assert.Equal("ok", root.GetProperty("status").GetString());
+        Assert.Equal(2, root.GetProperty("speakers").GetArrayLength());
+    }
+
+    [SkippableFact]
+    public async Task RunAgainstMissingWav_ReturnsErrorResponse()
+    {
+        Skip.IfNot(Python3Available(), "python3 not available on PATH");
+        Skip.IfNot(File.Exists(ScriptPath), $"sidecar script missing at {ScriptPath}");
+
+        var missing = Path.Combine(Path.GetTempPath(), $"voxflow-missing-{Guid.NewGuid():N}.wav");
+        var result = await RunSidecarAsync(
+            JsonSerializer.Serialize(new { version = 1, wavPath = missing }));
+
+        Assert.Equal(0, result.ExitCode);
+        using var doc = JsonDocument.Parse(result.StdOut);
+        var root = doc.RootElement;
+        Assert.Equal("error", root.GetProperty("status").GetString());
+        var message = root.GetProperty("error").GetString() ?? string.Empty;
+        Assert.Contains("wav", message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [SkippableFact]
+    public async Task RunWithMalformedJsonRequest_ReturnsErrorResponse_AndExitsNonZero()
+    {
+        Skip.IfNot(Python3Available(), "python3 not available on PATH");
+        Skip.IfNot(File.Exists(ScriptPath), $"sidecar script missing at {ScriptPath}");
+
+        var result = await RunSidecarAsync("{ this is not json");
+
+        Assert.NotEqual(0, result.ExitCode);
+        using var doc = JsonDocument.Parse(result.StdOut);
+        Assert.Equal("error", doc.RootElement.GetProperty("status").GetString());
+    }
+
+    private static async Task<(int ExitCode, string StdOut, string StdErr)> RunSidecarAsync(string stdin)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = "python3",
+            RedirectStandardInput = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+        psi.ArgumentList.Add(ScriptPath);
+
+        using var process = Process.Start(psi)
+            ?? throw new InvalidOperationException("failed to start python3");
+
+        var stdOutTask = process.StandardOutput.ReadToEndAsync();
+        var stdErrTask = process.StandardError.ReadToEndAsync();
+
+        await process.StandardInput.WriteAsync(stdin);
+        process.StandardInput.Close();
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        await process.WaitForExitAsync(cts.Token);
+
+        var stdOut = await stdOutTask;
+        var stdErr = await stdErrTask;
+        return (process.ExitCode, stdOut, stdErr);
+    }
+
+    private static bool Python3Available()
+    {
+        try
+        {
+            var psi = new ProcessStartInfo
+            {
+                FileName = "python3",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+            psi.ArgumentList.Add("--version");
+            using var process = Process.Start(psi);
+            if (process is null)
+            {
+                return false;
+            }
+            process.WaitForExit(5000);
+            return process.ExitCode == 0;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}

--- a/tests/VoxFlow.Core.Tests/VoxFlow.Core.Tests.csproj
+++ b/tests/VoxFlow.Core.Tests/VoxFlow.Core.Tests.csproj
@@ -16,6 +16,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
     <PackageReference Include="NJsonSchema" Version="11.1.0" />
+    <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
   </ItemGroup>
 
   <ItemGroup>
@@ -35,5 +36,7 @@
 
   <ItemGroup>
     <None Include="..\..\docs\contracts\*.json" Link="contracts\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="..\..\src\VoxFlow.Core\Resources\voxflow_diarize.py" Link="python\voxflow_diarize.py" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="..\..\src\VoxFlow.Core\Resources\python-requirements.txt" Link="python\python-requirements.txt" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary

Python side of the speaker-labeling JSON contract (ADR-024 Phase 0, step P0.5).
Adds `src/VoxFlow.Core/Resources/voxflow_diarize.py` implementing the
`sidecar-diarization-v1` protocol: reads a single JSON request on stdin, runs
pyannote diarization, writes a single JSON response on stdout.

- Request: `{"version": 1, "wavPath": "/abs/path.wav"}`
- Response (ok): `{"version": 1, "status": "ok", "speakers": [...], "segments": [...]}`
- Response (error): `{"version": 1, "status": "error", "error": "...", "speakers": [], "segments": []}`
- Speaker labels are normalized to `A`, `B`, `C`... in first-appearance order, matching the transcript contract from P0.2.
- Exit code is `0` for every recoverable outcome (including error envelopes); non-zero only for malformed JSON framing, so the .NET client can distinguish a well-formed error from a crashed process.
- The `pyannote.audio` import is deferred inside the diarization path so error-path tests (missing wav, malformed JSON) run without pyannote installed.

No .NET production code changes. The script is linked into the test project's output via `VoxFlow.Core.Tests.csproj` (not `CopyToOutputDirectory` at the Core level — that would flow the file transitively into the MacCatalyst app bundle and warn on `PublishFolderType`). Production packaging will wire the script into the app bundle explicitly in a later phase.

## TDD

Integration tests added in `tests/VoxFlow.Core.Tests/Services/Python/SidecarScriptContractTests.cs`, tagged `[Trait("Category", "RequiresPython")]` at the class level:

- `RunAgainstSingleSpeakerWav_ReturnsOkResponse_WithOneSpeaker` — `SkippableFact`, fixture-gated (P0.8).
- `RunAgainstTwoSpeakerWav_ReturnsOkResponse_WithTwoSpeakers` — `SkippableFact`, fixture-gated (P0.8).
- `RunAgainstMissingWav_ReturnsErrorResponse` — runs today; asserts error envelope + exit 0.
- `RunWithMalformedJsonRequest_ReturnsErrorResponse_AndExitsNonZero` — runs today; asserts error envelope + non-zero exit.

All four tests use `Skip.IfNot` to skip gracefully if `python3` is unavailable, if the script is missing from the test output, or if the audio fixture isn't yet committed. `Xunit.SkippableFact 1.4.13` added to `VoxFlow.Core.Tests.csproj`.

## Test plan

- [x] `dotnet test VoxFlow.sln` — green (320 passed, 4 skipped, 0 warnings)
- [x] `dotnet test --filter Category=RequiresPython` — green locally (error-path tests run; fixture tests skip pending P0.8)