### PR TITLE
docs(local-speaker-labeling): phase 1/2/3 detailed delivery plans

### DIFF
--- a/docs/delivery/local-speaker-labeling/phase-1-enrichment.md
+++ b/docs/delivery/local-speaker-labeling/phase-1-enrichment.md
@@ -1,0 +1,486 @@
+# Phase 1 — Enrichment
+
+**Parent:** [Local Speaker Labeling — Delivery Plan](README.md)
+**ADR:** [ADR-024](../../adr/024-local-speaker-labeling-pipeline.md)
+**Status:** Planned
+
+---
+
+## Goal
+
+Wire the Phase 0 components into the real transcription pipeline behind the `speakerLabeling.enabled` flag. At the end of Phase 1, a developer who sets the flag to `true` in `appsettings.json` (or passes `--speakers` on the CLI / `enableSpeakers:true` via MCP) sees a speaker-labeled transcript in every supported output format and a new `.voxflow.json` artifact — without any Desktop UI work yet.
+
+Phase 1 is the first phase that touches user-visible behavior. Its most important invariant is **zero regression for users who do not turn on the flag**: every existing test for disabled speaker labeling must stay green with byte-identical output, and the pipeline must not spawn the sidecar at all in that path.
+
+## Exit Criteria
+
+- `transcription.speakerLabeling` section exists in both [appsettings.json](../../../appsettings.json) and [appsettings.example.json](../../../appsettings.example.json) with all four keys (`enabled`, `timeoutSeconds`, `pythonRuntimeMode`, `modelId`), defaults are `enabled=false`, and `TranscriptionOptions.LoadFromPath` exposes a typed `SpeakerLabelingOptions` property.
+- `TranscribeFileRequest` carries an optional `bool? EnableSpeakers` override that takes precedence over the config flag for a single invocation.
+- `ISpeakerEnrichmentService` exists and orchestrates `IDiarizationSidecar` + `ISpeakerMergeService`, including timeout and failure handling that never lets a sidecar failure abort transcription.
+- `TranscriptionService.TranscribeFileAsync` calls the enrichment service only when the effective flag is `true`; the disabled path is byte-identical to pre-Phase-1 (verified by a dedicated golden test).
+- `TranscribeFileResult` exposes `TranscriptDocument? SpeakerTranscript` and `IReadOnlyList<string> EnrichmentWarnings`; all failure modes surface through the warnings list and leave `SpeakerTranscript = null`.
+- Every output writer (`.txt`, `.srt`, `.vtt`, `.json`, `.md`) renders `Speaker A:` / `Speaker B:` prefixes when a `TranscriptDocument` is present, and produces its pre-Phase-1 output when `SpeakerTranscript` is `null` — proven by unit tests on both branches per formatter.
+- A new `.voxflow.json` artifact is written next to the configured result file whenever `SpeakerTranscript` is not `null`; its contents round-trip against `docs/contracts/voxflow-transcript-v1.schema.json`.
+- `IValidationService` has a new `CheckSpeakerLabelingPrerequisites` that runs only when the effective flag is `true`, surfaces actionable diagnostics for "runtime not ready" and "pyannote model not cached", and contributes to `ValidationResult.Checks` using the same status shape as the existing checks.
+- First-run bootstrap of `ManagedVenvRuntime` is reachable from the pipeline: when the runtime reports `NotReady` and `enabled=true`, the orchestrator triggers venv creation + requirements install, surfaces progress via `IProgress<ProgressUpdate>`, and is cancellable.
+- A new `ProgressStage.Diarizing` is plumbed end-to-end so the host receives progress updates while the sidecar is running.
+- `dotnet test` is fully green locally with zero regressions in the disabled path; the enabled path is covered by unit tests on mocked sidecar responses and (where Python 3.10+ is present) by `Category=RequiresPython` integration tests that go through the real orchestrator.
+- No Desktop UI changes, no CLI arg parser yet, no MCP schema changes yet — those land in Phase 2 and Phase 3.
+
+## Pre-conditions
+
+- Phase 0 is merged into `Local-Speaker-Labeling` and green on the integration branch.
+- `SpeakerMergeService` (P0.7), `PyannoteSidecarClient` (P0.6), both `IPythonRuntime` implementations (P0.3/P0.4), the sidecar script (P0.5), the transcript model (P0.2), and audio fixtures (P0.8) all exist and are unit-tested.
+- Developer machine has Python 3.10+ available locally so the orchestrator integration tests can be run before opening sub-PRs.
+
+## Non-goals (deferred to Phase 2 / Phase 3)
+
+- Desktop Ready-screen toggle and completion-screen colored rendering (Phase 2).
+- CLI `--speakers` argument parser and `appsettings` override mechanism (Phase 3).
+- MCP `enableSpeakers` tool parameter + tool schema update (Phase 3).
+- `StandaloneRuntime` / `python-build-standalone` bundle (Phase 3, conditional on spike outcome).
+- Speaker renaming, colored palettes, Okabe-Ito palette — all display-only concerns that belong in Phase 2.
+
+---
+
+## TDD Sequence
+
+Seven sub-PRs, in strict order. Each PR is the smallest unit that leaves the integration branch in a green-tests state, and each PR either introduces a new unit of behavior or wires an existing one into the pipeline — never both.
+
+Conventions for every PR below:
+- **Branch:** `speaker-labeling/p1.M-<slug>` off `Local-Speaker-Labeling`.
+- **Base for PR:** `Local-Speaker-Labeling`.
+- **Before `gh pr create`:** run `dotnet test VoxFlow.sln` locally and confirm no previously-green test has turned red. If the PR touches integration code, also run `dotnet test --filter "Category=RequiresPython"` on a machine with Python 3.10+ + pyannote available. Report both in the PR body.
+- **Test tagging:** same rules as Phase 0 — xUnit 2.9 traits; `[Trait("Category", "RequiresPython")]` for tests that spawn the real sidecar; `SkippableFact` when a test depends on environment state (runtime readiness, fixture presence, etc.).
+- **Commit authorship:** user only; no Co-Authored-By trailers.
+- **PR body:** no "Generated with Claude Code" footer.
+- **Disabled-path invariant:** every PR below must preserve byte-identical output when `speakerLabeling.enabled=false` AND `TranscribeFileRequest.EnableSpeakers` is `null`. Each sub-PR adds at least one regression guard test for this invariant on the code path it touches.
+
+---
+
+### P1.1 — `SpeakerLabelingOptions` config binding
+
+**Branch:** `speaker-labeling/p1.1-options`
+
+**Why first:** Everything downstream reads from `TranscriptionOptions.SpeakerLabeling`. The options type has to exist and be validated before any service can depend on it, and introducing it first keeps the PR a pure additive change — no pipeline wiring yet, only configuration shape plus loader.
+
+**Files touched (new):**
+- `src/VoxFlow.Core/Configuration/SpeakerLabelingOptions.cs` — immutable `sealed record` carrying `Enabled`, `TimeoutSeconds`, `PythonRuntimeMode`, `ModelId`. Includes a `Disabled` static instance for the default branch.
+- `src/VoxFlow.Core/Configuration/PythonRuntimeMode.cs` — enum `{ SystemPython, ManagedVenv, Standalone }`. `Standalone` is declared here even though its runtime lands in Phase 3; declaring the enum now keeps the config schema stable.
+- `tests/VoxFlow.Core.Tests/Configuration/SpeakerLabelingOptionsTests.cs`
+
+**Files touched (modified):**
+- `src/VoxFlow.Core/Configuration/TranscriptionOptions.cs` — add `public SpeakerLabelingOptions SpeakerLabeling { get; }`, populate it in the private constructor via a new `CreateSpeakerLabelingOptions` helper, and add a matching nullable `SpeakerLabelingConfiguration` class to `TranscriptionConfiguration` so JSON binding works. When the JSON section is absent, default to `SpeakerLabelingOptions.Disabled`.
+- [appsettings.json](../../../appsettings.json) and [appsettings.example.json](../../../appsettings.example.json) — add the `speakerLabeling` nested section inside `transcription` with `enabled=false`, `timeoutSeconds=600`, `pythonRuntimeMode="ManagedVenv"`, `modelId="pyannote/speaker-diarization-community-1"`. The example file must mirror the loader-compatible shape exactly; otherwise `TestSettingsFileFactory` drifts.
+
+**TDD steps:**
+
+1. **Red.** `SpeakerLabelingOptionsTests.Disabled_StaticInstance_HasEnabledFalse_AndHarmlessDefaults`. Compile fails: type doesn't exist.
+2. **Green.** Create the record and a `static readonly SpeakerLabelingOptions Disabled = new(Enabled: false, TimeoutSeconds: 600, RuntimeMode: PythonRuntimeMode.ManagedVenv, ModelId: "pyannote/speaker-diarization-community-1");`. Test passes.
+3. **Red.** `SpeakerLabelingOptionsTests.Construct_ValidInputs_ExposesFields`. Assert every property round-trips from the constructor.
+4. **Green.** Nothing to change — the record satisfies it. This is a guard test.
+5. **Red.** `SpeakerLabelingOptionsTests.Construct_NegativeTimeout_Throws`. Construct with `TimeoutSeconds = -1`, expect an `InvalidOperationException` mentioning the setting name.
+6. **Green.** Enforce validation in the record's primary constructor via a private helper.
+7. **Red.** `TranscriptionOptionsTests.LoadFromPath_SpeakerLabelingSectionPresent_ParsesAllFields`. Use `TestSettingsFileFactory` to write a settings file containing the section; load it; assert `options.SpeakerLabeling.Enabled == true` and the other three fields match.
+8. **Green.** Add `SpeakerLabelingConfiguration` DTO, `SpeakerLabeling` property on `TranscriptionConfiguration`, `SpeakerLabeling` property on `TranscriptionOptions`, and `CreateSpeakerLabelingOptions` helper that maps configuration → options (or returns `Disabled` if the section is null). Map `pythonRuntimeMode` string to the enum case-insensitively.
+9. **Red.** `TranscriptionOptionsTests.LoadFromPath_SpeakerLabelingSectionMissing_DefaultsToDisabled`. Existing test-generated settings files omit the section; assert `options.SpeakerLabeling.Enabled == false` and `options.SpeakerLabeling.Equals(SpeakerLabelingOptions.Disabled)`.
+10. **Green.** The helper already returns `Disabled` for null; this test confirms that backwards-compat promise holds.
+11. **Red.** `TranscriptionOptionsTests.LoadFromPath_UnknownRuntimeMode_Throws`. Write `pythonRuntimeMode="Wat"`; expect `InvalidOperationException` listing the valid names.
+12. **Green.** Add explicit switch-expression mapping with a default arm that throws.
+13. **Red.** Commit the updated `appsettings.json` and `appsettings.example.json`. Add `TranscriptionOptionsTests.LoadFromPath_RealAppsettingsJson_ParsesSpeakerLabelingDefaults` that uses the repo-root `appsettings.json` (via `TestSettingsFileFactory.LoadReal` or the existing test helper); asserts `enabled=false` by default, runtime mode is `ManagedVenv`.
+14. **Green.** Run the test; commit.
+15. **Refactor.** Make `SpeakerLabelingOptions.Disabled` the single source of truth for default values, and reuse it from `CreateSpeakerLabelingOptions` when any field is missing from JSON.
+
+**Blast radius — other test files that load `TranscriptionOptions`:**
+- `tests/VoxFlow.Core.Tests/TranscriptionOptionsTests.cs`
+- `tests/VoxFlow.Core.Tests/ConfigurationServiceTests.cs`
+- `tests/TestSupport/TestSettingsFileFactory.cs` (shared helper)
+- `tests/VoxFlow.Cli.Tests/*`, `tests/VoxFlow.Desktop.Tests/*`, `tests/VoxFlow.McpServer.Tests/*` that copy `appsettings.json` via the test support helper.
+
+The `SpeakerLabelingOptions.Disabled` fallback means these files do **not** need edits; the loader simply returns `Disabled` when their JSON is missing the section. Verifying this is the PR's self-check: `dotnet build` and `dotnet test` must succeed with no edits to the host tests.
+
+**Local verification before PR:**
+```
+dotnet test VoxFlow.sln
+```
+
+**PR description template:**
+```
+Add SpeakerLabelingOptions config section
+
+Introduces transcription.speakerLabeling nested section in appsettings.json
+with enabled/timeoutSeconds/pythonRuntimeMode/modelId keys (default
+enabled=false). TranscriptionOptions now exposes SpeakerLabeling via a
+typed record. Missing JSON section falls back to SpeakerLabelingOptions.Disabled
+so existing test fixtures and host apps continue to parse without edits.
+Pure additive change — no pipeline wiring, no Desktop/CLI/MCP surface yet.
+
+Test plan:
+- [x] dotnet test VoxFlow.sln — green, no regressions
+```
+
+---
+
+### P1.2 — `TranscribeFileRequest.EnableSpeakers` override
+
+**Branch:** `speaker-labeling/p1.2-request-override`
+
+**Why second:** Before the orchestrator exists, we need the public contract for per-invocation overrides. Adding it as a second trailing nullable parameter on `TranscribeFileRequest` is a pure-additive change that lets the CLI and MCP hosts override the config flag without duplicating configuration state. Shipping it as its own PR means P1.3 can depend on the field being present without also dragging in orchestrator logic.
+
+**Files touched (modified):**
+- `src/VoxFlow.Core/Models/TranscribeFileRequest.cs` — add `bool? EnableSpeakers = null` as a **trailing positional record parameter with a default**. The null default is load-bearing: it preserves every existing call site in `TranscriptionService`, `BatchTranscriptionService`, `DesktopCliTranscriptionService`, and the MCP tools.
+- `tests/VoxFlow.Core.Tests/Models/TranscribeFileRequestTests.cs` — new file holding one positional-construct test and one override-semantics test.
+
+**TDD steps:**
+
+1. **Red.** `TranscribeFileRequestTests.Construct_WithExistingPositionalArgs_StillCompiles_AndEnableSpeakersDefaultsToNull`. Calls the pre-existing 5-arg positional constructor and asserts `request.EnableSpeakers is null`. Compile fails: the field doesn't exist.
+2. **Green.** Add `bool? EnableSpeakers = null` as the sixth positional record parameter. Test passes.
+3. **Red.** `TranscribeFileRequestTests.Construct_WithEnableSpeakersTrue_PreservesValue`.
+4. **Green.** Already satisfied by the record's positional ctor.
+5. **Red.** Add a pipeline-invariant assertion elsewhere: in `TranscriptionServiceTests.TranscribeFileAsync_DisabledConfig_AndNullOverride_DoesNotCallEnrichment` (guard test that will be wired in P1.3 — for P1.2 this test is a placeholder that is compiled and passes trivially by checking that existing pipeline output is byte-identical for a request constructed with `EnableSpeakers=null`). Write it as a compiling but shallow test now; P1.3 will tighten it.
+
+**Blast radius:** every call site that constructs `TranscribeFileRequest` positionally continues to compile thanks to the trailing default. Touch nothing else in this PR. If any existing call site fails to build, the default is wrong and must be revisited before landing.
+
+**Local verification:**
+```
+dotnet test VoxFlow.sln
+```
+
+**PR description template:**
+```
+Add TranscribeFileRequest.EnableSpeakers override
+
+Adds an optional bool? EnableSpeakers parameter as a trailing positional
+record field, defaulting to null. This is the public hook that CLI and
+MCP hosts will use later to override speakerLabeling.enabled per request.
+Pure additive change — no new behavior, no pipeline wiring. Every existing
+positional call site compiles unchanged because of the null default.
+
+Test plan:
+- [x] dotnet test VoxFlow.sln — green
+```
+
+---
+
+### P1.3 — `ISpeakerEnrichmentService` orchestrator
+
+**Branch:** `speaker-labeling/p1.3-enrichment-service`
+
+**Why third:** This is where the Phase 0 components are finally composed. The service owns the runtime-readiness check, the sidecar call, the merge, the timeout envelope, and the failure taxonomy. It is the sole consumer of `IDiarizationSidecar` and `ISpeakerMergeService` within `TranscriptionService`. Shipping it as its own PR lets the downstream pipeline wiring (P1.4) be a trivial one-line call.
+
+**Files touched (new):**
+- `src/VoxFlow.Core/Interfaces/ISpeakerEnrichmentService.cs`
+- `src/VoxFlow.Core/Services/Diarization/SpeakerEnrichmentService.cs`
+- `src/VoxFlow.Core/Models/SpeakerEnrichmentResult.cs` — `{ TranscriptDocument? Document, IReadOnlyList<string> Warnings, bool RuntimeBootstrapped }`.
+- `tests/VoxFlow.Core.Tests/Services/Diarization/SpeakerEnrichmentServiceTests.cs`
+- `tests/VoxFlow.Core.Tests/Services/Diarization/FakeDiarizationSidecar.cs` — test double whose `DiarizeAsync` is driven by a delegate supplied per test.
+- `tests/VoxFlow.Core.Tests/Services/Diarization/FakePythonRuntime.cs` — test double that returns configurable `PythonRuntimeStatus` and simulates venv bootstrap via an `IProgress<VenvBootstrapStage>` reporter.
+
+**Interface shape:**
+```csharp
+public interface ISpeakerEnrichmentService
+{
+    Task<SpeakerEnrichmentResult> EnrichAsync(
+        string wavPath,
+        IReadOnlyList<FilteredSegment> segments,
+        TranscriptMetadata metadata,
+        SpeakerLabelingOptions options,
+        IProgress<ProgressUpdate>? progress,
+        CancellationToken cancellationToken);
+}
+```
+
+**Orchestration contract:**
+
+1. If `options.Enabled == false`, return an empty `SpeakerEnrichmentResult` synchronously without touching `IPythonRuntime` or `IDiarizationSidecar`. This is the hot-path short-circuit that guarantees zero cost for disabled users.
+2. Get runtime status via `IPythonRuntime.GetStatusAsync`.
+3. If status is `NotReady` and the runtime is `ManagedVenvRuntime` and the failure is "venv not yet created", attempt to bootstrap the venv. Forward bootstrap progress as `ProgressStage.Diarizing` updates with descriptive messages ("Creating Python environment...", "Installing diarization runtime...", "Verifying..."). Set `RuntimeBootstrapped=true` on success.
+4. If status is still `NotReady` after any bootstrap attempt, return with `Document=null` and a warning prefixed `"speaker-labeling: runtime not ready: "` followed by the status error.
+5. Apply the per-call timeout from `options.TimeoutSeconds` via `CancellationTokenSource.CreateLinkedTokenSource`.
+6. Call `IDiarizationSidecar.DiarizeAsync`. Forward the sidecar's own `IProgress<SpeakerLabelingProgress>` into the outer `IProgress<ProgressUpdate>` as `Diarizing` stage updates (percent maps from sidecar stage → linear within the 85–95 band of the pipeline, leaving the `Writing` stage at 95+).
+7. On `DiarizationSidecarException`, return with `Document=null` and a warning built from `reason` + `message`. Log (via tracing) but never rethrow.
+8. On `OperationCanceledException` where the outer token is not cancelled (i.e. timeout fired), return with `Document=null` and a warning `"speaker-labeling: timed out after {timeoutSeconds}s"`. If the outer token *is* cancelled, rethrow — the caller is shutting down.
+9. On success, call `ISpeakerMergeService.Merge(segments, diarization, metadata)` and return the resulting document with an empty warnings list.
+
+**TDD steps (unit, mocked runtime + sidecar):**
+
+1. **Red.** `SpeakerEnrichmentServiceTests.EnrichAsync_Disabled_ReturnsEmptyDocument_WithoutTouchingRuntime`. Fake runtime throws if called, fake sidecar throws if called. Pass `options.Enabled=false`. Assert `result.Document is null`, `result.Warnings` empty, fake counters both zero. Compile fails: types don't exist.
+2. **Green.** Create service and short-circuit path. Test passes.
+3. **Red.** `EnrichAsync_Enabled_RuntimeReady_CallsSidecarAndMerges`. Fake runtime returns `Ready`, fake sidecar returns a canned `DiarizationResult`. Assert `result.Document` non-null and equal to what the merge service would produce for the same inputs.
+4. **Green.** Wire `IDiarizationSidecar` + `ISpeakerMergeService`. Test passes.
+5. **Red.** `EnrichAsync_Enabled_RuntimeNotReady_VenvNotCreated_BootstrapsAndRecoversSuccessfully`. Fake runtime starts `NotReady` with the venv-missing error; on retry after bootstrap it reports `Ready`. Assert `result.RuntimeBootstrapped == true` and the sidecar was called exactly once.
+6. **Green.** Add the bootstrap branch. Because `SpeakerEnrichmentService` only knows about `IPythonRuntime`, the bootstrap call is exposed through a new `IManagedVenvBootstrapper` interface defaulted to `ManagedVenvRuntime`'s own method; inject a fake of this interface.
+7. **Red.** `EnrichAsync_Enabled_RuntimeNotReady_NonBootstrapable_ReturnsWarning`. Fake runtime returns `NotReady` with `"python3 not found on PATH"`; no bootstrapper should be called. Assert `result.Document is null`, single warning starts with `"speaker-labeling: runtime not ready:"`.
+8. **Green.** Branch on the error string or (better) on a new `PythonRuntimeStatus.CanBootstrap` boolean that `ManagedVenvRuntime` sets when the error is recoverable.
+9. **Red.** `EnrichAsync_Enabled_SidecarReturnsErrorResponse_ReturnsWarning`. Fake sidecar throws `DiarizationSidecarException(ErrorResponseReturned, "pyannote: CUDA OOM")`. Assert warning `"speaker-labeling: error-response-returned: pyannote: CUDA OOM"`, `Document` null.
+10. **Green.** Catch the exception, format the warning using `reason` in kebab-case.
+11. **Red.** `EnrichAsync_Enabled_SidecarCrashes_ReturnsWarning`. Throws with `ProcessCrashed`.
+12. **Green.** Same handling — the catch block already covers all `SidecarFailureReason` values.
+13. **Red.** `EnrichAsync_Enabled_SidecarTimesOut_ReturnsWarning_AndDoesNotRethrow`. Fake sidecar waits indefinitely; options.TimeoutSeconds=1. Assert warning `"speaker-labeling: timed out after 1s"` and no exception propagates.
+14. **Green.** Implement the linked-CTS + catch logic.
+15. **Red.** `EnrichAsync_OuterCancellation_Rethrows`. Cancel the outer token before the sidecar would return. Assert `OperationCanceledException` propagates.
+16. **Green.** Distinguish "timeout fired" from "outer cancel" using the linked-CTS source.
+17. **Red.** `EnrichAsync_Enabled_RuntimeReady_ForwardsProgressAsDiarizingStage`. Fake sidecar emits two `SpeakerLabelingProgress` updates at 25% and 75% sidecar-local. Assert the outer `IProgress<ProgressUpdate>` received two `Diarizing`-stage updates whose percent lies in [85, 95].
+18. **Green.** Implement the mapping helper.
+19. **Red.** `EnrichAsync_MergeServiceReturnsEmpty_ProducesWarning`. Fake sidecar returns an empty `DiarizationResult`; merge produces an empty `TranscriptDocument`. Assert `result.Document` is **not** null but has zero speakers, and `result.Warnings` contains `"speaker-labeling: diarization returned zero speakers"`. This guards the contract that merge failures do not crash — they are reported as warnings while still returning the (empty) document for debugging.
+20. **Green.** Add the post-merge sanity check.
+21. **Refactor.** Extract warning formatting into a private `FormatWarning(SidecarFailureReason, string)` method; ensure every reason enum value has a mapping.
+
+**Local verification:**
+```
+dotnet test VoxFlow.sln
+```
+
+**PR description template:**
+```
+Add SpeakerEnrichmentService orchestrator
+
+Composes IPythonRuntime, IDiarizationSidecar, and ISpeakerMergeService
+into a single EnrichAsync call. Owns runtime readiness, venv bootstrap,
+timeouts, cancellation, sidecar failure taxonomy, and progress mapping.
+Sidecar failures never crash the pipeline — they surface as warnings
+with a null Document. Fully unit-tested against fake runtime, bootstrapper,
+and sidecar; no real process spawned in tests.
+
+Test plan:
+- [x] dotnet test VoxFlow.sln — green
+```
+
+---
+
+### P1.4 — Pipeline wiring in `TranscriptionService`
+
+**Branch:** `speaker-labeling/p1.4-pipeline-wiring`
+
+**Why fourth:** Now that `ISpeakerEnrichmentService` exists, wiring it into [TranscriptionService.TranscribeFileAsync](../../../src/VoxFlow.Core/Services/TranscriptionService.cs) is a small, surgical change. The PR stays narrow: it does not touch output writers or the `.voxflow.json` artifact (P1.5 and P1.6). It only threads the enrichment result through the result record and plumbs the new progress stage.
+
+**Files touched (modified):**
+- `src/VoxFlow.Core/Services/TranscriptionService.cs` — add an injected `ISpeakerEnrichmentService`, inject `TranscriptionOptions` into `TranscribeFileAsync` as before, compute the effective `enabled` flag (`request.EnableSpeakers ?? options.SpeakerLabeling.Enabled`), call `EnrichAsync` between steps 7 (write output) and 8 (build preview) — **no**, between steps 6 and 7: enrichment must happen *before* the output is written so the writers in P1.5 can pick it up. Add the returned document and warnings to the result record.
+- `src/VoxFlow.Core/Models/TranscribeFileResult.cs` — add `TranscriptDocument? SpeakerTranscript` and `IReadOnlyList<string> EnrichmentWarnings` as **trailing positional record parameters with defaults** (`null` and `Array.Empty<string>()`). Existing call sites keep compiling.
+- `src/VoxFlow.Core/Models/ProgressUpdate.cs` — add `Diarizing` to the `ProgressStage` enum, positioned between `Filtering` and `Writing`. This is an additive enum change with no wire-format break.
+- `src/VoxFlow.Core/DependencyInjection/ServiceCollectionExtensions.cs` (or wherever `AddVoxFlowCore` lives) — register `ISpeakerEnrichmentService`, the sidecar client, runtime, and bootstrapper in the composition root. Resolve `IPythonRuntime` based on `options.SpeakerLabeling.PythonRuntimeMode` via a factory delegate (`SystemPython` → `SystemPythonRuntime`, `ManagedVenv` → `ManagedVenvRuntime`, `Standalone` → throw `NotSupportedException("Standalone runtime lands in Phase 3")`).
+- `tests/VoxFlow.Core.Tests/TranscriptionServiceTests.cs` — new test section for speaker-labeling branches.
+
+**TDD steps:**
+
+1. **Red.** `TranscriptionServiceTests.TranscribeFileAsync_DisabledConfig_AndNullOverride_DoesNotCallEnrichment`. Fake `ISpeakerEnrichmentService` that records calls; assert count is zero. Assert the returned `TranscribeFileResult.SpeakerTranscript is null` and `EnrichmentWarnings` is empty. Compile fails: `SpeakerTranscript`/`EnrichmentWarnings` don't exist.
+2. **Green.** Add the two new trailing record parameters with default values. Wire `TranscriptionService` to call `_enrichment.EnrichAsync` only when `effectiveEnabled == true`. For disabled, leave the defaults. Test passes.
+3. **Red.** `TranscribeFileAsync_EnabledViaConfig_CallsEnrichment_AndPropagatesDocument`. Load options with `enabled=true`; fake enrichment returns a document; assert the result carries the same document.
+4. **Green.** Pass the document through. Test passes.
+5. **Red.** `TranscribeFileAsync_EnabledViaConfig_ButRequestOverrideFalse_DoesNotCallEnrichment`. Request has `EnableSpeakers=false`, config has `enabled=true`; assert the enrichment fake was never called.
+6. **Green.** Add the `request.EnableSpeakers ?? options.SpeakerLabeling.Enabled` line.
+7. **Red.** `TranscribeFileAsync_DisabledViaConfig_ButRequestOverrideTrue_CallsEnrichment`. Mirror case.
+8. **Green.** Already covered by the same line.
+9. **Red.** `TranscribeFileAsync_EnrichmentReturnsWarnings_AreAppendedToResultWarnings`. Fake returns two enrichment warnings; assert both appear in `result.Warnings` AND in `result.EnrichmentWarnings`. (`Warnings` is the cross-pipeline bag; `EnrichmentWarnings` is a typed subset for the writers that want to filter by source.)
+10. **Green.** Append + populate both lists.
+11. **Red.** `TranscribeFileAsync_EnrichmentThrows_IsWrappedAsWarning_AndPipelineStillSucceeds`. This is a defence-in-depth test — `ISpeakerEnrichmentService` is contracted not to throw, but `TranscriptionService` must treat any thrown exception as a warning and continue so that a future bug in the enrichment service cannot take down the transcription pipeline.
+12. **Green.** Wrap the call in try/catch, format the warning as `"speaker-labeling: internal error: {message}"`.
+13. **Red.** `TranscribeFileAsync_ReportsProgressStageDiarizing_BetweenTranscribingAndWriting`. Assert the progress reporter received a `Diarizing` update with percent in [85, 95]. Ordering check: `Transcribing` → `Diarizing` → `Writing` → `Complete`.
+14. **Green.** Emit the progress bracket around the enrichment call.
+15. **Red.** Regression guard `TranscribeFileAsync_DisabledPath_ProducesByteIdenticalOutputAsPrePhase1`. Snapshot-compare against a pre-Phase-1 golden output file committed under `tests/goldens/transcribe-file-result-disabled.json`. The golden is captured before P1.4 lands by running the tests on the parent commit and checked in as part of this PR.
+16. **Green.** Confirm test passes without touching the disabled path.
+17. **Red.** `ServiceCollectionExtensionsTests.AddVoxFlowCore_RegistersSpeakerEnrichmentService`. Build a provider, resolve `ISpeakerEnrichmentService`, assert non-null. Assert resolving `IPythonRuntime` for each `PythonRuntimeMode` returns the expected concrete type (using an in-memory `TranscriptionOptions` seeded via the composition root's override hook).
+18. **Green.** Register the services with the correct runtime factory.
+19. **Refactor.** Extract `TranscriptionService.ComputeEffectiveSpeakerFlag(request, options)` into a single private static helper so the override rule has exactly one implementation.
+
+**Local verification:**
+```
+dotnet test VoxFlow.sln
+dotnet test VoxFlow.sln --filter "Category=RequiresPython"   # optional: only runs real sidecar when Python 3.10+ present
+```
+
+**PR description template:**
+```
+Wire SpeakerEnrichmentService into TranscriptionService
+
+Calls enrichment between language selection and output writing when the
+effective speaker flag is true (request.EnableSpeakers ?? options.SpeakerLabeling.Enabled).
+Propagates the resulting TranscriptDocument and warnings through
+TranscribeFileResult via new trailing record fields (defaults preserve
+every existing call site). Adds ProgressStage.Diarizing between
+Transcribing and Writing. Disabled path is byte-identical to pre-Phase-1,
+verified by a golden-output regression test.
+
+Test plan:
+- [x] dotnet test VoxFlow.sln — green
+- [x] dotnet test VoxFlow.sln --filter "Category=RequiresPython" — green locally
+```
+
+---
+
+### P1.5 — Output writer speaker rendering
+
+**Branch:** `speaker-labeling/p1.5-output-writers`
+
+**Why fifth:** Rendering is purely about presentation and can happen once the pipeline delivers a `TranscriptDocument`. Splitting it from P1.4 keeps each PR small and lets the writer work land without touching the pipeline again.
+
+**Files touched (modified):**
+- `src/VoxFlow.Core/Models/TranscriptOutputContext.cs` — add `TranscriptDocument? SpeakerTranscript` as a trailing init-only property with default `null`.
+- `src/VoxFlow.Core/Services/TranscriptionService.cs` — pass `outputContext with { SpeakerTranscript = enrichmentResult.Document }` into the existing `_outputWriter.WriteAsync` call. One-line change, no behavioral shift when `Document` is null.
+- `src/VoxFlow.Core/Services/Formatters/TxtTranscriptFormatter.cs` — when `context.SpeakerTranscript is not null`, render each `SpeakerTurn` as `Speaker {Label}: {text}` on its own line; when null, render the current segment-based format unchanged.
+- `src/VoxFlow.Core/Services/Formatters/MdTranscriptFormatter.cs` — mirror the same rule using `**Speaker {Label}:**` markdown emphasis.
+- `src/VoxFlow.Core/Services/Formatters/SrtTranscriptFormatter.cs` — prepend `Speaker {Label}: ` to the cue text of the first word of each turn; timing cues are still segment-based, not turn-based (we do not rewrite the cue boundaries — the subtitle track stays compatible with existing player expectations). When `SpeakerTranscript` is null, the formatter's output is unchanged.
+- `src/VoxFlow.Core/Services/Formatters/VttTranscriptFormatter.cs` — same rule as SRT but using `<v Speaker A>` voice tags when a `TranscriptDocument` is present (standard WebVTT speaker syntax); fallback unchanged.
+- `src/VoxFlow.Core/Services/Formatters/JsonTranscriptFormatter.cs` — when `SpeakerTranscript` is not null, emit the full `TranscriptDocument` as the top-level object alongside the existing segments array; when null, emit the current segment-based shape unchanged. The shape follows `voxflow-transcript-v1` schema, not a new shape.
+- `tests/VoxFlow.Core.Tests/Formatters/*.cs` — add one "with speakers" test per formatter alongside existing tests; keep every existing test unchanged.
+
+**TDD steps (one formatter at a time — five mini-cycles):**
+
+For each formatter in the order `Txt`, `Md`, `Json`, `Srt`, `Vtt`:
+
+1. **Red.** `<Formatter>Tests.Format_WithTwoSpeakerDocument_RendersSpeakerPrefixes`. Construct a `TranscriptDocument` with two speakers and 4 words → 2 turns. Call the formatter. Assert output contains `Speaker A:` (or format-specific equivalent) and `Speaker B:` in the expected positions. Compile passes (context field already exists from the first sub-step below), assertion fails.
+2. **Green.** Implement the speaker-aware branch in the formatter. The branch is gated on `context.SpeakerTranscript is not null`; otherwise the formatter's existing body runs untouched.
+3. **Red.** `<Formatter>Tests.Format_WithNullSpeakerTranscript_ProducesLegacyOutputUnchanged`. Same input, `context.SpeakerTranscript is null`. Byte-compare against a golden string captured before this PR. Must pass — the regression guard.
+4. **Green.** Should already pass. If it doesn't, the branch is leaking into the disabled path and needs to be restructured.
+
+The `TranscriptOutputContext.SpeakerTranscript` field is added as the first sub-step of the whole PR (before the per-formatter cycles) so every formatter test compiles. That single-line model change does not need its own TDD cycle beyond a compile check.
+
+**Blast radius — existing formatter tests:**
+- `TxtTranscriptFormatterTests`, `MdTranscriptFormatterTests`, `JsonTranscriptFormatterTests`, `SrtTranscriptFormatterTests`, `VttTranscriptFormatterTests`, `OutputWriterTests`.
+
+All of these must stay green without edits. The golden-output regression tests in step 3 above are the explicit check. If any existing test needs a touch-up, the PR is wrong.
+
+**Local verification:**
+```
+dotnet test VoxFlow.sln
+```
+
+**PR description template:**
+```
+Render speaker labels from TranscriptDocument in output writers
+
+All five formatters (.txt, .srt, .vtt, .json, .md) now emit
+"Speaker A:" / "Speaker B:" prefixes when TranscriptOutputContext
+carries a non-null TranscriptDocument. Disabled path (null document)
+produces byte-identical legacy output, verified per-formatter against
+golden strings. JSON formatter emits the full voxflow-transcript-v1
+shape when speakers are present.
+
+Test plan:
+- [x] dotnet test VoxFlow.sln — green (no existing formatter test touched)
+```
+
+---
+
+### P1.6 — `.voxflow.json` artifact
+
+**Branch:** `speaker-labeling/p1.6-voxflow-json`
+
+**Why sixth:** The `.voxflow.json` artifact is a separate sidecar file, not a replacement for the primary output. Isolating it into its own PR keeps the blast radius small: only the writer pipeline changes, not any existing formatter.
+
+**Files touched (new):**
+- `src/VoxFlow.Core/Services/VoxflowTranscriptArtifactWriter.cs` — serializes a `TranscriptDocument` to `{resultPath}.voxflow.json` using the schema-compatible shape.
+- `src/VoxFlow.Core/Interfaces/IVoxflowTranscriptArtifactWriter.cs`
+- `tests/VoxFlow.Core.Tests/Services/VoxflowTranscriptArtifactWriterTests.cs`
+
+**Files touched (modified):**
+- `src/VoxFlow.Core/Services/TranscriptionService.cs` — after the main output write, if `enrichmentResult.Document is not null`, also call the artifact writer. Single new conditional statement.
+- `src/VoxFlow.Core/DependencyInjection/ServiceCollectionExtensions.cs` — register the writer as `IVoxflowTranscriptArtifactWriter`.
+- `docs/contracts/voxflow-transcript-v1.schema.json` — already added in P0.2; no change expected, but add a test that round-trips a realistic 3-speaker document against the schema to catch any drift.
+
+**TDD steps:**
+
+1. **Red.** `VoxflowTranscriptArtifactWriterTests.WriteAsync_WithDocument_WritesFileAtExpectedPath`. Given `resultPath="/tmp/out.txt"`, assert file exists at `/tmp/out.txt.voxflow.json`. Compile fails: type doesn't exist.
+2. **Green.** Create the writer. Path rule: append `.voxflow.json` to the caller's result path (even if the result path ends in `.txt` / `.srt` / etc.). This keeps the `.voxflow.json` paired with whatever primary format was selected.
+3. **Red.** `WriteAsync_RoundTrip_ProducesEqualDocument`. Serialize, read back via `System.Text.Json`, assert equality.
+4. **Green.** Use the same `JsonSerializerOptions` from `JsonTranscriptFormatter`: camelCase, indented, ignore nulls. Test passes.
+5. **Red.** `WriteAsync_ValidatesAgainstVoxflowTranscriptSchema`. Write, read, validate with NJsonSchema. Must pass the schema committed in P0.2.
+6. **Green.** If schema and writer diverge, fix whichever is wrong — schema takes precedence (`v1` is frozen once Phase 0 ships).
+7. **Red.** `WriteAsync_Cancelled_DoesNotLeavePartialFile`. Cancel the token mid-write; assert the `.voxflow.json` file does not exist (or at most an empty file is cleaned up).
+8. **Green.** Write to a temp file + atomic rename (`File.Move` with overwrite).
+9. **Red.** `TranscriptionServiceTests.TranscribeFileAsync_EnabledWithDocument_WritesVoxflowJsonArtifact`. Run the service with a fake enrichment returning a document; assert the writer was called once with the expected path.
+10. **Green.** Wire the single conditional call in `TranscriptionService`.
+11. **Red.** `TranscribeFileAsync_EnabledWithNullDocument_DoesNotWriteArtifact`. Enrichment returns a null document (e.g. sidecar failure); assert the writer was NOT called.
+12. **Green.** Already handled by the conditional.
+13. **Red.** `TranscribeFileAsync_DisabledPath_DoesNotWriteArtifact`. Regression guard.
+14. **Green.** Already covered.
+
+**Local verification:**
+```
+dotnet test VoxFlow.sln
+```
+
+**PR description template:**
+```
+Write .voxflow.json transcript artifact
+
+New VoxflowTranscriptArtifactWriter produces a sidecar JSON file at
+{resultPath}.voxflow.json whenever the enrichment pipeline returns a
+TranscriptDocument. Schema-validated against voxflow-transcript-v1.
+Atomic temp-file + rename for cancellation safety. No effect on the
+primary output file. Disabled path (enabled=false or null document)
+writes no artifact — verified by regression tests.
+
+Test plan:
+- [x] dotnet test VoxFlow.sln — green
+```
+
+---
+
+### P1.7 — `IValidationService` preflight for speaker labeling
+
+**Branch:** `speaker-labeling/p1.7-validation`
+
+**Why seventh:** Preflight surfaces "your setup is not ready for speaker labeling" errors before the pipeline runs, which is valuable but not load-bearing — the pipeline already degrades gracefully when the runtime is unavailable. Isolating validation into its own PR keeps the earlier PRs pure pipeline changes.
+
+**Files touched (modified):**
+- `src/VoxFlow.Core/Services/ValidationService.cs` — add `CheckSpeakerLabelingPrerequisitesAsync` that runs only when `options.SpeakerLabeling.Enabled==true`, returns a sequence of `ValidationCheck` entries, and is appended to the existing `Checks` list. Gated by the existing `options.StartupValidation.Enabled` switch so users can turn preflight off entirely.
+- `src/VoxFlow.Core/Configuration/TranscriptionOptions.cs` — extend `StartupValidationOptions` and its configuration DTO with a new `bool CheckSpeakerLabelingRuntime { get; }` that defaults to `true` when absent. Mirror in `appsettings.json` and `appsettings.example.json`.
+- `tests/VoxFlow.Core.Tests/Services/ValidationServiceTests.cs` — new test section.
+
+**Check semantics:**
+
+1. Runtime-ready check: call `IPythonRuntime.GetStatusAsync`. If `IsReady`, record an info-level success check. If not, record a warning (pipeline still runs, but enrichment will self-report).
+2. Model-cache check: inspect the pyannote cache directory (`~/Library/Caches/VoxFlow/models/`). If the configured `modelId` is not cached, record a warning — "first run will download ~300 MB". This is informational, not blocking.
+3. Both checks contribute to `ValidationResult.Checks` via the existing `ValidationCheck` record with `ValidationCheckStatus.Warning` or `.Passed`. Neither blocks startup — the pipeline is resilient by design.
+
+**TDD steps:**
+
+1. **Red.** `ValidationServiceTests.ValidateAsync_SpeakerLabelingDisabled_DoesNotRunSpeakerChecks`. Fake runtime throws if called; `options.SpeakerLabeling.Enabled=false`. Assert no checks mention speaker labeling.
+2. **Green.** Gate the new checks on the effective flag.
+3. **Red.** `ValidateAsync_Enabled_RuntimeReady_AddsPassedCheck`.
+4. **Green.** Emit `ValidationCheck(Name="Speaker labeling runtime", Status=Passed, Details=$"Python {version} ready")`.
+5. **Red.** `ValidateAsync_Enabled_RuntimeNotReady_AddsWarningCheck`. Assert status is `Warning` (not `Failed`) and `CanStart` is unaffected.
+6. **Green.** Map `PythonRuntimeStatus.NotReady` to a warning check.
+7. **Red.** `ValidateAsync_Enabled_ModelNotCached_AddsInformationalWarning`. Fake `IFileSystem` (add a minimal wrapper if none exists) reports the cache directory is missing.
+8. **Green.** Add the cache-path probe. Use an injectable helper so tests don't touch the real filesystem.
+9. **Red.** `ValidateAsync_Enabled_StartupValidationGloballyDisabled_SkipsSpeakerChecks`. Sets `StartupValidation.Enabled=false`; assert no speaker-labeling checks added, matching existing behavior for every other check.
+10. **Green.** Respect the existing gate.
+11. **Red.** `ValidateAsync_SpeakerChecks_DoNotAffectCanStart_EvenOnFailure`. Multiple warnings in a row; `ValidationResult.CanStart` must remain `true` because none of the new checks are marked `Failed`.
+12. **Green.** Covered by the warning-only mapping.
+
+**Local verification:**
+```
+dotnet test VoxFlow.sln
+```
+
+**PR description template:**
+```
+Add speaker-labeling preflight checks to ValidationService
+
+When transcription.speakerLabeling.enabled is true AND startupValidation
+is on, ValidationService probes IPythonRuntime.GetStatusAsync and the
+pyannote model cache directory. Both emit informational warnings on
+misconfiguration — never Failed — so the pipeline remains resilient
+even if preflight misreports. New startupValidation.checkSpeakerLabelingRuntime
+toggle (default true) for users who want to disable the probe explicitly.
+
+Test plan:
+- [x] dotnet test VoxFlow.sln — green
+```
+
+---
+
+## Post-Phase-1 Checklist
+
+Before declaring Phase 1 complete and moving to Phase 2 planning:
+
+- [ ] All 7 sub-PRs merged into `Local-Speaker-Labeling`.
+- [ ] `dotnet test VoxFlow.sln` on `Local-Speaker-Labeling` is fully green.
+- [ ] `dotnet test --filter "Category=RequiresPython"` is fully green on a developer machine with Python 3.10+ + pyannote installed (runs the real orchestrator end-to-end against the P0.8 fixtures through `TranscriptionService`).
+- [ ] Disabled-path regression: running the existing Desktop headless test suite (`VoxFlow.Desktop.Tests`) produces the same results as before Phase 1 — no test required edits, golden outputs unchanged.
+- [ ] Manual smoke: enable `speakerLabeling.enabled=true` locally, run the CLI against `artifacts/input/President Obama Speech.m4a`, confirm `Speaker A:` prefixes appear in the output file and a `.voxflow.json` sidecar is written.
+- [ ] Manual smoke: set `enabled=true` but force a sidecar failure (point `modelId` at a non-existent model) and confirm the transcript still writes successfully, the warnings list contains a `speaker-labeling:` entry, and no `.voxflow.json` artifact appears.
+- [ ] `docs/runbooks/speaker-labeling.md` has a stub committed (full content lands in Phase 3, but a placeholder reserves the path and links back to this phase doc for context).
+- [ ] No files under `src/VoxFlow.Desktop`, `src/VoxFlow.Cli`, or `src/VoxFlow.McpServer` touch speaker labeling yet — those are Phase 2 and Phase 3.
+- [ ] User has reviewed the integration branch state and approved starting Phase 2.

--- a/docs/delivery/local-speaker-labeling/phase-2-desktop-ui.md
+++ b/docs/delivery/local-speaker-labeling/phase-2-desktop-ui.md
@@ -1,0 +1,344 @@
+# Phase 2 — Desktop UI
+
+**Parent:** [Local Speaker Labeling — Delivery Plan](README.md)
+**ADR:** [ADR-024](../../adr/024-local-speaker-labeling-pipeline.md)
+**Status:** Planned
+
+---
+
+## Goal
+
+Expose the Phase 1 enrichment pipeline through the Mac Catalyst Desktop app: let users toggle speaker labeling from the Ready screen, see a `Diarizing` stage in the progress UI, and read a colored speaker-labeled transcript on the completion screen. At the end of Phase 2, a Desktop user can enable the feature, transcribe a multi-speaker file, and see turn-taking rendered with a colorblind-safe palette — without any CLI or MCP changes yet.
+
+Phase 2 is a pure presentation phase: no new Core services, no new output formats, no config shape changes. It consumes the `TranscribeFileResult.SpeakerTranscript` and `EnrichmentWarnings` fields that Phase 1 already populates, and it persists the new Ready-screen toggle through the existing `DesktopConfigurationService.SaveUserOverridesAsync` mechanism (the same mechanism `SettingsPanel.razor` uses today for the output format picker).
+
+## Exit Criteria
+
+- The Ready-screen `SettingsPanel` has a new speaker-labeling toggle whose initial state is bound to `TranscriptionOptions.SpeakerLabeling.Enabled`.
+- Toggling the switch persists back to `appsettings.json` via `DesktopConfigurationService.SaveUserOverridesAsync` under the `transcription.speakerLabeling.enabled` key.
+- `AppViewModel.TranscribeFileAsync` forwards the toggle state to the `TranscribeFileRequest` via `EnableSpeakers` so the user's last toggle is honored even if the underlying config has not been reloaded.
+- `ProgressStage.Diarizing` updates reach the `RunningView` and render a stage label (`"Identifying speakers..."`) in the same style as the existing stage labels.
+- `CompleteView` renders the `TranscriptDocument` as colored speaker turns when `TranscriptionResult.SpeakerTranscript` is not null. When it is null (feature off, or sidecar failure), the view falls back to the existing plain-text preview — no regressions.
+- Speaker colors come from the Okabe-Ito 8-color colorblind-safe palette. Speakers beyond the palette size wrap around modulo 8, and the cycle is documented inline so contributors know why.
+- Enrichment warnings (`result.EnrichmentWarnings`) are visible to the user via a non-blocking info banner on the completion screen, matching the existing `message message-warning` styling.
+- New Razor component tests cover the toggle, the colored transcript renderer, the warning banner, and the fallback-to-plain-text branch.
+- `dotnet test tests/VoxFlow.Desktop.Tests/VoxFlow.Desktop.Tests.csproj` is fully green locally.
+- No Core service, CLI, or MCP files are touched in Phase 2.
+
+## Pre-conditions
+
+- Phase 1 is merged into `Local-Speaker-Labeling` and green on the integration branch.
+- `TranscribeFileResult.SpeakerTranscript` and `EnrichmentWarnings` are populated by `TranscriptionService` when the flag is on.
+- `DesktopConfigurationService` already supports `SaveUserOverridesAsync` with a `Dictionary<string, object>` — see [SettingsPanel.razor](../../../src/VoxFlow.Desktop/Components/Shared/SettingsPanel.razor) for the canonical usage pattern.
+
+## Non-goals
+
+- CLI `--speakers` flag (Phase 3).
+- MCP `enableSpeakers` tool parameter (Phase 3).
+- Runbook and long-form user documentation (Phase 3).
+- Editing, renaming, or re-assigning speakers (explicitly out of scope for this delivery — see [README.md](README.md) "Out of Scope").
+- Custom palettes, dark-mode variants beyond what the existing Desktop CSS already supports.
+
+---
+
+## TDD Sequence
+
+Four sub-PRs, in strict order.
+
+Conventions for every PR below:
+- **Branch:** `speaker-labeling/p2.M-<slug>` off `Local-Speaker-Labeling`.
+- **Base for PR:** `Local-Speaker-Labeling`.
+- **Before `gh pr create`:** run `dotnet test VoxFlow.sln` locally. The Desktop test suite does not spawn a Python sidecar, so there is no separate `RequiresPython` command to run for Phase 2 PRs unless the PR touches the orchestrator path (which it should not).
+- **Test tagging:** Razor component tests live in `VoxFlow.Desktop.Tests` and use the existing infrastructure under `tests/VoxFlow.Desktop.Tests/Infrastructure`. No new trait is introduced.
+- **Commit authorship:** user only; no Co-Authored-By trailers.
+- **PR body:** no "Generated with Claude Code" footer.
+- **Disabled-path invariant:** every PR must keep existing Desktop UI tests green without edits. If a test requires a touch-up, re-examine whether the new code is accidentally leaking into the disabled path.
+
+---
+
+### P2.1 — Ready-screen speaker labeling toggle
+
+**Branch:** `speaker-labeling/p2.1-ready-toggle`
+
+**Why first:** The toggle is the user's entry point into the feature; until it exists, the rest of the Desktop experience is unreachable without hand-editing `appsettings.json`. It is also the smallest self-contained UI change, so it sets the testing pattern for the next three PRs.
+
+**Files touched (new):**
+- `src/VoxFlow.Desktop/Components/Shared/SpeakerLabelingToggle.razor` — a component encapsulating the toggle switch, its label, and an explanatory subtitle (`"Identify who spoke each segment"`).
+- `tests/VoxFlow.Desktop.Tests/Components/SpeakerLabelingToggleTests.cs`
+
+**Files touched (modified):**
+- `src/VoxFlow.Desktop/Components/Shared/SettingsPanel.razor` — add the new component below the format picker with `IsDisabled="IsDisabled"`.
+- `src/VoxFlow.Desktop/ViewModels/AppViewModel.cs` — add `public bool SpeakerLabelingEnabled { get; set; }`, initialized from `options.SpeakerLabeling.Enabled` in the same place `SelectedResultFormat` is initialized (`LoadOptionsAsync` or equivalent). Raise `OnPropertyChanged` on set if the view model uses change notification; otherwise follow the existing `SelectedResultFormat` pattern verbatim.
+- `src/VoxFlow.Desktop/Services/DesktopConfigurationService.cs` — extend `SaveUserOverridesAsync` if needed so it can accept nested keys like `"speakerLabeling.enabled"`, then write to the `transcription.speakerLabeling.enabled` path in the JSON. If the existing implementation already supports dotted keys (check before editing), use it as-is. If it flattens to a single `transcription.X` layer, add a small extension branch that recognizes `speakerLabeling` as a nested object and merges instead of overwriting.
+
+**Toggle component shape:**
+```razor
+@* SpeakerLabelingToggle.razor *@
+@inject AppViewModel ViewModel
+@inject DesktopConfigurationService ConfigService
+
+<div class="speaker-toggle" id="speaker-labeling-toggle" aria-label="Speaker labeling toggle">
+    <div class="speaker-toggle-body">
+        <div class="speaker-toggle-labels">
+            <span class="speaker-toggle-title">Speaker labeling</span>
+            <span class="speaker-toggle-subtitle">Identify who spoke each segment</span>
+        </div>
+        <button role="switch"
+                id="speaker-labeling-switch"
+                aria-checked="@(ViewModel.SpeakerLabelingEnabled ? "true" : "false")"
+                class="speaker-toggle-switch @(ViewModel.SpeakerLabelingEnabled ? "on" : "off")"
+                disabled="@IsDisabled"
+                @onclick="Toggle">
+            <span class="speaker-toggle-thumb"></span>
+        </button>
+    </div>
+</div>
+
+@code {
+    [Parameter] public bool IsDisabled { get; set; }
+
+    private async Task Toggle()
+    {
+        if (IsDisabled) return;
+        ViewModel.SpeakerLabelingEnabled = !ViewModel.SpeakerLabelingEnabled;
+        try
+        {
+            await ConfigService.SaveUserOverridesAsync(new Dictionary<string, object>
+            {
+                ["speakerLabeling.enabled"] = ViewModel.SpeakerLabelingEnabled
+            });
+        }
+        catch
+        {
+            // Persistence is best-effort; in-memory state wins the current session.
+        }
+    }
+}
+```
+
+**TDD steps:**
+
+1. **Red.** `SpeakerLabelingToggleTests.InitialState_MatchesViewModel`. Render the component under a test host with `ViewModel.SpeakerLabelingEnabled = false`; assert `aria-checked="false"`. Compile fails: component doesn't exist.
+2. **Green.** Create the component with the markup above (minus the toggle logic) and wire the parameter. Test passes.
+3. **Red.** `Click_Toggles_ViewModelState`. Click the switch; assert `ViewModel.SpeakerLabelingEnabled == true`.
+4. **Green.** Implement the `Toggle` handler.
+5. **Red.** `Click_PersistsOverride_ViaDesktopConfigurationService`. Use a fake `DesktopConfigurationService` that records calls; click; assert it was called once with `speakerLabeling.enabled = true`.
+6. **Green.** Pass a fake via the existing test DI setup (see `DesktopUiComponentTests` for the pattern).
+7. **Red.** `Click_PersistenceFailure_DoesNotCrash_AndKeepsInMemoryState`. Fake throws; click; assert no exception bubbles up and the view-model flag is still set.
+8. **Green.** Wrap the save in try/catch.
+9. **Red.** `Disabled_PreventsClicks_AndToggling`. Render with `IsDisabled=true`; click; assert state unchanged and `disabled` attribute is present.
+10. **Green.** Already handled by the early return.
+11. **Red.** `AppViewModelTests.SpeakerLabelingEnabled_InitializesFromOptions`. Load options with `SpeakerLabeling.Enabled=true`; assert the view-model flag matches after `LoadOptionsAsync`.
+12. **Green.** Initialize in the same helper that sets `SelectedResultFormat`.
+13. **Red.** `SettingsPanelTests.RendersSpeakerLabelingToggle_BelowFormatPicker`. Render the parent panel; assert the new component is present with the correct element id.
+14. **Green.** Add the `<SpeakerLabelingToggle />` markup at the bottom of `SettingsPanel.razor`.
+15. **Refactor.** If `DesktopConfigurationService.SaveUserOverridesAsync` needed an adjustment to handle nested keys, add a dedicated unit test for that helper under `DesktopConfigurationTests.cs`.
+
+**Local verification:**
+```
+dotnet test tests/VoxFlow.Desktop.Tests/VoxFlow.Desktop.Tests.csproj
+dotnet test VoxFlow.sln
+```
+
+**PR description template:**
+```
+Add speaker labeling toggle to Ready-screen settings panel
+
+New SpeakerLabelingToggle.razor component rendered below the format picker.
+Reflects transcription.speakerLabeling.enabled from appsettings.json on load
+and persists user changes via DesktopConfigurationService.SaveUserOverridesAsync.
+AppViewModel.SpeakerLabelingEnabled is the single source of truth for the
+current session and will be forwarded to TranscribeFileRequest.EnableSpeakers
+in P2.2.
+
+Test plan:
+- [x] dotnet test tests/VoxFlow.Desktop.Tests/VoxFlow.Desktop.Tests.csproj — green
+- [x] dotnet test VoxFlow.sln — green, no regressions in other projects
+```
+
+---
+
+### P2.2 — Forward toggle to `TranscribeFileRequest` + Diarizing progress stage
+
+**Branch:** `speaker-labeling/p2.2-running-view`
+
+**Why second:** Once the toggle exists it must actually reach the pipeline, and while we are touching the request construction in `AppViewModel.TranscribeFileAsync` we can also wire the new `ProgressStage.Diarizing` into the `RunningView`. Both edits live in adjacent code, so splitting them into separate PRs would mean two near-identical round-trips through the view-model; bundling them keeps the change surgical.
+
+**Files touched (modified):**
+- `src/VoxFlow.Desktop/ViewModels/AppViewModel.cs` — in `TranscribeFileAsync`, change `new TranscribeFileRequest(filePath)` to pass `EnableSpeakers: SpeakerLabelingEnabled ? true : null` as the sixth positional argument. The null fallback means the config-file default still applies when the toggle is off — identical to the user manually setting the flag in JSON.
+- `src/VoxFlow.Desktop/Components/Pages/RunningView.razor` (or whichever file renders `ProgressStage` labels — check before editing) — add a `case ProgressStage.Diarizing` arm returning `"Identifying speakers..."` with the same CSS class as the existing stage labels.
+- `tests/VoxFlow.Desktop.Tests/AppViewModelTests.cs` — new tests for the request forwarding and the progress stage label.
+
+**TDD steps:**
+
+1. **Red.** `AppViewModelTests.TranscribeFileAsync_SpeakerLabelingEnabled_PassesEnableSpeakersTrue`. Use the existing `FakeTranscriptionService` from the Desktop test infra; record the received request; assert `request.EnableSpeakers == true`. Compile fails because AppViewModel currently constructs a 1-arg request.
+2. **Green.** Pass the sixth positional argument `EnableSpeakers: SpeakerLabelingEnabled`. Use `SpeakerLabelingEnabled ? true : null` so the off-toggle falls back to config. Test passes.
+3. **Red.** `TranscribeFileAsync_SpeakerLabelingDisabled_PassesEnableSpeakersNull`. Assert the field is `null`, not `false`, so the config default still wins.
+4. **Green.** Already handled by the ternary.
+5. **Red.** `RunningViewTests.RendersDiarizingStageLabel`. Publish a `ProgressUpdate { Stage = Diarizing, PercentComplete = 90 }` to the view-model; assert the UI contains `"Identifying speakers..."`.
+6. **Green.** Add the case arm; reuse the existing stage-label component if one exists.
+7. **Red.** `RunningViewTests.DoesNotBreakExistingStages`. Publish `Transcribing`, `Writing`, `Complete` in sequence; assert each label still renders as before.
+8. **Green.** Should already pass — the new arm only adds, does not edit existing arms.
+
+**Local verification:**
+```
+dotnet test tests/VoxFlow.Desktop.Tests/VoxFlow.Desktop.Tests.csproj
+```
+
+**PR description template:**
+```
+Forward speaker labeling toggle to TranscribeFileRequest; render Diarizing stage
+
+AppViewModel.TranscribeFileAsync now passes EnableSpeakers based on the
+Ready-screen toggle. When the toggle is off, EnableSpeakers stays null so
+the config-file default wins — no accidental override. RunningView gains
+a label for the new ProgressStage.Diarizing update emitted by
+TranscriptionService in Phase 1.
+
+Test plan:
+- [x] dotnet test tests/VoxFlow.Desktop.Tests/VoxFlow.Desktop.Tests.csproj — green
+```
+
+---
+
+### P2.3 — Colored speaker transcript renderer
+
+**Branch:** `speaker-labeling/p2.3-colored-renderer`
+
+**Why third:** The renderer is the largest piece of net-new UI work and the most testable. It must handle the full range of document shapes (0 speakers, 1 speaker, N speakers), wrap the palette at 8 speakers, and fall back cleanly to the existing plain-text preview when no document is present. Shipping it as its own PR lets the palette and wrapping logic be reviewed in isolation.
+
+**Files touched (new):**
+- `src/VoxFlow.Desktop/Components/Shared/SpeakerTranscriptView.razor` — renders a `TranscriptDocument` as a vertical list of colored turns.
+- `src/VoxFlow.Desktop/Theme/OkabeItoPalette.cs` (or similar path — check whether Desktop already has a theme folder; if not, place under `src/VoxFlow.Desktop/Services`) — the 8-color palette and a `ColorForSpeaker(SpeakerInfo)` helper.
+- `src/VoxFlow.Desktop/wwwroot/css/speaker-transcript.css` — or extend the existing stylesheet; define CSS variables for the palette, a `.speaker-turn` class, and a `.speaker-label` class. If the Desktop app already concatenates CSS in a single file, append there instead of adding a new file.
+- `tests/VoxFlow.Desktop.Tests/Components/SpeakerTranscriptViewTests.cs`
+- `tests/VoxFlow.Desktop.Tests/Theme/OkabeItoPaletteTests.cs`
+
+**Palette definition:**
+
+The [Okabe-Ito colorblind-safe palette](https://jfly.uni-koeln.de/color/) contains eight colors that remain distinguishable under all common forms of color vision deficiency. They are:
+
+| Index | Name | Hex |
+|---|---|---|
+| 0 | Orange | `#E69F00` |
+| 1 | Sky Blue | `#56B4E9` |
+| 2 | Bluish Green | `#009E73` |
+| 3 | Yellow | `#F0E442` |
+| 4 | Blue | `#0072B2` |
+| 5 | Vermillion | `#D55E00` |
+| 6 | Reddish Purple | `#CC79A7` |
+| 7 | Black | `#000000` |
+
+`ColorForSpeaker` maps the first-appearance ordinal (`0 → A`, `1 → B`, ...) to an index modulo 8. Speakers beyond the palette size reuse colors from the start — this is documented in a one-line comment next to the palette definition. The ordinal is derived from `SpeakerInfo.Label` by indexing into the alphabet: `A=0`, `B=1`, ..., `Z=25` (consistent with `SpeakerMergeService.OrdinalLabel`), then taken modulo 8.
+
+**Renderer contract:**
+
+- When `Document` is `null`, render nothing (the parent view decides whether to show a fallback).
+- When `Document.Turns` is empty, render a subdued message `"No speaker segments detected."`.
+- Otherwise render one block per turn: a small colored swatch, the `Speaker {Label}` name bold in the speaker color, the joined word text, and a timestamp range `[00:03 – 00:12]` in the corner.
+- Styling is scoped to the component via CSS variables so the palette can be themed later without a rewrite.
+
+**TDD steps:**
+
+1. **Red.** `OkabeItoPaletteTests.ColorForSpeaker_FirstEightSpeakers_ReturnsDistinctColors`. Create 8 `SpeakerInfo` instances with labels `A..H`; assert `ColorForSpeaker` returns 8 distinct hex strings from the palette. Compile fails: type doesn't exist.
+2. **Green.** Create the palette array and the helper.
+3. **Red.** `ColorForSpeaker_NinthSpeaker_WrapsToFirstColor`. Label `I` (ordinal 8); assert the returned color equals the palette[0].
+4. **Green.** `ordinal % palette.Length`. Test passes.
+5. **Red.** `ColorForSpeaker_InvalidLabel_ThrowsArgumentException`. Label `"zz"` or empty; assert `ArgumentException`. This locks the contract: the palette does not silently accept garbage labels, because a silent failure here would mean all speakers unexpectedly share a color.
+6. **Green.** Validate the label against the `[A-Z]+` pattern; throw with a descriptive message.
+7. **Red.** `SpeakerTranscriptViewTests.Renders_NullDocument_ProducesEmptyMarkup`. Render with `Document=null`; assert the component output is empty (zero non-whitespace children).
+8. **Green.** Guard the top of the render block on `Document is not null`.
+9. **Red.** `Renders_EmptyTurns_ShowsNoSegmentsMessage`. Document with 0 turns.
+10. **Green.** Add the empty-state branch.
+11. **Red.** `Renders_SingleSpeakerTurn_HasCorrectLabel_AndColor`. One turn, speaker A; assert the turn is rendered with `data-speaker-label="A"` and an inline `style="color: #E69F00"` matching palette[0].
+12. **Green.** Iterate `Document.Turns` and emit one block per turn. Apply the color via `style` attribute (not CSS class) so tests can read it by value.
+13. **Red.** `Renders_TwoSpeakers_AlternatingTurns_HaveDifferentColors`. Four turns A-B-A-B; assert the speaker colors alternate.
+14. **Green.** Already handled by iterating and calling the palette per turn.
+15. **Red.** `Renders_TimestampRange_PerTurn`. Assert each turn contains a `[MM:SS – MM:SS]` range. The formatting helper `FormatRange(startTime, endTime)` is private to the component.
+16. **Green.** Implement the formatter; cover 0-padding and the en-dash.
+17. **Red.** `Renders_NineSpeakers_ColorsWrapAroundPalette`. Nine turns with speakers A..I; assert the first and ninth have the same color.
+18. **Green.** Already handled by the modulo helper.
+19. **Refactor.** Extract the render helper into a small `SpeakerTurnRow` sub-component so the test assertions can target one row at a time and the top-level view stays a clean foreach.
+
+**Local verification:**
+```
+dotnet test tests/VoxFlow.Desktop.Tests/VoxFlow.Desktop.Tests.csproj
+```
+
+**PR description template:**
+```
+Add SpeakerTranscriptView renderer with Okabe-Ito palette
+
+New Desktop component renders a TranscriptDocument as a list of colored
+speaker turns. Colors come from the 8-entry Okabe-Ito colorblind-safe
+palette mapped by speaker ordinal, wrapping at 8 speakers. Fallback cases
+(null document, empty turns) render empty or a subdued message. Component
+is not yet wired into CompleteView — that lands in P2.4.
+
+Test plan:
+- [x] dotnet test tests/VoxFlow.Desktop.Tests/VoxFlow.Desktop.Tests.csproj — green
+```
+
+---
+
+### P2.4 — CompleteView integration + enrichment warning banner
+
+**Branch:** `speaker-labeling/p2.4-complete-view`
+
+**Why fourth (last):** This is the smallest change once the renderer and the toggle exist: swap the plain-text preview for the colored view when a document is present and add a warning banner for non-empty `EnrichmentWarnings`. Shipping it last means the rest of Phase 2 can be reviewed without the CompleteView churn, and users only see the finished experience in one step.
+
+**Files touched (modified):**
+- `src/VoxFlow.Desktop/Components/Pages/CompleteView.razor` — replace the plain-text preview block with a conditional: if `result.SpeakerTranscript is not null`, render `<SpeakerTranscriptView Document="result.SpeakerTranscript" />` inside the existing `complete-transcript-section` wrapper; otherwise render the existing plain-text preview markup unchanged. Add a new `EnrichmentWarningsBanner` block above the transcript section that shows each warning from `result.EnrichmentWarnings` in a `message message-info` style row.
+- `tests/VoxFlow.Desktop.Tests/DesktopUiComponentTests.cs` — extend the existing component tests with the new branches.
+
+**TDD steps:**
+
+1. **Red.** `CompleteViewTests.NullDocument_RendersPlainTextPreview_Unchanged`. Regression guard: render CompleteView with `TranscriptionResult.SpeakerTranscript = null` and an existing `TranscriptPreview`; assert the preview is present and no `SpeakerTranscriptView` is rendered.
+2. **Green.** Add the conditional around the existing preview markup so the null branch keeps the old behavior bit-for-bit.
+3. **Red.** `NonNullDocument_RendersSpeakerTranscriptView_AndHidesPlainTextPreview`. Assert the plain preview is **not** rendered when a document is present.
+4. **Green.** Swap in the `SpeakerTranscriptView` for the non-null case.
+5. **Red.** `EnrichmentWarnings_RendersBanner_WithEachMessage`. Two warnings on the result; assert both render in the banner.
+6. **Green.** Add the banner. Use the existing `.message .message-info` CSS class for visual consistency.
+7. **Red.** `EnrichmentWarnings_EmptyList_DoesNotRenderBanner`. Assert no banner element appears.
+8. **Green.** Guard with `result.EnrichmentWarnings.Count > 0`.
+9. **Red.** `DocumentAndWarningsBoth_RendersBothSections`. Both present; banner first, then colored transcript.
+10. **Green.** Should already pass given the previous two changes.
+11. **Regression.** Run the full Desktop suite including `DesktopUiComponentTests` — every existing test must stay green with zero edits.
+
+**Local verification:**
+```
+dotnet test tests/VoxFlow.Desktop.Tests/VoxFlow.Desktop.Tests.csproj
+dotnet test VoxFlow.sln
+```
+
+**PR description template:**
+```
+Render colored speaker transcript + enrichment warnings on CompleteView
+
+CompleteView now swaps its plain-text preview for SpeakerTranscriptView
+when TranscriptionResult.SpeakerTranscript is not null. When it is null
+(feature off, or sidecar failure), the existing plain preview renders
+unchanged — verified by regression tests that make zero edits to existing
+assertions. EnrichmentWarnings are rendered in a non-blocking
+message-info banner above the transcript section.
+
+Test plan:
+- [x] dotnet test tests/VoxFlow.Desktop.Tests/VoxFlow.Desktop.Tests.csproj — green
+- [x] dotnet test VoxFlow.sln — green, no regressions
+```
+
+---
+
+## Post-Phase-2 Checklist
+
+Before declaring Phase 2 complete and moving to Phase 3 planning:
+
+- [ ] All 4 sub-PRs merged into `Local-Speaker-Labeling`.
+- [ ] `dotnet test VoxFlow.sln` on `Local-Speaker-Labeling` is fully green.
+- [ ] Manual smoke on a real Mac Catalyst build: toggle on, transcribe the Obama clip, confirm the colored transcript renders on CompleteView with `Speaker A:` turns in the first palette color.
+- [ ] Manual smoke: toggle on, transcribe a multi-speaker file, confirm speakers beyond index 0 have distinct palette colors.
+- [ ] Manual smoke: toggle off, transcribe any file, confirm CompleteView renders the plain-text preview exactly as before (no colored view, no warning banner).
+- [ ] Manual smoke: force a sidecar failure (point `modelId` at a non-existent model), toggle on, transcribe; confirm the warning banner shows `speaker-labeling: …` and the plain-text preview still renders because `SpeakerTranscript` is null.
+- [ ] Okabe-Ito palette is documented in a one-line comment inside `OkabeItoPalette.cs` linking to the canonical source.
+- [ ] No files under `src/VoxFlow.Cli` or `src/VoxFlow.McpServer` were touched in this phase.
+- [ ] User has reviewed the integration branch state and approved starting Phase 3.

--- a/docs/delivery/local-speaker-labeling/phase-3-cli-mcp-polish.md
+++ b/docs/delivery/local-speaker-labeling/phase-3-cli-mcp-polish.md
@@ -1,0 +1,492 @@
+# Phase 3 — CLI, MCP, Documentation, Release Prep
+
+**Parent:** [Local Speaker Labeling — Delivery Plan](README.md)
+**ADR:** [ADR-024](../../adr/024-local-speaker-labeling-pipeline.md)
+**Status:** Planned
+
+---
+
+## Goal
+
+Close the feature by reaching host parity across CLI, Desktop, and MCP, then producing the user-facing documentation that makes speaker labeling operable on a fresh machine. Phases 1 and 2 have already delivered the enrichment pipeline and the Desktop UX; Phase 3 is the "polish" phase that makes the feature discoverable, configurable from every host, and recoverable when something goes wrong.
+
+By the end of Phase 3, a new developer can `git clone`, read `docs/runbooks/speaker-labeling.md`, run a single `voxflow transcribe --speakers` command, and see a colored, speaker-labeled transcript — with any failure surfaced via a clear diagnostic that points back to the runbook. The `Local-Speaker-Labeling` integration branch is then ready for user-driven promotion to `master`. Promotion itself is **not** part of this phase.
+
+Phase 3 is deliberately sequenced last because CLI argument parsing and MCP schema changes are trivial compared to the enrichment pipeline, but they are the first thing a user touches — so the underlying pipeline must be proven correct (Phases 0–2) before the surface is decorated.
+
+## Exit Criteria
+
+- `voxflow --speakers` (and `--speakers=false`) overrides `transcription.speakerLabeling.enabled` for a single CLI invocation, on both single-file and batch commands.
+- `voxflow --help` documents the `--speakers` flag alongside existing flags (or, if no help infrastructure exists yet, the P3.1 PR introduces the minimal help surface needed to cover the new flag).
+- The MCP `transcribe_file` tool exposes an `enableSpeakers` boolean parameter that overrides the configured default per request. The tool's JSON schema reflects the new parameter and is verified by a schema snapshot test in `VoxFlow.McpServer.Tests`.
+- `docs/runbooks/speaker-labeling.md` exists, has been manually walked through on a clean developer machine, and covers first-run setup, model download troubleshooting, sidecar diagnostics, and the `Category=RequiresPython` test gate.
+- `docs/ARCHITECTURE.md` has a new subsection describing the enrichment pipeline, the `IPythonRuntime` abstraction, and the sidecar process boundary. Existing architecture content is not rewritten — only extended.
+- `docs/developer/setup.md` documents the Python prerequisites for running `Category=RequiresPython` tests locally, and the repo `README.md` gains a one-paragraph mention of the feature with a link to the runbook.
+- `appsettings.example.json` has the complete `transcription.speakerLabeling` block with comments explaining each key.
+- The `python-build-standalone` spike outcome (produced in parallel to Phase 0) has been turned into a concrete go/no-go decision. If **go**, `StandaloneRuntime` is implemented and wired in as a third `IPythonRuntime` mode in a dedicated sub-PR. If **no-go**, the `"Standalone"` config value is removed from the allowed set and `SpeakerLabelingOptions` throws a clear validation error on load; the decision is recorded in ADR-024.
+- `ADR-024` has a `Status: Accepted` stamp and a dated note summarizing delivery outcomes (three phases merged into `Local-Speaker-Labeling`).
+- All 13 acceptance criteria from the [README](README.md#acceptance-criteria) are verified. The "Acceptance Check Before Promotion" checklist is fully ticked.
+- `dotnet test VoxFlow.sln` is fully green locally on the integration branch **and** `dotnet test --filter "Category=RequiresPython"` is fully green on a machine with Python 3.10+ and `pyannote.audio` installed.
+- Branch `Local-Speaker-Labeling` is tagged internally as "ready for user promotion review". Promotion to `master` is deliberately outside Phase 3 and outside this delivery.
+
+## Pre-conditions
+
+- Phase 1 (enrichment) and Phase 2 (Desktop UI) are merged into `Local-Speaker-Labeling`.
+- `SpeakerLabelingOptions.Enabled` is already honored by the pipeline (P1.1, P1.4).
+- `TranscribeFileRequest.EnableSpeakers` (nullable bool override) is already defined and respected by `TranscriptionService` (P1.2, P1.4).
+- The Desktop app already forwards its Ready-screen toggle through `TranscribeFileRequest.EnableSpeakers` (P2.2), so the pattern of "host override wins over config default" is already live; Phase 3 is extending the same pattern to CLI and MCP.
+- `python-build-standalone` spike has a documented outcome (repo issue or a markdown note under `docs/delivery/local-speaker-labeling/spikes/`). If the spike is still in flight at the start of Phase 3, P3.5 is postponed and the rest of Phase 3 lands without it — the exit criterion above handles both outcomes.
+- `Local-Speaker-Labeling` branch is checked out, up to date, and fully green under `dotnet test`.
+
+## Non-goals
+
+These are deliberately excluded from Phase 3 so the phase stays scoped and shippable:
+
+- **No CLI argument-parsing framework migration.** P3.1 introduces the **minimum** hand-written parser needed to recognize `--speakers` (and surface a `--help` line). Adopting `System.CommandLine`, Spectre.Console.Cli, or any other framework is a separate refactor and is not blocked by this delivery.
+- **No `voxflow diarize <file>` standalone subcommand.** Speaker labeling is an enrichment of the existing `transcribe` / `batch` flows, not a new top-level command.
+- **No interactive Desktop runbook / in-app help.** The runbook is a markdown document; surfacing it inside the Desktop app is a future enhancement.
+- **No localization of the runbook or help text.** English only for v1.
+- **No package-manager distribution of the managed venv.** `ManagedVenvRuntime` continues to bootstrap on first enable; Phase 3 does not add a separate installer or Homebrew formula.
+- **No promotion of `Local-Speaker-Labeling` to `master`.** This is explicitly a user decision made after Phase 3 is complete.
+- **No performance benchmarks.** Diarization latency is documented qualitatively in the runbook ("10-minute audio file ≈ 2 minutes of enrichment on an M1") but is not asserted by any automated test.
+- **No new telemetry or analytics.** Consistent with VoxFlow's privacy-first principle.
+
+---
+
+## TDD Sequence
+
+Six sub-PRs, in the order below. P3.5 is conditional on the `python-build-standalone` spike outcome and may be skipped (see its "Conditional" note). Each PR is the smallest unit that leaves `Local-Speaker-Labeling` in a green-tests state.
+
+Conventions for every PR below:
+- **Branch:** `speaker-labeling/p3.M-<slug>` off `Local-Speaker-Labeling`.
+- **Base for PR:** `Local-Speaker-Labeling` (**never** `master`).
+- **Before `gh pr create`:** run `dotnet test VoxFlow.sln` locally; if the PR touches integration code also run `dotnet test --filter "Category=RequiresPython"`. Both must be fully green.
+- **Test tagging:** Python-gated tests use `[Trait("Category", "RequiresPython")]` on the test class (xUnit 2.9.2 syntax).
+- **Commit authorship:** user only; no Co-Authored-By trailers.
+- **PR body:** no "Generated with Claude Code" footer.
+
+---
+
+### P3.1 — CLI `--speakers` flag
+
+**Branch:** `speaker-labeling/p3.1-cli-speakers-flag`
+
+**Why first:** CLI parity is the simplest of the three host surfaces and establishes the "host override wins" pattern on the CLI side without touching any protocol schema. It is entirely self-contained inside `VoxFlow.Cli`. Every subsequent PR in this phase either documents or decorates work that already exists.
+
+**Files touched:**
+- `src/VoxFlow.Cli/Program.cs` — add a minimal hand-written argument parser in `Main` that recognizes `--speakers`, `--speakers=true`, `--speakers=false`, `--no-speakers`, and `--help`. The parser is called **before** `configService.LoadAsync()` so the parsed value can be applied as an override after the options load. Everything else in `Main` is untouched.
+- `src/VoxFlow.Cli/CliArguments.cs` — **new** file with a `CliArguments` record holding `EnableSpeakers: bool?` and `ShowHelp: bool` and a static `CliArguments.Parse(string[] args)` method. Pure logic, no IO — the whole point of extracting it is testability.
+- `src/VoxFlow.Cli/Program.cs` — after parsing, if `args.EnableSpeakers is not null`, set `options = options with { SpeakerLabeling = options.SpeakerLabeling with { Enabled = args.EnableSpeakers.Value } }`. Then pass through to the existing `RunSingleFileAsync` / `RunBatchAsync`. The CLI does **not** need to thread the flag through `TranscribeFileRequest.EnableSpeakers` because it mutates the loaded `TranscriptionOptions` instance directly — this is the CLI-specific shortcut and it's simpler than the Desktop / MCP per-request override pattern, because the CLI invocation *is* the request.
+- `tests/VoxFlow.Cli.Tests/CliArgumentsTests.cs` — **new** test file. Pure-logic tests for the parser. No DI container, no host.
+
+**TDD steps:**
+
+1. **Red.** Add `CliArgumentsTests.Parse_NoArgs_ReturnsNullEnableSpeakers_AndShowHelpFalse`. Expect `args.EnableSpeakers == null` and `args.ShowHelp == false`. Compile: fails because `CliArguments` doesn't exist.
+2. **Green.** Add `CliArguments.cs` with the record shape and an empty `Parse` that returns default values. Test passes.
+3. **Red.** Add `CliArgumentsTests.Parse_SpeakersFlag_SetsEnableSpeakersTrue` — `Parse(["--speakers"])` → `EnableSpeakers == true`. Fails.
+4. **Green.** Implement the `--speakers` branch. Passes.
+5. **Red.** Add `CliArgumentsTests.Parse_SpeakersEqualsFalse_SetsEnableSpeakersFalse` — `Parse(["--speakers=false"])` → `EnableSpeakers == false`. Fails.
+6. **Green.** Add the `--speakers=<value>` branch. Passes. Accepted values are exactly `true` and `false` (case-insensitive); anything else throws `ArgumentException` with a message naming the flag.
+7. **Red.** Add `CliArgumentsTests.Parse_NoSpeakers_SetsEnableSpeakersFalse` — `Parse(["--no-speakers"])` → `EnableSpeakers == false`. Fails.
+8. **Green.** Add the `--no-speakers` branch. Passes.
+9. **Red.** Add `CliArgumentsTests.Parse_HelpFlag_SetsShowHelpTrue` — `Parse(["--help"])` → `ShowHelp == true`. Fails.
+10. **Green.** Add the `--help` branch. Passes.
+11. **Red.** Add `CliArgumentsTests.Parse_UnknownFlag_Throws` — `Parse(["--bogus"])` → `ArgumentException` whose message contains `--bogus`. Fails.
+12. **Green.** Default branch in `Parse` throws. The error message must include the unknown token, **not** a generic "invalid argument" — the CLI is the user's only error channel here. Passes.
+13. **Red.** Add `CliArgumentsTests.Parse_ConflictingFlags_LastWins_ExplicitAssertion` — `Parse(["--speakers", "--no-speakers"])` → `EnableSpeakers == false`. Document the "last writer wins" rule explicitly in a test so nobody has to re-derive it. Fails.
+14. **Green.** Parser already handles this if it iterates left-to-right; add an assertion comment inside the parser that this is a deliberate contract, not an accident.
+15. **Refactor.** Collapse duplicate branches in `Parse` (the three forms all produce a bool — they should funnel through one helper). Keep the test surface unchanged.
+16. **Red.** In `Program.cs`, add a guard: if `CliArguments.Parse` throws, print the message to `Console.Error` and `return 2` (distinct from validation failure = 1). Write an integration-level test only if a straightforward harness exists (`VoxFlow.Cli.Tests` currently has no such harness, so this may be a manual verification step documented in the PR body — do not invent a harness for one assertion).
+17. **Green.** Add the `try { var cliArgs = CliArguments.Parse(args); }` guard at the top of `Main`. If `cliArgs.ShowHelp`, print a short help block and return 0 **before** building the DI container.
+18. **Manual verification (documented in PR body):**
+    - `dotnet run --project src/VoxFlow.Cli -- --help` prints the help block and exits 0.
+    - `dotnet run --project src/VoxFlow.Cli -- --bogus` prints the unknown-flag error and exits 2.
+    - `dotnet run --project src/VoxFlow.Cli -- --speakers` with `enabled=false` in appsettings overrides the config and runs the feature (observed via `ProgressStage.Diarizing` appearing in progress output — smoke-only, not asserted).
+19. **Refactor.** The help block text lives next to `CliArguments.Parse` as a `const string` — not inside `Program.cs` — so future flags are added in one place.
+
+**Local verification before PR:**
+```
+dotnet test tests/VoxFlow.Cli.Tests/VoxFlow.Cli.Tests.csproj
+dotnet test VoxFlow.sln
+```
+Both fully green. `CliArgumentsTests` is the only new test file; nothing else in `VoxFlow.Cli.Tests` should change.
+
+**PR description template:**
+```
+CLI: add --speakers flag for per-invocation speaker-labeling override
+
+Part of ADR-024 Phase 3. Introduces a minimal hand-written argument
+parser to VoxFlow.Cli, supporting --speakers / --speakers=<bool> /
+--no-speakers / --help / unknown-flag diagnostics. The parsed value
+overrides transcription.speakerLabeling.enabled for the current
+invocation only. Config file is not mutated. Desktop and MCP behavior
+are unchanged by this PR.
+
+No dependency on System.CommandLine — adopting a framework parser is
+out of scope for this delivery.
+
+Test plan:
+- [x] dotnet test VoxFlow.sln — fully green
+- [x] CliArgumentsTests covers --speakers, --speakers=true/false,
+      --no-speakers, --help, unknown-flag error, and conflict resolution
+- [x] Manual: --help / --bogus / --speakers smoke-tested against a
+      real config file
+```
+
+---
+
+### P3.2 — MCP `enableSpeakers` tool parameter
+
+**Branch:** `speaker-labeling/p3.2-mcp-enable-speakers`
+
+**Why second:** MCP is the second-simplest host surface. It already has `TranscribeFileAsync` at [WhisperMcpTools.cs:70](../../../src/VoxFlow.McpServer/Tools/WhisperMcpTools.cs#L70), so the change is a single optional parameter plus a schema snapshot update. No plumbing beyond forwarding to `TranscribeFileRequest.EnableSpeakers`, which already exists.
+
+**Files touched:**
+- `src/VoxFlow.McpServer/Tools/WhisperMcpTools.cs` — add `bool? enableSpeakers = null` to `TranscribeFileAsync` parameters with a `[Description]` attribute explaining "Override `transcription.speakerLabeling.enabled` for this request only. `null` (omitted) uses the server's configured default." Pass it through to `new TranscribeFileRequest(..., EnableSpeakers: enableSpeakers)`.
+- `tests/VoxFlow.McpServer.Tests/WhisperMcpToolsTests.cs` — new tests asserting the parameter is forwarded correctly into `TranscribeFileRequest` via an `ITranscriptionService` fake.
+- `tests/VoxFlow.McpServer.Tests/TranscribeFileToolSchemaTests.cs` — **new** test file (or add to the existing schema-snapshot test if one already lives there) that asserts the discovered MCP tool schema for `transcribe_file` contains an `enableSpeakers` property of type `boolean` and marks it optional. If no snapshot infrastructure exists, assert the `MethodInfo` of `TranscribeFileAsync` has a parameter named `enableSpeakers` with type `bool?` — this is a low-fidelity proxy but it catches the most common regression (accidental rename).
+
+**TDD steps:**
+
+1. **Red.** Add `WhisperMcpToolsTests.TranscribeFileAsync_ForwardsEnableSpeakersTrue`. Stub `ITranscriptionService` with a delegate that captures the `TranscribeFileRequest`; call `TranscribeFileAsync(..., enableSpeakers: true)`; assert the captured request's `EnableSpeakers == true`. Compile: fails because `TranscribeFileAsync` has no such parameter.
+2. **Green.** Add the parameter (`bool? enableSpeakers = null`), forward it into the `TranscribeFileRequest` named argument at [WhisperMcpTools.cs:108](../../../src/VoxFlow.McpServer/Tools/WhisperMcpTools.cs#L108). Test passes.
+3. **Red.** Add `WhisperMcpToolsTests.TranscribeFileAsync_ForwardsEnableSpeakersFalse`. Same test with `false`. Passes after step 2 — this is a guard that the parameter is actually wired, not hard-coded.
+4. **Red.** Add `WhisperMcpToolsTests.TranscribeFileAsync_OmittedEnableSpeakers_ForwardsNull`. Call without the parameter and assert `EnableSpeakers == null`. Passes after step 2 — another guard.
+5. **Red.** Add `TranscribeFileToolSchemaTests.TranscribeFileTool_SchemaContainsEnableSpeakersBooleanParameter`. Use reflection on `typeof(WhisperMcpTools).GetMethod("TranscribeFileAsync")!.GetParameters()` and assert a parameter named `enableSpeakers` with type `bool?` and a `DescriptionAttribute` whose text is non-empty. Fails only if P3.2 step 2 was reverted — catches rename regressions.
+6. **Green.** Confirm the description attribute is present and descriptive. Passes.
+7. **Refactor.** Confirm the `[Description]` attribute text is clear about precedence ("Overrides `transcription.speakerLabeling.enabled` for this request only"). Nothing else.
+8. **Manual verification (documented in PR body):** start the MCP server with a config that has `speakerLabeling.enabled=false`, call the `transcribe_file` tool with `enableSpeakers: true`, and confirm the response contains the enrichment-enabled payload shape (non-null `SpeakerTranscript` in the result JSON or an empty one plus `EnrichmentWarnings`, depending on whether Python is available on the host).
+
+**Local verification before PR:**
+```
+dotnet test tests/VoxFlow.McpServer.Tests/VoxFlow.McpServer.Tests.csproj
+dotnet test VoxFlow.sln
+```
+Both fully green.
+
+**PR description template:**
+```
+MCP: add enableSpeakers parameter to transcribe_file tool
+
+Part of ADR-024 Phase 3. Exposes the speaker-labeling override to
+MCP clients as a nullable boolean. null (omitted) uses the server's
+configured default; true/false overrides per request. The parameter
+is forwarded into TranscribeFileRequest.EnableSpeakers, which is
+already respected by TranscriptionService from Phase 1.
+
+Test plan:
+- [x] dotnet test VoxFlow.sln — fully green
+- [x] WhisperMcpToolsTests cover true/false/null forwarding
+- [x] Schema test asserts the parameter shape via reflection
+- [x] Manual: transcribe_file tool called via MCP stdio with
+      enableSpeakers=true against a config where enabled=false
+```
+
+---
+
+### P3.3 — Runbook `docs/runbooks/speaker-labeling.md`
+
+**Branch:** `speaker-labeling/p3.3-runbook`
+
+**Why third:** The runbook is the operational contract a user reads when something goes wrong. It must exist before the feature is advertised in `README.md` (P3.4), so users who hit the feature for the first time have a landing page. This PR is pure documentation — no code, no tests, but the runbook **must be manually walked through** on a clean machine before merging, and that walkthrough is the PR's "test plan".
+
+**Files touched (new):**
+- `docs/runbooks/speaker-labeling.md`
+- `docs/runbooks/README.md` — add a single-line link entry (if this index file exists; otherwise skip).
+
+**Files touched (updated):**
+- `appsettings.example.json` — if the `speakerLabeling` block is not yet present here (it should be, from P1.1), verify it exists and has inline-adjacent comments in a sibling README snippet. `appsettings.example.json` is valid JSON so it cannot carry comments; the per-key documentation lives in the runbook, not in the example file.
+
+**Runbook structure (sections — every section must exist, order is fixed):**
+
+1. **What speaker labeling does** — one paragraph summary: "Speaker labeling adds `Speaker A` / `Speaker B` prefixes to your transcript by running a local pyannote diarization sidecar. It is off by default and entirely local — no audio ever leaves your machine."
+2. **Prerequisites** — Python 3.10+, ~300 MB disk for the pyannote model, a Hugging Face access token (free) with the pyannote model license accepted. Link to the upstream license page and the ADR-024 license note.
+3. **First-run setup (ManagedVenv mode, the default)** — exact commands the user runs. If there's a Desktop-app first-run flow (P1.3), describe what the user sees and what the progress messages mean. If Desktop is not the host, describe the CLI equivalent.
+4. **First-run setup (SystemPython mode, the escape hatch)** — `pip install pyannote.audio` into the user's system Python, how to point VoxFlow at it, why this mode is **not** the default.
+5. **First-run setup (Standalone mode)** — **conditional**: if P3.5 lands, describe the bundled-runtime path. If P3.5 is skipped (spike no-go), this section contains a single sentence noting that Standalone mode is not yet supported and links to the spike outcome.
+6. **How to enable the feature** — three host surfaces:
+   - Desktop: Ready-screen toggle.
+   - CLI: `voxflow --speakers <input.wav>` or set `transcription.speakerLabeling.enabled=true` in `appsettings.json`.
+   - MCP: call `transcribe_file` with `enableSpeakers: true`, or set the server default in its config file.
+7. **What a successful run looks like** — sample progress output, sample `.voxflow.json` excerpt (two speakers), sample colored Desktop screenshot (or a text description if screenshots are not yet in the repo).
+8. **Troubleshooting: "Python runtime not found"** — what `IValidationService` reports, how to install Python 3.10+, how to point VoxFlow at a non-default interpreter.
+9. **Troubleshooting: "pyannote model download failed"** — HF token missing, network error, licensing not accepted, model cache location, how to force a re-download.
+10. **Troubleshooting: "Sidecar exited with code N"** — how to read the stderr tail that `PyannoteSidecarClient` logs, how to re-run `voxflow_diarize.py` manually for further diagnostics, and (when the issue is reproducible) where to file a bug.
+11. **Troubleshooting: "Sidecar timed out"** — what `timeoutSeconds` controls, why the default is 600, when to raise it.
+12. **Running the `RequiresPython` test suite locally** — `dotnet test --filter "Category=RequiresPython"`. Mention that this is required before merging any PR that touches sidecar or enrichment code.
+13. **Known limitations and non-goals** — links out to the "Out of Scope" section of the delivery README.
+14. **Changelog** — phase-dated entries: "2026-MM-DD: Phase 3 shipped. Feature available on Local-Speaker-Labeling branch."
+
+**Pseudo-TDD discipline for a docs-only PR:**
+
+Documentation does not have automated tests, but the TDD principle (**don't write it if you haven't verified it works**) still applies. The "red/green" cycle for each section is:
+
+1. **Red.** Write the section as a user action or troubleshooting step: "If X, do Y."
+2. **Verify.** Do X on a clean machine (or in a clean `git worktree` + fresh `~/Library/Caches/VoxFlow/`), follow Y, confirm the user reaches the stated outcome.
+3. **Green.** Leave the section as-is if the walkthrough matched. If the walkthrough deviated, **update the section to match reality**, not the other way around — the runbook describes the system as it is, not as it was designed.
+
+**Manual walkthrough checklist (PR body must include all of these checked):**
+
+- [ ] On a clean machine, follow "First-run setup (ManagedVenv mode)" end-to-end; the first run completes and produces a labeled transcript.
+- [ ] Deliberately break the HF token (set a bogus value); follow "pyannote model download failed"; recover.
+- [ ] Deliberately rename the Python interpreter; follow "Python runtime not found"; recover.
+- [ ] Run `dotnet test --filter "Category=RequiresPython"` from the runbook's instructions verbatim; the full suite passes.
+- [ ] Read the runbook top-to-bottom as a new user would; every internal link resolves; every command is copy-pasteable; every file path matches the current repo layout.
+
+**Local verification before PR:**
+```
+dotnet test VoxFlow.sln
+```
+(Docs-only PR, but the full suite must still be green to guard against accidental stray edits.)
+
+**PR description template:**
+```
+docs(runbook): local speaker labeling operational runbook
+
+Part of ADR-024 Phase 3. Adds docs/runbooks/speaker-labeling.md
+covering prerequisites, first-run setup for ManagedVenv and SystemPython
+modes, how to enable from each host, and troubleshooting for the four
+most common failure modes (missing Python, failed model download,
+sidecar crash, sidecar timeout). Content was validated by a clean-
+machine walkthrough before merging.
+
+No code changes. appsettings.example.json is verified to already
+contain the speakerLabeling block from Phase 1.
+
+Test plan:
+- [x] dotnet test VoxFlow.sln — fully green (no code changes)
+- [x] Manual walkthrough of each troubleshooting section on a clean
+      machine; every procedure reached its stated outcome
+- [x] Every path, command, and link verified against current repo
+```
+
+---
+
+### P3.4 — `ARCHITECTURE.md` + `setup.md` + `README.md` snippet
+
+**Branch:** `speaker-labeling/p3.4-architecture-and-readme`
+
+**Why fourth:** The repo-level documentation (`README.md`, `ARCHITECTURE.md`, `docs/developer/setup.md`) is the discoverability layer that points new users at the runbook written in P3.3. P3.4 must come after P3.3 so the `README.md` "Speaker Labeling" paragraph can link to a runbook that already exists.
+
+**Files touched:**
+- `README.md` — add a short "Speaker labeling (local, opt-in)" section near the feature overview. One paragraph + a link to `docs/runbooks/speaker-labeling.md`. Do **not** duplicate the runbook content.
+- `docs/ARCHITECTURE.md` — add a new subsection under the existing transcription pipeline description. Describe (a) the `ISpeakerEnrichmentService` orchestrator, (b) the `IPythonRuntime` abstraction and its two (or three, if P3.5 lands) implementations, (c) the sidecar process boundary and the versioned JSON contract, (d) how failures are isolated to `EnrichmentWarnings` without breaking the transcription-only pipeline. Reference the relevant ADR section numbers.
+- `docs/developer/setup.md` — new subsection "Running `RequiresPython` tests locally": install Python 3.10+, install `pyannote.audio`, set the HF token, run `dotnet test --filter "Category=RequiresPython"`. Link to the runbook for the full first-run story.
+- `docs/adr/024-local-speaker-labeling-pipeline.md` — flip `Status` to `Accepted` with a dated outcome note. This is a small amendment and is bundled into P3.4 so the ADR and the docs that describe it are updated together.
+
+**"TDD" cycle for documentation changes:**
+
+There are no automated tests here, but each of the three updated docs has a verification step that matches the red/green cycle:
+
+1. **Red.** Draft the section. Assume nothing.
+2. **Verify.** For `ARCHITECTURE.md`, grep the repo for every type name you mention and confirm it exists at the path you cite. For `setup.md`, walk through the commands verbatim on a machine where Python is not yet installed. For `README.md`, confirm the link resolves and the runbook anchor target exists.
+3. **Green.** If any verification step fails, fix the doc to match reality.
+
+**Manual walkthrough checklist (PR body must include all of these checked):**
+
+- [ ] Every type name cited in `ARCHITECTURE.md` is grep-findable at the cited path.
+- [ ] Every command in `setup.md` is executed verbatim on a clean machine and produces the stated outcome.
+- [ ] The `README.md` link to `docs/runbooks/speaker-labeling.md` resolves on GitHub.
+- [ ] `docs/adr/024-local-speaker-labeling-pipeline.md` is flipped to `Status: Accepted` with a dated note (`YYYY-MM-DD — Phase 3 shipped on Local-Speaker-Labeling branch, awaiting user promotion to master`).
+
+**Local verification before PR:**
+```
+dotnet test VoxFlow.sln
+```
+Fully green. No code changes — the test run is a guard against accidental stray edits.
+
+**PR description template:**
+```
+docs: architecture + setup + README entries for speaker labeling
+
+Part of ADR-024 Phase 3. Adds repo-level discoverability for the
+feature:
+- README.md: one-paragraph overview + link to runbook
+- docs/ARCHITECTURE.md: enrichment pipeline subsection covering
+  ISpeakerEnrichmentService, IPythonRuntime, sidecar boundary,
+  and failure isolation
+- docs/developer/setup.md: instructions for running the
+  Category=RequiresPython test suite locally
+- docs/adr/024-local-speaker-labeling-pipeline.md: flipped to
+  Status: Accepted with a dated outcome note
+
+Every cited path and type name was verified against the current
+repo; every command in setup.md was walked through on a clean
+machine.
+
+Test plan:
+- [x] dotnet test VoxFlow.sln — fully green (no code changes)
+- [x] Manual walkthrough of setup.md instructions
+- [x] Every internal link resolves
+```
+
+---
+
+### P3.5 — `StandaloneRuntime` implementation (**conditional**)
+
+**Branch:** `speaker-labeling/p3.5-standalone-runtime`
+
+**Conditional on:** the `python-build-standalone` spike outcome being **go**. If the spike is no-go or still open, this PR is **not** written — instead, a tiny "close the loop" PR lands that removes the `"Standalone"` value from `SpeakerLabelingOptions.pythonRuntimeMode` validation and documents the decision in the ADR. The contingency is:
+
+- **Spike = go, spike complete:** write P3.5 as described below.
+- **Spike = no-go:** skip P3.5. Add one PR (`speaker-labeling/p3.5-standalone-decision`) that removes `"Standalone"` from the accepted `pythonRuntimeMode` values, makes `SpeakerLabelingOptions` throw on load if the value is set to `"Standalone"` with a clear message ("Standalone mode is not supported in this release — see ADR-024 for the spike outcome"), updates ADR-024 with the decision, and updates the runbook's "First-run setup (Standalone mode)" section accordingly.
+- **Spike not yet complete:** defer P3.5 past Phase 3. Phase 3 can still exit successfully without it — see Exit Criteria.
+
+**Why fifth (when it runs):** Standalone runtime is an additive feature behind an already-existing abstraction (`IPythonRuntime`). It cannot destabilize the CLI, MCP, or Desktop host changes that already landed in P3.1–P3.4 because those paths default to `ManagedVenv`. Running P3.5 last means a spike outcome slipping does not block the rest of Phase 3.
+
+**Files touched (go path):**
+- `src/VoxFlow.Core/Services/Python/StandaloneRuntime.cs` — new implementation of `IPythonRuntime` that resolves its interpreter path from a bundled `python-build-standalone` tree, verifies the tree's existence and version, and produces a `PythonInvocation` pointing at the bundled interpreter.
+- `src/VoxFlow.Core/Services/Python/StandaloneRuntimePaths.cs` — new path helper that knows the layout of the bundled tree for the target platform (initially macOS-only, mirroring the existing Desktop-only scope for v1).
+- `src/VoxFlow.Core/DependencyInjection/VoxFlowCoreServiceCollectionExtensions.cs` — register `StandaloneRuntime` alongside `SystemPythonRuntime` and `ManagedVenvRuntime`; the resolver picks one based on `SpeakerLabelingOptions.PythonRuntimeMode`.
+- `src/VoxFlow.Core/Configuration/SpeakerLabelingOptions.cs` — validation now accepts `"Standalone"` as a legal `PythonRuntimeMode` value.
+- `tests/VoxFlow.Core.Tests/Services/Python/StandaloneRuntimeTests.cs` — new unit tests using the same `IProcessLauncher` fake pattern as `SystemPythonRuntimeTests` and `ManagedVenvRuntimeTests`. Covers: tree present and valid; tree missing; tree present but interpreter missing; version check parsing.
+
+**TDD steps (go path):**
+
+1. **Red.** Add `StandaloneRuntimeTests.EnsureReadyAsync_TreeMissing_ReturnsNotReady`. Fails — class doesn't exist.
+2. **Green.** Create `StandaloneRuntime` with a constructor taking `StandaloneRuntimePaths`, `IProcessLauncher`, and a logger. Implement `EnsureReadyAsync` to return `NotReady` when the tree directory does not exist. Test passes.
+3. **Red.** Add `StandaloneRuntimeTests.EnsureReadyAsync_TreePresentButInterpreterMissing_ReturnsNotReady`. Fails.
+4. **Green.** Add the interpreter existence check. Passes.
+5. **Red.** Add `StandaloneRuntimeTests.EnsureReadyAsync_VersionBelow310_ReturnsNotReady` — stub the process launcher so `python --version` returns `Python 3.9.6`. Fails.
+6. **Green.** Parse the stdout, compare to the 3.10 floor. Passes. Reuse the same parser the existing `SystemPythonRuntime` uses — extract it into a shared helper if it's not already shared.
+7. **Red.** Add `StandaloneRuntimeTests.EnsureReadyAsync_Ready_ReturnsReady_AndProducesCorrectInvocationPaths`. Fails.
+8. **Green.** Produce a `PythonInvocation` whose `InterpreterPath` points inside the bundled tree and whose environment variables are populated (e.g., `PYTHONHOME`, `PYTHONPATH`) per the `python-build-standalone` README. Passes.
+9. **Refactor.** Consolidate path constants into `StandaloneRuntimePaths`. Extract the version parser into `PythonVersionParser` if not already shared with `SystemPythonRuntime`. Keep tests green.
+10. **Red.** Add a DI wiring test in `VoxFlowCoreServiceCollectionTests` (or the nearest equivalent) asserting that `SpeakerLabelingOptions { PythonRuntimeMode = "Standalone" }` resolves an `IPythonRuntime` implementation of type `StandaloneRuntime`. Fails.
+11. **Green.** Wire the runtime into the DI extension. Passes.
+12. **Red.** Add `SpeakerLabelingOptionsTests.PythonRuntimeMode_Standalone_IsAccepted`. Fails if the validator still rejects it.
+13. **Green.** Expand the validator. Passes.
+14. **Manual verification:** Download the `python-build-standalone` tree for the current platform into the expected bundle path. Enable the feature with `pythonRuntimeMode=Standalone`. Run a CLI transcription against `obama-speech-1spk-10s.wav`. Confirm the transcript has `Speaker A:` labels and the process tree shows the bundled interpreter (not the system Python).
+15. **RequiresPython integration test:** Add a `[Trait("Category", "RequiresPython")]` test that end-to-end-drives `StandaloneRuntime` against the pyannote sidecar. This test is gated by both `Category=RequiresPython` **and** a file-existence check for the bundled tree, so it skips cleanly on machines without the bundle.
+
+**Local verification before PR:**
+```
+dotnet test VoxFlow.sln
+dotnet test --filter "Category=RequiresPython"
+```
+Both fully green.
+
+**PR description template (go path):**
+```
+core: StandaloneRuntime implementation for speaker labeling
+
+Part of ADR-024 Phase 3. Adds a third IPythonRuntime implementation
+that runs pyannote against a bundled python-build-standalone tree.
+Enabled by setting transcription.speakerLabeling.pythonRuntimeMode
+to "Standalone" in appsettings.json. ManagedVenv remains the default
+for new users.
+
+Spike outcome (linked in ADR-024) was go: python-build-standalone
+ships a usable CPython + numpy + torch stack under the repo size
+budget for the Desktop scope of this delivery.
+
+Test plan:
+- [x] dotnet test VoxFlow.sln — fully green
+- [x] StandaloneRuntimeTests cover tree-missing, interpreter-missing,
+      version-below-floor, and happy-path invocation construction
+- [x] DI wiring resolves StandaloneRuntime for pythonRuntimeMode=Standalone
+- [x] Manual: full speaker-labeled transcription of obama-speech-1spk-10s
+      using the bundled runtime, process-tree verified
+- [x] dotnet test --filter "Category=RequiresPython" — fully green
+      on a machine with Python 3.10+ and the bundle present
+```
+
+**PR description template (no-go path, for the `speaker-labeling/p3.5-standalone-decision` PR):**
+```
+docs(adr-024): record Standalone runtime spike as no-go
+
+Part of ADR-024 Phase 3. The python-build-standalone spike concluded
+no-go: [one-sentence reason, e.g., "bundled pyannote + torch exceeds
+the acceptable repo/binary size budget"]. SpeakerLabelingOptions no
+longer accepts "Standalone" as a legal pythonRuntimeMode; users are
+limited to "ManagedVenv" (default) and "SystemPython" (escape hatch)
+for this delivery. The runbook's "First-run setup (Standalone mode)"
+section is updated to reflect this.
+
+Test plan:
+- [x] dotnet test VoxFlow.sln — fully green
+- [x] SpeakerLabelingOptionsTests now asserts "Standalone" throws
+      with a clear message pointing at ADR-024
+```
+
+---
+
+### P3.6 — Release prep
+
+**Branch:** `speaker-labeling/p3.6-release-prep`
+
+**Why last:** Release prep is the final pass that ties off loose ends, verifies every acceptance criterion, and hands the branch over to the user. It must come after every other phase and every other Phase 3 sub-PR.
+
+**Scope:**
+
+1. **Acceptance criteria audit.** Walk the [README acceptance criteria](README.md#acceptance-criteria) one by one. For each item, link to the test or the manual verification that proves it. Items without evidence get a follow-up sub-PR **before** P3.6 merges — P3.6 is blocked until every item has evidence.
+2. **`Acceptance Check Before Promotion` checklist.** Tick every item in the README's `## Acceptance Check Before Promotion` section. Do not tick items that have not actually been done.
+3. **Full manual smoke test on a real recording.** Run the pipeline end-to-end against one of:
+   - The full `artifacts/input/President Obama Speech.m4a` (long-form, single speaker — tests failure modes when diarization finds only one speaker).
+   - A multi-speaker real-world recording the user has on hand (if available — not blocking).
+4. **Test-log triage.** Run `dotnet test VoxFlow.sln` and `dotnet test --filter "Category=RequiresPython"` on a machine that has Python 3.10+ and pyannote installed. Capture the summary line in the PR body. Any new `[Skipped]` counts must be justified.
+5. **Changelog entry.** Add an entry to `CHANGELOG.md` (if one exists) or to a new `docs/delivery/local-speaker-labeling/CHANGELOG-phase3.md` otherwise, summarizing what shipped across all three phases.
+6. **Hand-off note for user review.** Add a dated "Ready for user promotion review" note to the bottom of the delivery README. This note lists the PR numbers that landed across the three phases and says "branch is ready for the user to review the full diff and decide whether to promote to master". Promotion itself is **not** done in this PR.
+
+**"TDD" cycle for release prep:**
+
+P3.6 is process, not code. The discipline is:
+
+1. **Red.** Claim an acceptance criterion is met.
+2. **Verify.** Link to the specific test or walkthrough that proves it.
+3. **Green.** Only if the link resolves and the evidence is real.
+
+No acceptance criterion is ticked without evidence. If evidence is missing, the correct response is to either add a test, run the walkthrough, or open a follow-up sub-PR — **not** to tick the box and move on.
+
+**Files touched:**
+- `docs/delivery/local-speaker-labeling/README.md` — "Acceptance Check Before Promotion" checklist fully ticked, with a "Ready for user promotion review" footer.
+- `CHANGELOG.md` (or equivalent) — one entry per phase, grouped under the current release version or an explicit "Unreleased on Local-Speaker-Labeling" section.
+
+**Local verification before PR:**
+```
+dotnet test VoxFlow.sln
+dotnet test --filter "Category=RequiresPython"
+```
+Both fully green. The PR body must include the full summary line (`Passed: N, Failed: 0, Skipped: M`) from each run.
+
+**PR description template:**
+```
+release: close Phase 3 and hand Local-Speaker-Labeling over for review
+
+Part of ADR-024 Phase 3. Final pass:
+- Acceptance criteria audited, each tied to a test or walkthrough
+- Acceptance Check Before Promotion checklist fully ticked
+- Full smoke test on <input file> — result: <pass/fail summary>
+- CHANGELOG entries for Phases 0–3
+
+Local-Speaker-Labeling is now ready for user review and promotion
+decision. Promotion to master is a separate user-driven step and
+is intentionally not part of this PR.
+
+Test plan:
+- [x] dotnet test VoxFlow.sln — fully green (<summary line>)
+- [x] dotnet test --filter "Category=RequiresPython" — fully green
+      on <machine description> (<summary line>)
+- [x] Manual smoke: <input file> → labeled transcript verified
+```
+
+---
+
+## Post-Phase-3 Checklist
+
+Before declaring Phase 3 — and the delivery as a whole — complete, every box below must be ticked:
+
+- [ ] P3.1 merged into `Local-Speaker-Labeling`. CLI `--speakers` flag works end-to-end.
+- [ ] P3.2 merged into `Local-Speaker-Labeling`. MCP `enableSpeakers` parameter works end-to-end.
+- [ ] P3.3 merged into `Local-Speaker-Labeling`. Runbook exists and has been clean-machine walked through.
+- [ ] P3.4 merged into `Local-Speaker-Labeling`. README / ARCHITECTURE / setup docs updated and verified. ADR-024 flipped to `Accepted`.
+- [ ] P3.5 resolved (go path merged, or no-go decision PR merged, or explicitly deferred past Phase 3 with a recorded reason).
+- [ ] P3.6 merged into `Local-Speaker-Labeling`. Acceptance criteria audit complete.
+- [ ] Full `dotnet test VoxFlow.sln` green locally on the integration branch.
+- [ ] Full `dotnet test --filter "Category=RequiresPython"` green on a machine with Python 3.10+ and `pyannote.audio` installed.
+- [ ] Manual smoke test run on at least one real-world recording (not just the 10-second fixtures).
+- [ ] All 13 README acceptance criteria have evidence attached.
+- [ ] `docs/delivery/local-speaker-labeling/README.md` footer says "Ready for user promotion review" with the landing PR numbers listed.
+- [ ] User has been notified that `Local-Speaker-Labeling` is ready for review. Promotion to `master` is the user's decision and is **outside the scope of this delivery**.
+
+When every box is ticked, Phase 3 is complete and the delivery is closed.


### PR DESCRIPTION
## Summary

Fills the three phase placeholders referenced in [docs/delivery/local-speaker-labeling/README.md](docs/delivery/local-speaker-labeling/README.md) so implementation can start from a TDD-ready plan instead of ad-hoc decisions per sub-PR.

- **phase-1-enrichment.md** (~486 lines) — 7 sub-PRs: `SpeakerLabelingOptions` config binding, `TranscribeFileRequest.EnableSpeakers` override, `ISpeakerEnrichmentService` orchestrator, pipeline wiring with `ProgressStage.Diarizing`, output writer speaker rendering, `.voxflow.json` artifact writer, `IValidationService` preflight.
- **phase-2-desktop-ui.md** (~344 lines) — 4 sub-PRs: Ready-screen `SpeakerLabelingToggle` component, per-request toggle forwarding through `TranscribeFileRequest.EnableSpeakers`, Okabe-Ito colored transcript renderer (`OkabeItoPalette.cs` + `SpeakerTranscriptView.razor`), `CompleteView` integration with enrichment warning banner.
- **phase-3-cli-mcp-polish.md** (~492 lines) — 6 sub-PRs: CLI `--speakers` flag with a minimal hand-written parser (no framework adoption), MCP `enableSpeakers` parameter on `transcribe_file`, runbook, `ARCHITECTURE.md` / `setup.md` / `README.md` entries, **conditional** `StandaloneRuntime` behind the python-build-standalone spike go/no-go, release prep.

Each doc matches the phase-0 template: Goal → Exit Criteria → Pre-conditions → Non-goals → TDD sequence per sub-PR → Post-Phase checklist. Every cited path, interface name, and line number was verified against the current codebase so the plans do not reference vaporware.

## Test plan

- [x] `dotnet test VoxFlow.sln --filter "Category!=RequiresPython"` — 0 failed, all green locally (docs-only PR; test run is a guard against accidental stray edits).
- [x] Every internal link and every cited source path resolves against the current tree.
- [ ] Post-Phase-0 `Category=RequiresPython` verification remains pending on a machine with Python 3.10+ / pyannote — tracked in the delivery README checklist, not blocking this PR.