### PR TITLE
feat(core): add PyannoteSidecarClient (ADR-024 P0.6)

### DIFF
--- a/src/VoxFlow.Core/Interfaces/IDiarizationSidecar.cs
+++ b/src/VoxFlow.Core/Interfaces/IDiarizationSidecar.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using VoxFlow.Core.Models;
+
+namespace VoxFlow.Core.Interfaces;
+
+/// <summary>
+/// Bridges the .NET speaker-labeling pipeline to the <c>voxflow_diarize.py</c>
+/// sidecar. Implementations own the process lifetime, stdin/stdout/stderr
+/// plumbing, schema validation, and the failure taxonomy surfaced via
+/// <c>DiarizationSidecarException</c>.
+/// </summary>
+public interface IDiarizationSidecar
+{
+    Task<DiarizationResult> DiarizeAsync(
+        DiarizationRequest request,
+        IProgress<SpeakerLabelingProgress>? progress,
+        CancellationToken cancellationToken);
+}

--- a/src/VoxFlow.Core/Interfaces/IProcessLauncher.cs
+++ b/src/VoxFlow.Core/Interfaces/IProcessLauncher.cs
@@ -11,4 +11,16 @@ namespace VoxFlow.Core.Interfaces;
 public interface IProcessLauncher
 {
     Task<ProcessExecutionResult> RunAsync(ProcessStartInfo startInfo, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Variant that writes <paramref name="stdIn"/> to the child's standard
+    /// input (closing it afterwards) and captures stdout/stderr as strings.
+    /// Phase 0 buffers stderr and forwards it to the caller after the process
+    /// exits; real-time stderr streaming can be added later without breaking
+    /// the interface.
+    /// </summary>
+    Task<ProcessExecutionResult> RunAsync(
+        ProcessStartInfo startInfo,
+        string stdIn,
+        CancellationToken cancellationToken);
 }

--- a/src/VoxFlow.Core/Models/DiarizationRequest.cs
+++ b/src/VoxFlow.Core/Models/DiarizationRequest.cs
@@ -1,0 +1,7 @@
+namespace VoxFlow.Core.Models;
+
+/// <summary>
+/// Input to <c>IDiarizationSidecar.DiarizeAsync</c>: the absolute path to a
+/// WAV file the sidecar should diarize.
+/// </summary>
+public sealed record DiarizationRequest(string WavPath);

--- a/src/VoxFlow.Core/Models/DiarizationResult.cs
+++ b/src/VoxFlow.Core/Models/DiarizationResult.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+
+namespace VoxFlow.Core.Models;
+
+/// <summary>
+/// Output of <c>IDiarizationSidecar.DiarizeAsync</c>: one speaker roster plus
+/// the per-speaker time spans.
+/// </summary>
+public sealed record DiarizationResult(
+    int Version,
+    IReadOnlyList<DiarizationSpeaker> Speakers,
+    IReadOnlyList<DiarizationSegment> Segments);

--- a/src/VoxFlow.Core/Models/DiarizationSegment.cs
+++ b/src/VoxFlow.Core/Models/DiarizationSegment.cs
@@ -1,0 +1,7 @@
+namespace VoxFlow.Core.Models;
+
+/// <summary>
+/// One speaker-homogeneous time span emitted by the diarization sidecar.
+/// Speaker IDs are the ordinal labels from <see cref="DiarizationSpeaker.Id"/>.
+/// </summary>
+public sealed record DiarizationSegment(string Speaker, double Start, double End);

--- a/src/VoxFlow.Core/Models/DiarizationSpeaker.cs
+++ b/src/VoxFlow.Core/Models/DiarizationSpeaker.cs
@@ -1,0 +1,8 @@
+namespace VoxFlow.Core.Models;
+
+/// <summary>
+/// One speaker in a <see cref="DiarizationResult"/>. <paramref name="Id"/> is an
+/// ordinal label (A, B, C...) in first-appearance order, matching the
+/// sidecar-diarization-v1 contract.
+/// </summary>
+public sealed record DiarizationSpeaker(string Id, double TotalDuration);

--- a/src/VoxFlow.Core/Models/SidecarFailureReason.cs
+++ b/src/VoxFlow.Core/Models/SidecarFailureReason.cs
@@ -1,0 +1,17 @@
+namespace VoxFlow.Core.Models;
+
+/// <summary>
+/// Taxonomy of diarization-sidecar failures surfaced via
+/// <c>DiarizationSidecarException</c>. Each value corresponds to a
+/// user-actionable remedy (e.g., install the runtime, increase the timeout,
+/// report a schema regression).
+/// </summary>
+public enum SidecarFailureReason
+{
+    RuntimeNotReady,
+    ProcessCrashed,
+    Timeout,
+    MalformedJson,
+    SchemaViolation,
+    ErrorResponseReturned
+}

--- a/src/VoxFlow.Core/Models/SpeakerLabelingProgress.cs
+++ b/src/VoxFlow.Core/Models/SpeakerLabelingProgress.cs
@@ -1,0 +1,10 @@
+namespace VoxFlow.Core.Models;
+
+/// <summary>
+/// Progress checkpoint forwarded from the diarization sidecar's stderr stream.
+/// The sidecar emits NDJSON progress lines; <see cref="PyannoteSidecarClient"/>
+/// parses them and reports each as a <see cref="SpeakerLabelingProgress"/>.
+/// Phase 0 only surfaces the two fields pyannote itself provides; richer UX
+/// state (e.g., bytes downloaded) can be added later without a contract break.
+/// </summary>
+public sealed record SpeakerLabelingProgress(string Stage, double? Fraction);

--- a/src/VoxFlow.Core/Services/Diarization/DiarizationSidecarException.cs
+++ b/src/VoxFlow.Core/Services/Diarization/DiarizationSidecarException.cs
@@ -1,0 +1,20 @@
+using System;
+using VoxFlow.Core.Models;
+
+namespace VoxFlow.Core.Services.Diarization;
+
+/// <summary>
+/// Raised by <see cref="PyannoteSidecarClient"/> when diarization fails in a
+/// way the caller can categorize via <see cref="Reason"/> and either retry,
+/// surface to the user, or give up.
+/// </summary>
+public sealed class DiarizationSidecarException : Exception
+{
+    public DiarizationSidecarException(SidecarFailureReason reason, string message, Exception? inner = null)
+        : base(message, inner)
+    {
+        Reason = reason;
+    }
+
+    public SidecarFailureReason Reason { get; }
+}

--- a/src/VoxFlow.Core/Services/Diarization/PyannoteSidecarClient.cs
+++ b/src/VoxFlow.Core/Services/Diarization/PyannoteSidecarClient.cs
@@ -1,0 +1,232 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using NJsonSchema;
+using VoxFlow.Core.Interfaces;
+using VoxFlow.Core.Models;
+using VoxFlow.Core.Services.Python;
+
+namespace VoxFlow.Core.Services.Diarization;
+
+/// <summary>
+/// Default <see cref="IDiarizationSidecar"/> that invokes
+/// <c>voxflow_diarize.py</c> via the configured <see cref="IPythonRuntime"/>
+/// and <see cref="IProcessLauncher"/>. Owns: writing the JSON request on
+/// stdin, parsing stdout per sidecar-diarization-v1, mapping failures to
+/// <see cref="DiarizationSidecarException"/>.
+/// </summary>
+public sealed class PyannoteSidecarClient : IDiarizationSidecar
+{
+    private const int ProtocolVersion = 1;
+    private const string SchemaResourceName = "VoxFlow.Core.Contracts.sidecar-diarization-v1.schema.json";
+
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+
+    private static readonly Lazy<JsonSchema> ResponseSchema = new(LoadResponseSchema);
+
+    private static JsonSchema LoadResponseSchema()
+    {
+        using var stream = typeof(PyannoteSidecarClient).Assembly
+            .GetManifestResourceStream(SchemaResourceName)
+            ?? throw new InvalidOperationException(
+                $"Embedded schema '{SchemaResourceName}' not found.");
+        using var reader = new StreamReader(stream);
+        return JsonSchema.FromJsonAsync(reader.ReadToEnd()).GetAwaiter().GetResult();
+    }
+
+    private readonly IPythonRuntime _runtime;
+    private readonly IProcessLauncher _launcher;
+    private readonly string _scriptPath;
+    private readonly TimeSpan _timeout;
+
+    public PyannoteSidecarClient(
+        IPythonRuntime runtime,
+        IProcessLauncher launcher,
+        string scriptPath,
+        TimeSpan timeout)
+    {
+        ArgumentNullException.ThrowIfNull(runtime);
+        ArgumentNullException.ThrowIfNull(launcher);
+        ArgumentException.ThrowIfNullOrWhiteSpace(scriptPath);
+        _runtime = runtime;
+        _launcher = launcher;
+        _scriptPath = scriptPath;
+        _timeout = timeout;
+    }
+
+    public async Task<DiarizationResult> DiarizeAsync(
+        DiarizationRequest request,
+        IProgress<SpeakerLabelingProgress>? progress,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var status = await _runtime.GetStatusAsync(cancellationToken).ConfigureAwait(false);
+        if (!status.IsReady)
+        {
+            throw new DiarizationSidecarException(
+                SidecarFailureReason.RuntimeNotReady,
+                $"Python runtime is not ready: {status.Error}");
+        }
+
+        var psi = _runtime.CreateStartInfo(_scriptPath, Array.Empty<string>());
+        var payload = JsonSerializer.Serialize(
+            new RequestEnvelope(ProtocolVersion, request.WavPath),
+            SerializerOptions);
+
+        using var timeoutCts = new CancellationTokenSource(_timeout);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
+            cancellationToken, timeoutCts.Token);
+
+        ProcessExecutionResult process;
+        try
+        {
+            process = await _launcher.RunAsync(psi, payload, linkedCts.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            if (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+            {
+                throw new DiarizationSidecarException(
+                    SidecarFailureReason.Timeout,
+                    $"voxflow_diarize.py did not return within {_timeout.TotalSeconds:0.##}s");
+            }
+            throw;
+        }
+
+        ForwardProgress(process.StdErr, progress);
+
+        if (process.ExitCode != 0 && string.IsNullOrWhiteSpace(process.StdOut))
+        {
+            throw new DiarizationSidecarException(
+                SidecarFailureReason.ProcessCrashed,
+                $"voxflow_diarize.py exited with code {process.ExitCode}. stderr: {process.StdErr}");
+        }
+
+        JsonDocument document;
+        try
+        {
+            document = JsonDocument.Parse(process.StdOut);
+        }
+        catch (JsonException ex)
+        {
+            throw new DiarizationSidecarException(
+                SidecarFailureReason.MalformedJson,
+                $"voxflow_diarize.py wrote non-JSON to stdout: {ex.Message}",
+                ex);
+        }
+
+        using (document)
+        {
+            var root = document.RootElement;
+
+            // Error envelopes are valid against the schema but short-circuit here
+            // so we return a useful message instead of a structural complaint.
+            if (root.TryGetProperty("status", out var statusElement)
+                && string.Equals(statusElement.GetString(), "error", StringComparison.Ordinal))
+            {
+                var message = root.TryGetProperty("error", out var errorElement)
+                    ? errorElement.GetString() ?? "unknown error"
+                    : "unknown error";
+                throw new DiarizationSidecarException(
+                    SidecarFailureReason.ErrorResponseReturned,
+                    $"voxflow_diarize.py returned error envelope: {message}");
+            }
+
+            var validationErrors = ResponseSchema.Value.Validate(process.StdOut);
+            if (validationErrors.Count > 0)
+            {
+                var joined = string.Join("; ", validationErrors.Select(e => e.ToString()));
+                throw new DiarizationSidecarException(
+                    SidecarFailureReason.SchemaViolation,
+                    $"voxflow_diarize.py response failed schema validation: {joined}");
+            }
+
+            return ParseResponse(root);
+        }
+    }
+
+    private static DiarizationResult ParseResponse(JsonElement root)
+    {
+        var version = root.GetProperty("version").GetInt32();
+        var speakers = new List<DiarizationSpeaker>();
+        foreach (var el in root.GetProperty("speakers").EnumerateArray())
+        {
+            speakers.Add(new DiarizationSpeaker(
+                el.GetProperty("id").GetString() ?? string.Empty,
+                el.GetProperty("totalDuration").GetDouble()));
+        }
+
+        var segments = new List<DiarizationSegment>();
+        foreach (var el in root.GetProperty("segments").EnumerateArray())
+        {
+            segments.Add(new DiarizationSegment(
+                el.GetProperty("speaker").GetString() ?? string.Empty,
+                el.GetProperty("start").GetDouble(),
+                el.GetProperty("end").GetDouble()));
+        }
+
+        return new DiarizationResult(version, speakers, segments);
+    }
+
+    private static void ForwardProgress(string stdErr, IProgress<SpeakerLabelingProgress>? progress)
+    {
+        if (progress is null || string.IsNullOrEmpty(stdErr))
+        {
+            return;
+        }
+
+        foreach (var rawLine in stdErr.Split('\n'))
+        {
+            var line = rawLine.Trim();
+            if (line.Length == 0 || line[0] != '{')
+            {
+                continue;
+            }
+
+            SpeakerLabelingProgress? parsed;
+            try
+            {
+                using var doc = JsonDocument.Parse(line);
+                var root = doc.RootElement;
+                if (!root.TryGetProperty("stage", out var stageEl))
+                {
+                    continue;
+                }
+                var stage = stageEl.GetString();
+                if (stage is null)
+                {
+                    continue;
+                }
+                double? fraction = root.TryGetProperty("fraction", out var fracEl)
+                    && fracEl.ValueKind == JsonValueKind.Number
+                        ? fracEl.GetDouble()
+                        : null;
+                parsed = new SpeakerLabelingProgress(stage, fraction);
+            }
+            catch (JsonException)
+            {
+                parsed = null;
+            }
+
+            if (parsed is not null)
+            {
+                progress.Report(parsed);
+            }
+        }
+    }
+
+    private sealed record RequestEnvelope(
+        [property: JsonPropertyName("version")] int Version,
+        [property: JsonPropertyName("wavPath")] string WavPath);
+}

--- a/src/VoxFlow.Core/Services/Python/DefaultProcessLauncher.cs
+++ b/src/VoxFlow.Core/Services/Python/DefaultProcessLauncher.cs
@@ -11,7 +11,22 @@ namespace VoxFlow.Core.Services.Python;
 /// </summary>
 public sealed class DefaultProcessLauncher : IProcessLauncher
 {
-    public async Task<ProcessExecutionResult> RunAsync(ProcessStartInfo startInfo, CancellationToken cancellationToken)
+    public Task<ProcessExecutionResult> RunAsync(ProcessStartInfo startInfo, CancellationToken cancellationToken)
+        => RunInternalAsync(startInfo, stdIn: null, cancellationToken);
+
+    public Task<ProcessExecutionResult> RunAsync(
+        ProcessStartInfo startInfo,
+        string stdIn,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(stdIn);
+        return RunInternalAsync(startInfo, stdIn, cancellationToken);
+    }
+
+    private static async Task<ProcessExecutionResult> RunInternalAsync(
+        ProcessStartInfo startInfo,
+        string? stdIn,
+        CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(startInfo);
 
@@ -19,6 +34,10 @@ public sealed class DefaultProcessLauncher : IProcessLauncher
         startInfo.RedirectStandardError = true;
         startInfo.UseShellExecute = false;
         startInfo.CreateNoWindow = true;
+        if (stdIn is not null)
+        {
+            startInfo.RedirectStandardInput = true;
+        }
 
         using var process = new Process { StartInfo = startInfo };
         process.Start();
@@ -37,6 +56,12 @@ public sealed class DefaultProcessLauncher : IProcessLauncher
                 // Process may have exited between HasExited check and Kill; swallow.
             }
         });
+
+        if (stdIn is not null)
+        {
+            await process.StandardInput.WriteAsync(stdIn.AsMemory(), cancellationToken).ConfigureAwait(false);
+            process.StandardInput.Close();
+        }
 
         var stdOutTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
         var stdErrTask = process.StandardError.ReadToEndAsync(cancellationToken);

--- a/src/VoxFlow.Core/VoxFlow.Core.csproj
+++ b/src/VoxFlow.Core/VoxFlow.Core.csproj
@@ -14,6 +14,11 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.0" />
+    <PackageReference Include="NJsonSchema" Version="11.1.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="..\..\docs\contracts\sidecar-diarization-v1.schema.json" LogicalName="VoxFlow.Core.Contracts.sidecar-diarization-v1.schema.json" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/VoxFlow.Core.Tests/Services/Diarization/FakePythonRuntime.cs
+++ b/tests/VoxFlow.Core.Tests/Services/Diarization/FakePythonRuntime.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using VoxFlow.Core.Interfaces;
+using VoxFlow.Core.Services.Python;
+
+namespace VoxFlow.Core.Tests.Services.Diarization;
+
+/// <summary>
+/// Test double for <see cref="IPythonRuntime"/>. Tests can mark the runtime
+/// ready/not-ready and inspect what <see cref="CreateStartInfo"/> was asked
+/// to build.
+/// </summary>
+internal sealed class FakePythonRuntime : IPythonRuntime
+{
+    public string InterpreterPath { get; set; } = "/fake/venv/bin/python3";
+    public PythonRuntimeStatus NextStatus { get; set; }
+        = PythonRuntimeStatus.Ready("/fake/venv/bin/python3", "3.11.0");
+    public List<(string ScriptPath, string[] Args)> StartInfoRequests { get; } = new();
+
+    public Task<PythonRuntimeStatus> GetStatusAsync(CancellationToken cancellationToken)
+        => Task.FromResult(NextStatus);
+
+    public ProcessStartInfo CreateStartInfo(string scriptPath, IEnumerable<string> arguments)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(scriptPath);
+        ArgumentNullException.ThrowIfNull(arguments);
+
+        var args = new List<string>();
+        foreach (var a in arguments)
+        {
+            args.Add(a);
+        }
+        StartInfoRequests.Add((scriptPath, args.ToArray()));
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = InterpreterPath,
+            RedirectStandardInput = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+        psi.ArgumentList.Add(scriptPath);
+        foreach (var a in args)
+        {
+            psi.ArgumentList.Add(a);
+        }
+        return psi;
+    }
+}

