### PR TITLE
feat(core): SpeakerLabelingOptions config binding (P1.1)

### DIFF
--- a/appsettings.example.json
+++ b/appsettings.example.json
@@ -87,6 +87,12 @@
       "useColors": true,
       "progressBarWidth": 32,
       "refreshIntervalMilliseconds": 120
+    },
+    "speakerLabeling": {
+      "enabled": false,
+      "timeoutSeconds": 600,
+      "pythonRuntimeMode": "ManagedVenv",
+      "modelId": "pyannote/speaker-diarization-community-1"
     }
   },
 

--- a/appsettings.json
+++ b/appsettings.json
@@ -87,6 +87,12 @@
       "useColors": true,
       "progressBarWidth": 32,
       "refreshIntervalMilliseconds": 120
+    },
+    "speakerLabeling": {
+      "enabled": false,
+      "timeoutSeconds": 600,
+      "pythonRuntimeMode": "ManagedVenv",
+      "modelId": "pyannote/speaker-diarization-community-1"
     }
   }
 }

--- a/src/VoxFlow.Core/Configuration/PythonRuntimeMode.cs
+++ b/src/VoxFlow.Core/Configuration/PythonRuntimeMode.cs
@@ -1,0 +1,12 @@
+namespace VoxFlow.Core.Configuration;
+
+/// <summary>
+/// Selects which Python runtime implementation hosts the speaker-labeling sidecar.
+/// Standalone is declared now so the config schema stays stable; its runtime lands in Phase 3.
+/// </summary>
+public enum PythonRuntimeMode
+{
+    SystemPython,
+    ManagedVenv,
+    Standalone
+}

--- a/src/VoxFlow.Core/Configuration/SpeakerLabelingOptions.cs
+++ b/src/VoxFlow.Core/Configuration/SpeakerLabelingOptions.cs
@@ -1,0 +1,44 @@
+using System;
+
+namespace VoxFlow.Core.Configuration;
+
+/// <summary>
+/// Immutable configuration for the local speaker-labeling enrichment pipeline.
+/// </summary>
+public sealed record SpeakerLabelingOptions(
+    bool Enabled,
+    int TimeoutSeconds,
+    PythonRuntimeMode RuntimeMode,
+    string ModelId)
+{
+    public static readonly SpeakerLabelingOptions Disabled = new(
+        Enabled: false,
+        TimeoutSeconds: 600,
+        RuntimeMode: PythonRuntimeMode.ManagedVenv,
+        ModelId: "pyannote/speaker-diarization-community-1");
+
+    public int TimeoutSeconds { get; } = EnsurePositiveTimeout(TimeoutSeconds);
+    public string ModelId { get; } = EnsureNonEmptyModelId(ModelId);
+
+    private static int EnsurePositiveTimeout(int value)
+    {
+        if (value <= 0)
+        {
+            throw new InvalidOperationException(
+                $"Settings value '{nameof(TimeoutSeconds)}' must be greater than zero.");
+        }
+
+        return value;
+    }
+
+    private static string EnsureNonEmptyModelId(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new InvalidOperationException(
+                $"Settings value '{nameof(ModelId)}' is required.");
+        }
+
+        return value.Trim();
+    }
+}

--- a/src/VoxFlow.Core/Configuration/TranscriptionOptions.cs
+++ b/src/VoxFlow.Core/Configuration/TranscriptionOptions.cs
@@ -47,6 +47,7 @@ public sealed class TranscriptionOptions
     public ConsoleProgressOptions ConsoleProgress { get; }
     public ResultFormat ResultFormat { get; }
     public BatchOptions Batch { get; }
+    public SpeakerLabelingOptions SpeakerLabeling { get; }
 
     /// <summary>
     /// Creates validated options from raw configuration data.
@@ -105,6 +106,7 @@ public sealed class TranscriptionOptions
         StartupValidation = CreateStartupValidationOptions(configuration.StartupValidation);
         ConsoleProgress = CreateConsoleProgressOptions(configuration.ConsoleProgress);
         Batch = IsBatchMode ? CreateBatchOptions(configuration.Batch) : BatchOptions.Disabled;
+        SpeakerLabeling = CreateSpeakerLabelingOptions(configuration.SpeakerLabeling);
     }
 
     /// <summary>
@@ -295,6 +297,53 @@ public sealed class TranscriptionOptions
     }
 
     /// <summary>
