### PR TITLE
feat(core): TranscribeFileRequest.EnableSpeakers override (P1.2)

### DIFF
--- a/src/VoxFlow.Core/Models/TranscribeFileRequest.cs
+++ b/src/VoxFlow.Core/Models/TranscribeFileRequest.cs
@@ -8,4 +8,5 @@ public sealed record TranscribeFileRequest(
     string? ResultFilePath = null,
     string? ConfigurationPath = null,
     IReadOnlyList<string>? ForceLanguages = null,
-    bool OverwriteExistingResult = true);
+    bool OverwriteExistingResult = true,
+    bool? EnableSpeakers = null);

--- a/tests/VoxFlow.Core.Tests/Models/TranscribeFileRequestTests.cs
+++ b/tests/VoxFlow.Core.Tests/Models/TranscribeFileRequestTests.cs
@@ -1,0 +1,54 @@
+using VoxFlow.Core.Models;
+using Xunit;
+
+namespace VoxFlow.Core.Tests.Models;
+
+public sealed class TranscribeFileRequestTests
+{
+    [Fact]
+    public void Construct_WithExistingPositionalArgs_StillCompiles_AndEnableSpeakersDefaultsToNull()
+    {
+        var request = new TranscribeFileRequest(
+            "/tmp/input.m4a",
+            "/tmp/result.txt",
+            "/tmp/appsettings.json",
+            new[] { "en", "uk" },
+            true);
+
+        Assert.Equal("/tmp/input.m4a", request.InputPath);
+        Assert.Equal("/tmp/result.txt", request.ResultFilePath);
+        Assert.Equal("/tmp/appsettings.json", request.ConfigurationPath);
+        Assert.NotNull(request.ForceLanguages);
+        Assert.Equal(2, request.ForceLanguages!.Count);
+        Assert.True(request.OverwriteExistingResult);
+        Assert.Null(request.EnableSpeakers);
+    }
+
+    [Fact]
+    public void Construct_WithOnlyInputPath_EnableSpeakersDefaultsToNull()
+    {
+        var request = new TranscribeFileRequest("/tmp/input.m4a");
+
+        Assert.Null(request.EnableSpeakers);
+    }
+
+    [Fact]
+    public void Construct_WithEnableSpeakersTrue_PreservesValue()
+    {
+        var request = new TranscribeFileRequest(
+            InputPath: "/tmp/input.m4a",
+            EnableSpeakers: true);
+
+        Assert.True(request.EnableSpeakers);
+    }
+
+    [Fact]
+    public void Construct_WithEnableSpeakersFalse_PreservesValue()
+    {
+        var request = new TranscribeFileRequest(
+            InputPath: "/tmp/input.m4a",
+            EnableSpeakers: false);
+
+        Assert.False(request.EnableSpeakers);
+    }
+}


### PR DESCRIPTION
## Summary

Second sub-PR of [Phase 1](docs/delivery/local-speaker-labeling/phase-1-enrichment.md). Adds `bool? EnableSpeakers = null` as a trailing positional record parameter on [TranscribeFileRequest](src/VoxFlow.Core/Models/TranscribeFileRequest.cs).

This is the public hook that:
- **Desktop** will use in Phase 2 to forward the Ready-screen toggle through the pipeline (P2.2).
- **CLI** will use in Phase 3 to honor the `--speakers` flag (P3.1).
- **MCP** will use in Phase 3 to honor the `enableSpeakers` tool parameter (P3.2).

`TranscriptionService` will start respecting the override in P1.4 — this PR only introduces the field.

## What this is not

Pure additive change. No new behavior, no pipeline wiring, no orchestrator. The null default is load-bearing: every pre-existing positional call site in `TranscriptionService`, `BatchTranscriptionService`, `DesktopCliTranscriptionService`, and the MCP tools compiles unchanged. The full test suite ran against untouched host code as the self-check that the default is correct.

## Test plan

- [x] `dotnet test VoxFlow.sln --filter "Category!=RequiresPython"` — green. Core 245 (+4 from P1.1), MCP 35, CLI 6, Desktop 70/72 (2 real-audio skips).
- [x] [TranscribeFileRequestTests](tests/VoxFlow.Core.Tests/Models/TranscribeFileRequestTests.cs) — 4 cases: existing 5-arg positional ctor still compiles and defaults `EnableSpeakers` to null, single-arg ctor defaults to null, `EnableSpeakers: true` preserved, `EnableSpeakers: false` preserved.
- [ ] Post-Phase-0 `Category=RequiresPython` verification pending on a machine with Python 3.10+ / pyannote — not blocked by this PR (no sidecar code touched).