--- a/tests/VoxFlow.Core.Tests/Services/Diarization/PyannoteSidecarClientIntegrationTests.cs
+++ b/tests/VoxFlow.Core.Tests/Services/Diarization/PyannoteSidecarClientIntegrationTests.cs
@@ -1,0 +1,90 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using VoxFlow.Core.Models;
+using VoxFlow.Core.Services.Diarization;
+using VoxFlow.Core.Services.Python;
+using Xunit;
+
+namespace VoxFlow.Core.Tests.Services.Diarization;
+
+/// <summary>
+/// End-to-end integration tests for <see cref="PyannoteSidecarClient"/>
+/// against the real <c>voxflow_diarize.py</c> script, real
+/// <see cref="SystemPythonRuntime"/>, and real audio fixtures. The class is
+/// tagged so CI/dev can opt in/out via <c>--filter Category=RequiresPython</c>;
+/// fixture-backed tests use <see cref="SkippableFactAttribute"/> to stay green
+/// before the audio fixtures land in P0.8.
+/// </summary>
+[Trait("Category", "RequiresPython")]
+public sealed class PyannoteSidecarClientIntegrationTests
+{
+    private static string ScriptPath => Path.Combine(
+        AppContext.BaseDirectory, "python", "voxflow_diarize.py");
+
+    private static string SingleSpeakerFixturePath => Path.Combine(
+        AppContext.BaseDirectory, "fixtures", "sidecar", "audio", "obama-speech-1spk-10s.wav");
+
+    private static string TwoSpeakerFixturePath => Path.Combine(
+        AppContext.BaseDirectory, "fixtures", "sidecar", "audio", "libricss-2spk-10s.wav");
+
+    private static string ThreeSpeakerFixturePath => Path.Combine(
+        AppContext.BaseDirectory, "fixtures", "sidecar", "audio", "libricss-3spk-10s.wav");
+
+    [SkippableFact]
+    public async Task DiarizeAsync_RealSidecar_SingleSpeakerWav_Returns1Speaker()
+    {
+        Skip.IfNot(File.Exists(ScriptPath), $"sidecar script missing at {ScriptPath}");
+        Skip.IfNot(File.Exists(SingleSpeakerFixturePath),
+            "fixture not yet committed; will be enabled in P0.8");
+
+        var client = CreateClient();
+        var result = await client.DiarizeAsync(
+            new DiarizationRequest(SingleSpeakerFixturePath),
+            progress: null,
+            CancellationToken.None);
+
+        Assert.Equal(1, result.Version);
+        Assert.Single(result.Speakers);
+    }
+
+    [SkippableFact]
+    public async Task DiarizeAsync_RealSidecar_TwoSpeakerWav_Returns2Speakers()
+    {
+        Skip.IfNot(File.Exists(ScriptPath), $"sidecar script missing at {ScriptPath}");
+        Skip.IfNot(File.Exists(TwoSpeakerFixturePath),
+            "fixture not yet committed; will be enabled in P0.8");
+
+        var client = CreateClient();
+        var result = await client.DiarizeAsync(
+            new DiarizationRequest(TwoSpeakerFixturePath),
+            progress: null,
+            CancellationToken.None);
+
+        Assert.Equal(2, result.Speakers.Count);
+    }
+
+    [SkippableFact]
+    public async Task DiarizeAsync_RealSidecar_ThreeSpeakerWav_ReturnsAtLeast3Speakers()
+    {
+        Skip.IfNot(File.Exists(ScriptPath), $"sidecar script missing at {ScriptPath}");
+        Skip.IfNot(File.Exists(ThreeSpeakerFixturePath),
+            "fixture not yet committed; will be enabled in P0.8");
+
+        var client = CreateClient();
+        var result = await client.DiarizeAsync(
+            new DiarizationRequest(ThreeSpeakerFixturePath),
+            progress: null,
+            CancellationToken.None);
+
+        Assert.True(result.Speakers.Count >= 3, $"expected >=3 speakers, got {result.Speakers.Count}");
+    }
+
+    private static PyannoteSidecarClient CreateClient()
+    {
+        var launcher = new DefaultProcessLauncher();
+        var runtime = new SystemPythonRuntime(launcher);
+        return new PyannoteSidecarClient(runtime, launcher, ScriptPath, TimeSpan.FromMinutes(5));
+    }
+}