+    /// Maps the raw speaker-labeling JSON section onto the validated options record,
+    /// falling back to <see cref="SpeakerLabelingOptions.Disabled"/> when the section is absent.
+    /// </summary>
+    private static SpeakerLabelingOptions CreateSpeakerLabelingOptions(SpeakerLabelingConfiguration? configuration)
+    {
+        if (configuration is null)
+        {
+            return SpeakerLabelingOptions.Disabled;
+        }
+
+        var runtimeMode = ParsePythonRuntimeMode(configuration.PythonRuntimeMode);
+        var modelId = string.IsNullOrWhiteSpace(configuration.ModelId)
+            ? SpeakerLabelingOptions.Disabled.ModelId
+            : configuration.ModelId;
+        var timeoutSeconds = configuration.TimeoutSeconds <= 0
+            ? SpeakerLabelingOptions.Disabled.TimeoutSeconds
+            : configuration.TimeoutSeconds;
+
+        return new SpeakerLabelingOptions(
+            Enabled: configuration.Enabled,
+            TimeoutSeconds: timeoutSeconds,
+            RuntimeMode: runtimeMode,
+            ModelId: modelId);
+    }
+
+    /// <summary>
+    /// Maps the raw JSON string onto <see cref="PythonRuntimeMode"/> case-insensitively and
+    /// throws a descriptive error that lists every legal value when the input is unrecognized.
+    /// </summary>
+    private static PythonRuntimeMode ParsePythonRuntimeMode(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return SpeakerLabelingOptions.Disabled.RuntimeMode;
+        }
+
+        return value.Trim().ToLowerInvariant() switch
+        {
+            "systempython" => PythonRuntimeMode.SystemPython,
+            "managedvenv" => PythonRuntimeMode.ManagedVenv,
+            "standalone" => PythonRuntimeMode.Standalone,
+            _ => throw new InvalidOperationException(
+                $"Settings value 'transcription.speakerLabeling.pythonRuntimeMode' must be one of: SystemPython, ManagedVenv, Standalone. Got '{value}'.")
+        };
+    }
+
+    /// <summary>
     /// Ensures a required string setting is present.
     /// </summary>
     private static string RequireValue(string? value, string settingName)
@@ -406,6 +455,18 @@ public sealed class TranscriptionConfiguration
     public StartupValidationConfiguration? StartupValidation { get; set; }
     public ConsoleProgressConfiguration? ConsoleProgress { get; set; }
     public BatchConfiguration? Batch { get; set; }
+    public SpeakerLabelingConfiguration? SpeakerLabeling { get; set; }
+}
+
+/// <summary>
+/// Represents raw speaker-labeling settings loaded from JSON inside the transcription section.
+/// </summary>
+public sealed class SpeakerLabelingConfiguration
+{
+    public bool Enabled { get; set; }
+    public int TimeoutSeconds { get; set; }
+    public string? PythonRuntimeMode { get; set; }
+    public string? ModelId { get; set; }
 }
 
 /// <summary>

--- a/tests/TestSupport/TestSettingsFileFactory.cs
+++ b/tests/TestSupport/TestSettingsFileFactory.cs
@@ -38,7 +38,8 @@ internal static class TestSettingsFileFactory
         int maxDuplicateSegmentTextLength = 32,
         string processingMode = "single",
         object? batch = null,