--- a/tests/VoxFlow.Core.Tests/Services/Diarization/PyannoteSidecarClientTests.cs
+++ b/tests/VoxFlow.Core.Tests/Services/Diarization/PyannoteSidecarClientTests.cs
@@ -1,0 +1,229 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using VoxFlow.Core.Models;
+using VoxFlow.Core.Services.Diarization;
+using VoxFlow.Core.Services.Python;
+using VoxFlow.Core.Tests.Services.Python;
+using Xunit;
+
+namespace VoxFlow.Core.Tests.Services.Diarization;
+
+public sealed class PyannoteSidecarClientTests
+{
+    private const string ScriptPath = "/tmp/voxflow_diarize.py";
+
+    [Fact]
+    public async Task DiarizeAsync_HappyPath_ReturnsResultFromStdout()
+    {
+        var runtime = new FakePythonRuntime();
+        var launcher = new FakeProcessLauncher();
+        launcher.SetResponse(
+            runtime.InterpreterPath,
+            exitCode: 0,
+            stdOut: """
+            {
+              "version": 1,
+              "status": "ok",
+              "speakers": [
+                { "id": "A", "totalDuration": 4.5 },
+                { "id": "B", "totalDuration": 2.25 }
+              ],
+              "segments": [
+                { "speaker": "A", "start": 0.0, "end": 4.5 },
+                { "speaker": "B", "start": 4.5, "end": 6.75 }
+              ]
+            }
+            """);
+
+        var client = new PyannoteSidecarClient(runtime, launcher, ScriptPath, TimeSpan.FromSeconds(5));
+
+        var result = await client.DiarizeAsync(
+            new DiarizationRequest("/tmp/input.wav"),
+            progress: null,
+            CancellationToken.None);
+
+        Assert.Equal(1, result.Version);
+        Assert.Equal(2, result.Speakers.Count);
+        Assert.Equal("A", result.Speakers[0].Id);
+        Assert.Equal(4.5, result.Speakers[0].TotalDuration);
+        Assert.Equal(2, result.Segments.Count);
+        Assert.Equal("A", result.Segments[0].Speaker);
+        Assert.Equal(0.0, result.Segments[0].Start);
+        Assert.Equal(4.5, result.Segments[0].End);
+
+        Assert.Single(launcher.Invocations);
+        var stdinPayload = Assert.Single(launcher.StdInputs);
+        Assert.NotNull(stdinPayload);
+        Assert.Contains("\"wavPath\"", stdinPayload);
+        Assert.Contains("/tmp/input.wav", stdinPayload);
+        Assert.Contains("\"version\"", stdinPayload);
+        Assert.Equal(ScriptPath, runtime.StartInfoRequests.Single().ScriptPath);
+    }
+
+    [Fact]
+    public async Task DiarizeAsync_NonZeroExit_ThrowsWithProcessCrashed()
+    {
+        var runtime = new FakePythonRuntime();
+        var launcher = new FakeProcessLauncher();
+        launcher.SetResponse(runtime.InterpreterPath, exitCode: 1, stdOut: string.Empty, stdErr: "segfault");
+
+        var client = new PyannoteSidecarClient(runtime, launcher, ScriptPath, TimeSpan.FromSeconds(5));
+
+        var ex = await Assert.ThrowsAsync<DiarizationSidecarException>(
+            () => client.DiarizeAsync(new DiarizationRequest("/tmp/a.wav"), progress: null, CancellationToken.None));
+
+        Assert.Equal(SidecarFailureReason.ProcessCrashed, ex.Reason);
+        Assert.Contains("segfault", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task DiarizeAsync_MalformedJsonOnStdout_ThrowsWithMalformedJson()
+    {
+        var runtime = new FakePythonRuntime();
+        var launcher = new FakeProcessLauncher();
+        launcher.SetResponse(runtime.InterpreterPath, exitCode: 0, stdOut: "{ this is not json");
+
+        var client = new PyannoteSidecarClient(runtime, launcher, ScriptPath, TimeSpan.FromSeconds(5));
+
+        var ex = await Assert.ThrowsAsync<DiarizationSidecarException>(
+            () => client.DiarizeAsync(new DiarizationRequest("/tmp/a.wav"), progress: null, CancellationToken.None));
+
+        Assert.Equal(SidecarFailureReason.MalformedJson, ex.Reason);
+        Assert.NotNull(ex.InnerException);
+    }
+
+    [Fact]
+    public async Task DiarizeAsync_ResponseWithStatusError_ThrowsWithErrorResponseReturned()
+    {
+        var runtime = new FakePythonRuntime();
+        var launcher = new FakeProcessLauncher();
+        launcher.SetResponse(
+            runtime.InterpreterPath,
+            exitCode: 0,
+            stdOut: """
+            {
+              "version": 1,
+              "status": "error",
+              "error": "wav file not found: /tmp/a.wav",
+              "speakers": [],
+              "segments": []
+            }
+            """);
+
+        var client = new PyannoteSidecarClient(runtime, launcher, ScriptPath, TimeSpan.FromSeconds(5));
+
+        var ex = await Assert.ThrowsAsync<DiarizationSidecarException>(
+            () => client.DiarizeAsync(new DiarizationRequest("/tmp/a.wav"), progress: null, CancellationToken.None));
+
+        Assert.Equal(SidecarFailureReason.ErrorResponseReturned, ex.Reason);
+        Assert.Contains("wav file not found", ex.Message);
+    }
+
+    [Fact]
+    public async Task DiarizeAsync_Timeout_ThrowsTimeout()
+    {
+        var runtime = new FakePythonRuntime();
+        var launcher = new FakeProcessLauncher();
+        launcher.SetNeverReturns(runtime.InterpreterPath);
+
+        var client = new PyannoteSidecarClient(
+            runtime, launcher, ScriptPath, timeout: TimeSpan.FromMilliseconds(100));
+
+        var ex = await Assert.ThrowsAsync<DiarizationSidecarException>(
+            () => client.DiarizeAsync(new DiarizationRequest("/tmp/a.wav"), progress: null, CancellationToken.None));
+
+        Assert.Equal(SidecarFailureReason.Timeout, ex.Reason);
+    }
+
+    [Fact]
+    public async Task DiarizeAsync_ExternalCancellation_ThrowsOperationCanceled()
+    {
+        var runtime = new FakePythonRuntime();
+        var launcher = new FakeProcessLauncher();
+        launcher.SetNeverReturns(runtime.InterpreterPath);
+
+        var client = new PyannoteSidecarClient(
+            runtime, launcher, ScriptPath, timeout: TimeSpan.FromSeconds(30));
+
+        using var cts = new CancellationTokenSource();
+        var task = client.DiarizeAsync(new DiarizationRequest("/tmp/a.wav"), progress: null, cts.Token);
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => task);
+    }
+
+    [Fact]
+    public async Task DiarizeAsync_ProgressOnStderr_ForwardsToReporter()
+    {
+        var runtime = new FakePythonRuntime();
+        var launcher = new FakeProcessLauncher();
+        launcher.SetResponse(
+            runtime.InterpreterPath,
+            exitCode: 0,
+            stdOut: """{"version":1,"status":"ok","speakers":[{"id":"A","totalDuration":1.0}],"segments":[{"speaker":"A","start":0.0,"end":1.0}]}""",
+            stdErr: """
+            {"stage":"loading_model"}
+            {"stage":"inferring","fraction":0.5}
+            """);
+
+        var reports = new List<SpeakerLabelingProgress>();
+        var progress = new ListProgress<SpeakerLabelingProgress>(reports);
+
+        var client = new PyannoteSidecarClient(runtime, launcher, ScriptPath, TimeSpan.FromSeconds(5));
+        await client.DiarizeAsync(new DiarizationRequest("/tmp/a.wav"), progress, CancellationToken.None);
+
+        Assert.Equal(2, reports.Count);
+        Assert.Equal("loading_model", reports[0].Stage);
+        Assert.Null(reports[0].Fraction);
+        Assert.Equal("inferring", reports[1].Stage);
+        Assert.Equal(0.5, reports[1].Fraction);
+    }
+
+    [Fact]
+    public async Task DiarizeAsync_SchemaViolation_ThrowsWithSchemaViolation()
+    {
+        var runtime = new FakePythonRuntime();
+        var launcher = new FakeProcessLauncher();
+        // Valid JSON, but missing required "speakers" field → schema violation.
+        launcher.SetResponse(
+            runtime.InterpreterPath,
+            exitCode: 0,
+            stdOut: """{"version":1,"status":"ok","segments":[]}""");
+
+        var client = new PyannoteSidecarClient(runtime, launcher, ScriptPath, TimeSpan.FromSeconds(5));
+
+        var ex = await Assert.ThrowsAsync<DiarizationSidecarException>(
+            () => client.DiarizeAsync(new DiarizationRequest("/tmp/a.wav"), progress: null, CancellationToken.None));
+
+        Assert.Equal(SidecarFailureReason.SchemaViolation, ex.Reason);
+    }
+
+    [Fact]
+    public async Task DiarizeAsync_RuntimeNotReady_ThrowsWithRuntimeNotReady()
+    {
+        var runtime = new FakePythonRuntime
+        {
+            NextStatus = PythonRuntimeStatus.NotReady("venv missing, call CreateVenv first")
+        };
+        var launcher = new FakeProcessLauncher();
+
+        var client = new PyannoteSidecarClient(runtime, launcher, ScriptPath, TimeSpan.FromSeconds(5));
+
+        var ex = await Assert.ThrowsAsync<DiarizationSidecarException>(
+            () => client.DiarizeAsync(new DiarizationRequest("/tmp/a.wav"), progress: null, CancellationToken.None));
+
+        Assert.Equal(SidecarFailureReason.RuntimeNotReady, ex.Reason);
+        Assert.Contains("venv missing", ex.Message);
+        Assert.Empty(launcher.Invocations);
+    }
+
+    private sealed class ListProgress<T> : IProgress<T>
+    {
+        private readonly List<T> _list;
+        public ListProgress(List<T> list) { _list = list; }
+        public void Report(T value) => _list.Add(value);
+    }
+}

--- a/tests/VoxFlow.Core.Tests/Services/Python/FakeProcessLauncher.cs
+++ b/tests/VoxFlow.Core.Tests/Services/Python/FakeProcessLauncher.cs
@@ -15,22 +15,28 @@ namespace VoxFlow.Core.Tests.Services.Python;
 /// </summary>
 internal sealed class FakeProcessLauncher : IProcessLauncher
 {
-    private readonly Dictionary<string, Func<ProcessStartInfo, CancellationToken, Task<ProcessExecutionResult>>> _handlers = new();
+    private readonly Dictionary<string, Func<ProcessStartInfo, string?, CancellationToken, Task<ProcessExecutionResult>>> _handlers = new();
     public List<ProcessStartInfo> Invocations { get; } = new();
+    public List<string?> StdInputs { get; } = new();
 
     public void SetResponse(string fileName, int exitCode, string stdOut, string stdErr = "")
     {
-        _handlers[fileName] = (_, _) => Task.FromResult(new ProcessExecutionResult(exitCode, stdOut, stdErr));
+        _handlers[fileName] = (_, _, _) => Task.FromResult(new ProcessExecutionResult(exitCode, stdOut, stdErr));
+    }
+
+    public void SetResponseFromStdin(string fileName, Func<string, ProcessExecutionResult> factory)
+    {
+        _handlers[fileName] = (_, stdIn, _) => Task.FromResult(factory(stdIn ?? string.Empty));
     }
 
     public void SetThrow(string fileName, Exception ex)
     {
-        _handlers[fileName] = (_, _) => throw ex;
+        _handlers[fileName] = (_, _, _) => throw ex;
     }
 
     public void SetNeverReturns(string fileName)
     {
-        _handlers[fileName] = async (_, ct) =>
+        _handlers[fileName] = async (_, _, ct) =>
         {
             await Task.Delay(Timeout.Infinite, ct).ConfigureAwait(false);
             throw new InvalidOperationException("unreachable");
@@ -38,14 +44,24 @@ internal sealed class FakeProcessLauncher : IProcessLauncher
     }
 
     public Task<ProcessExecutionResult> RunAsync(ProcessStartInfo startInfo, CancellationToken cancellationToken)
+        => RunInternalAsync(startInfo, stdIn: null, cancellationToken);
+
+    public Task<ProcessExecutionResult> RunAsync(ProcessStartInfo startInfo, string stdIn, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(stdIn);
+        return RunInternalAsync(startInfo, stdIn, cancellationToken);
+    }
+
+    private Task<ProcessExecutionResult> RunInternalAsync(ProcessStartInfo startInfo, string? stdIn, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(startInfo);
         Invocations.Add(startInfo);
+        StdInputs.Add(stdIn);
         if (!_handlers.TryGetValue(startInfo.FileName, out var handler))
         {
             throw new InvalidOperationException($"No fake response configured for '{startInfo.FileName}'.");
         }
 
-        return handler(startInfo, cancellationToken);
+        return handler(startInfo, stdIn, cancellationToken);
     }
 }


### PR DESCRIPTION
## Summary

Bridges \`IPythonRuntime\` and \`voxflow_diarize.py\` (ADR-024 Phase 0, step P0.6). \`PyannoteSidecarClient\` owns the full process-boundary contract:

- Writes the JSON request on stdin, reads the JSON response on stdout.
- Validates the response against the embedded \`sidecar-diarization-v1.schema.json\` via NJsonSchema.
- Forwards NDJSON progress lines from stderr to an \`IProgress<SpeakerLabelingProgress>\`.
- Enforces an internal timeout (linked with external cancellation) that kills the child process and raises \`Timeout\`.
- Short-circuits on \`RuntimeNotReady\` before launching.
- Maps every failure to a \`SidecarFailureReason\`: \`RuntimeNotReady\`, \`ProcessCrashed\`, \`Timeout\`, \`MalformedJson\`, \`SchemaViolation\`, \`ErrorResponseReturned\`.
- Surfaces failures via \`DiarizationSidecarException(Reason, message, inner?)\`.

\`IProcessLauncher\` gains a stdin-aware \`RunAsync\` overload; \`DefaultProcessLauncher\` writes+closes stdin before draining stdout. \`FakeProcessLauncher\` captures \`StdInputs\` and routes responses to the new overload so existing P0.3–P0.4 tests stay unchanged.

New models in \`VoxFlow.Core.Models\`: \`DiarizationRequest\`, \`DiarizationResult\`, \`DiarizationSpeaker\`, \`DiarizationSegment\`, \`SidecarFailureReason\`, \`SpeakerLabelingProgress\`.

## TDD

9 unit tests in \`PyannoteSidecarClientTests\` (mocked runtime + launcher), written red-first:

1. \`DiarizeAsync_HappyPath_ReturnsResultFromStdout\`
2. \`DiarizeAsync_NonZeroExit_ThrowsWithProcessCrashed\`
3. \`DiarizeAsync_MalformedJsonOnStdout_ThrowsWithMalformedJson\`
4. \`DiarizeAsync_ResponseWithStatusError_ThrowsWithErrorResponseReturned\`
5. \`DiarizeAsync_Timeout_ThrowsTimeout\`
6. \`DiarizeAsync_ExternalCancellation_ThrowsOperationCanceled\`
7. \`DiarizeAsync_ProgressOnStderr_ForwardsToReporter\`
8. \`DiarizeAsync_SchemaViolation_ThrowsWithSchemaViolation\`
9. \`DiarizeAsync_RuntimeNotReady_ThrowsWithRuntimeNotReady\`

3 integration tests in \`PyannoteSidecarClientIntegrationTests\` tagged \`[Trait(\"Category\", \"RequiresPython\")]\` at the class level, each a \`SkippableFact\` that \`Skip.IfNot(File.Exists(fixturePath), …)\` pending P0.8: single/two/three-speaker fixtures wired through real \`SystemPythonRuntime\` + \`DefaultProcessLauncher\` + real \`voxflow_diarize.py\`.

## Test plan

- [x] \`dotnet test VoxFlow.sln\` — green (329 passed, 7 skipped, 0 warnings)
- [x] \`dotnet test --filter Category=RequiresPython\` — green locally (fixture tests skip pending P0.8)