-        string? resultFormat = null)
+        string? resultFormat = null,
+        object? speakerLabeling = null)
     {
         supportedLanguages ??=
         [
@@ -121,6 +122,11 @@ internal static class TestSettingsFileFactory
         if (batch != null)
         {
             transcription["batch"] = batch;
+        }
+
+        if (speakerLabeling != null)
+        {
+            transcription["speakerLabeling"] = speakerLabeling;
         }
 
         var configurationData = new Dictionary<string, object?>

--- a/tests/VoxFlow.Core.Tests/Configuration/SpeakerLabelingOptionsTests.cs
+++ b/tests/VoxFlow.Core.Tests/Configuration/SpeakerLabelingOptionsTests.cs
@@ -1,0 +1,68 @@
+using System;
+using VoxFlow.Core.Configuration;
+using Xunit;
+
+namespace VoxFlow.Core.Tests.Configuration;
+
+public sealed class SpeakerLabelingOptionsTests
+{
+    [Fact]
+    public void Disabled_StaticInstance_HasEnabledFalse_AndHarmlessDefaults()
+    {
+        var disabled = SpeakerLabelingOptions.Disabled;
+
+        Assert.False(disabled.Enabled);
+        Assert.Equal(600, disabled.TimeoutSeconds);
+        Assert.Equal(PythonRuntimeMode.ManagedVenv, disabled.RuntimeMode);
+        Assert.Equal("pyannote/speaker-diarization-community-1", disabled.ModelId);
+    }
+
+    [Fact]
+    public void Construct_ValidInputs_ExposesFields()
+    {
+        var options = new SpeakerLabelingOptions(
+            Enabled: true,
+            TimeoutSeconds: 900,
+            RuntimeMode: PythonRuntimeMode.SystemPython,
+            ModelId: "pyannote/custom-model");
+
+        Assert.True(options.Enabled);
+        Assert.Equal(900, options.TimeoutSeconds);
+        Assert.Equal(PythonRuntimeMode.SystemPython, options.RuntimeMode);
+        Assert.Equal("pyannote/custom-model", options.ModelId);
+    }
+
+    [Fact]
+    public void Construct_NegativeTimeout_Throws()
+    {
+        var exception = Assert.Throws<InvalidOperationException>(() => new SpeakerLabelingOptions(
+            Enabled: true,
+            TimeoutSeconds: -1,
+            RuntimeMode: PythonRuntimeMode.ManagedVenv,
+            ModelId: "pyannote/speaker-diarization-community-1"));
+
+        Assert.Contains("TimeoutSeconds", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Construct_ZeroTimeout_Throws()
+    {
+        Assert.Throws<InvalidOperationException>(() => new SpeakerLabelingOptions(
+            Enabled: true,
+            TimeoutSeconds: 0,
+            RuntimeMode: PythonRuntimeMode.ManagedVenv,
+            ModelId: "pyannote/speaker-diarization-community-1"));
+    }
+
+    [Fact]
+    public void Construct_EmptyModelId_Throws()
+    {
+        var exception = Assert.Throws<InvalidOperationException>(() => new SpeakerLabelingOptions(
+            Enabled: true,
+            TimeoutSeconds: 600,
+            RuntimeMode: PythonRuntimeMode.ManagedVenv,
+            ModelId: "   "));
+
+        Assert.Contains("ModelId", exception.Message, StringComparison.Ordinal);
+    }
+}

--- a/tests/VoxFlow.Core.Tests/TranscriptionOptionsTests.cs
+++ b/tests/VoxFlow.Core.Tests/TranscriptionOptionsTests.cs
@@ -105,4 +105,105 @@ public sealed class TranscriptionOptionsTests
         Assert.Equal(3, options.MaxConsecutiveDuplicateSegments);
         Assert.Equal(64, options.MaxDuplicateSegmentTextLength);
     }
+
+    [Fact]
+    public void LoadFromPath_SpeakerLabelingSectionMissing_DefaultsToDisabled()
+    {
+        using var directory = new TemporaryDirectory();
+
+        var settingsPath = TestSettingsFileFactory.Write(
+            directory.Path,
+            inputFilePath: "/tmp/input.m4a",
+            wavFilePath: "/tmp/output.wav",
+            resultFilePath: "/tmp/result.txt",
+            modelFilePath: "/tmp/model.bin",
+            ffmpegExecutablePath: "ffmpeg");
+
+        var options = TranscriptionOptions.LoadFromPath(settingsPath);
+
+        Assert.False(options.SpeakerLabeling.Enabled);
+        Assert.Equal(SpeakerLabelingOptions.Disabled, options.SpeakerLabeling);
+    }
+
+    [Fact]
+    public void LoadFromPath_SpeakerLabelingSectionPresent_ParsesAllFields()
+    {
+        using var directory = new TemporaryDirectory();
+
+        var settingsPath = TestSettingsFileFactory.Write(
+            directory.Path,
+            inputFilePath: "/tmp/input.m4a",
+            wavFilePath: "/tmp/output.wav",
+            resultFilePath: "/tmp/result.txt",
+            modelFilePath: "/tmp/model.bin",
+            ffmpegExecutablePath: "ffmpeg",
+            speakerLabeling: new
+            {
+                enabled = true,
+                timeoutSeconds = 900,
+                pythonRuntimeMode = "SystemPython",
+                modelId = "pyannote/custom-model"
+            });
+
+        var options = TranscriptionOptions.LoadFromPath(settingsPath);
+
+        Assert.True(options.SpeakerLabeling.Enabled);
+        Assert.Equal(900, options.SpeakerLabeling.TimeoutSeconds);
+        Assert.Equal(PythonRuntimeMode.SystemPython, options.SpeakerLabeling.RuntimeMode);
+        Assert.Equal("pyannote/custom-model", options.SpeakerLabeling.ModelId);
+    }
+
+    [Fact]
+    public void LoadFromPath_SpeakerLabelingRuntimeMode_IsCaseInsensitive()
+    {
+        using var directory = new TemporaryDirectory();
+
+        var settingsPath = TestSettingsFileFactory.Write(
+            directory.Path,
+            inputFilePath: "/tmp/input.m4a",
+            wavFilePath: "/tmp/output.wav",
+            resultFilePath: "/tmp/result.txt",
+            modelFilePath: "/tmp/model.bin",
+            ffmpegExecutablePath: "ffmpeg",
+            speakerLabeling: new
+            {
+                enabled = false,
+                timeoutSeconds = 600,
+                pythonRuntimeMode = "managedvenv",
+                modelId = "pyannote/speaker-diarization-community-1"
+            });
+
+        var options = TranscriptionOptions.LoadFromPath(settingsPath);
+
+        Assert.Equal(PythonRuntimeMode.ManagedVenv, options.SpeakerLabeling.RuntimeMode);
+    }
+
+    [Fact]
+    public void LoadFromPath_SpeakerLabelingUnknownRuntimeMode_Throws()
+    {
+        using var directory = new TemporaryDirectory();
+
+        var settingsPath = TestSettingsFileFactory.Write(
+            directory.Path,
+            inputFilePath: "/tmp/input.m4a",
+            wavFilePath: "/tmp/output.wav",
+            resultFilePath: "/tmp/result.txt",
+            modelFilePath: "/tmp/model.bin",
+            ffmpegExecutablePath: "ffmpeg",
+            speakerLabeling: new
+            {
+                enabled = true,
+                timeoutSeconds = 600,
+                pythonRuntimeMode = "Wat",
+                modelId = "pyannote/speaker-diarization-community-1"
+            });
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => TranscriptionOptions.LoadFromPath(settingsPath));
+
+        Assert.Contains("pythonRuntimeMode", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("SystemPython", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("ManagedVenv", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("Standalone", exception.Message, StringComparison.Ordinal);
+    }
 }


### PR DESCRIPTION
## Summary

First sub-PR of [Phase 1](docs/delivery/local-speaker-labeling/phase-1-enrichment.md). Adds the `transcription.speakerLabeling` nested section to [appsettings.json](appsettings.json) and [appsettings.example.json](appsettings.example.json) with four keys:

- `enabled` — default `false`. Opt-in flag; zero runtime cost when off.
- `timeoutSeconds` — default `600`. Hard per-file sidecar timeout.
- `pythonRuntimeMode` — enum `SystemPython | ManagedVenv | Standalone`, default `ManagedVenv`. Parsed case-insensitively.
- `modelId` — default `pyannote/speaker-diarization-community-1`.

[TranscriptionOptions](src/VoxFlow.Core/Configuration/TranscriptionOptions.cs) now exposes a typed [SpeakerLabelingOptions](src/VoxFlow.Core/Configuration/SpeakerLabelingOptions.cs) record loaded from the JSON section, with a `SpeakerLabelingOptions.Disabled` fallback when the section is absent. Unknown `pythonRuntimeMode` values throw `InvalidOperationException` with a message listing the three legal names.

The `Standalone` enum case is declared now so the config schema stays stable even though its runtime implementation lands in Phase 3 (conditional on the python-build-standalone spike outcome).

## What this is not

Pure additive change. No pipeline wiring, no `TranscribeFileRequest.EnableSpeakers`, no Desktop/CLI/MCP surface, no `ISpeakerEnrichmentService` — those land in P1.2 through P1.7. Zero behavioral change when the section is missing or `enabled=false`. Every pre-existing `TranscriptionOptions` call site in the test tree compiles and passes unchanged thanks to the `Disabled` fallback.

## Test plan

- [x] `dotnet test VoxFlow.sln --filter "Category!=RequiresPython"` — green. Core 241, MCP 35, CLI 6, Desktop 70/72 (2 real-audio skips).
- [x] [SpeakerLabelingOptionsTests](tests/VoxFlow.Core.Tests/Configuration/SpeakerLabelingOptionsTests.cs) — 5 unit cases: `Disabled` static instance, valid construction round-trips every field, negative timeout throws with setting name, zero timeout throws, empty `ModelId` throws.
- [x] [TranscriptionOptionsTests](tests/VoxFlow.Core.Tests/TranscriptionOptionsTests.cs) — 4 new loader cases: section missing → `Disabled`, section present → all fields parsed, `pythonRuntimeMode` case-insensitive, unknown `pythonRuntimeMode` throws with all three legal names listed in the message.
- [ ] Post-Phase-0 `Category=RequiresPython` verification remains pending on a machine with Python 3.10+ / pyannote — tracked in the delivery README checklist, not blocking this PR (no sidecar code touched).