### PR TITLE
feat(desktop): Phase 2 — Desktop UI for speaker labeling

### DIFF
--- a/docs/delivery/local-speaker-labeling/phase-2-desktop-ui.md
+++ b/docs/delivery/local-speaker-labeling/phase-2-desktop-ui.md
@@ -8,22 +8,25 @@
 
 ## Goal
 
-Expose the Phase 1 enrichment pipeline through the Mac Catalyst Desktop app: let users toggle speaker labeling from the Ready screen, see a `Diarizing` stage in the progress UI, and read a colored speaker-labeled transcript on the completion screen. At the end of Phase 2, a Desktop user can enable the feature, transcribe a multi-speaker file, and see turn-taking rendered with a colorblind-safe palette — without any CLI or MCP changes yet.
+Expose the Phase 1 enrichment pipeline through the Mac Catalyst Desktop app: let users toggle speaker labeling from the Ready screen, watch transcription progress on a **three-ring phase tracker** that matches the CLI's stacked `Transcription / Diarization / Merge` layout, and read a colored speaker-labeled transcript on the completion screen. At the end of Phase 2, a Desktop user can enable the feature, transcribe a multi-speaker file, see phase-by-phase progress with per-phase elapsed clocks and status lines, and see turn-taking rendered with a colorblind-safe palette — without any CLI or MCP changes yet.
 
-Phase 2 is a pure presentation phase: no new Core services, no new output formats, no config shape changes. It consumes the `TranscribeFileResult.SpeakerTranscript` and `EnrichmentWarnings` fields that Phase 1 already populates, and it persists the new Ready-screen toggle through the existing `DesktopConfigurationService.SaveUserOverridesAsync` mechanism (the same mechanism `SettingsPanel.razor` uses today for the output format picker).
+Phase 2 is a pure presentation phase: no new Core services, no new output formats, no config shape changes. It consumes the `TranscribeFileResult.SpeakerTranscript` and `EnrichmentWarnings` fields that Phase 1 already populates, reuses the `ProgressUpdate` stream the `CliProgressHandler` already bands into three phases, and persists the new Ready-screen toggle through the existing `DesktopConfigurationService.SaveUserOverridesAsync` mechanism (the same mechanism `SettingsPanel.razor` uses today for the output format picker).
 
 ## Exit Criteria
 
 - The Ready-screen `SettingsPanel` has a new speaker-labeling toggle whose initial state is bound to `TranscriptionOptions.SpeakerLabeling.Enabled`.
 - Toggling the switch persists back to `appsettings.json` via `DesktopConfigurationService.SaveUserOverridesAsync` under the `transcription.speakerLabeling.enabled` key.
 - `AppViewModel.TranscribeFileAsync` forwards the toggle state to the `TranscribeFileRequest` via `EnableSpeakers` so the user's last toggle is honored even if the underlying config has not been reloaded.
-- `ProgressStage.Diarizing` updates reach the `RunningView` and render a stage label (`"Identifying speakers..."`) in the same style as the existing stage labels.
+- `RunningView` renders **three phase rings** (`Transcription`, `Diarization`, `Merge`) stacked vertically. Each ring shows its own local `0..100%` percent, its own sub-status line (`"loading model"`, `"embeddings"`, `"writing output"`, …), and its own phase-local elapsed time that freezes when the phase completes. The three rings use the same color semantics as the CLI (`Transcription` = cyan, `Diarization` = magenta, `Merge` = green) with hex values grounded in the existing `--accent` palette.
+- Phase state transitions (`Idle → Running → Done`) are driven off `ProgressStage` via the same `ProgressPhase` banding used by `CliProgressHandler` (`Transcribing/LoadingModel/Converting/...` → Transcription, `Diarizing` → Diarization, `Writing/Complete` → Merge). When a phase transitions to `Done` its ring renders at 100 %, shows `done`, and its elapsed clock stops.
+- The per-phase elapsed clock keeps ticking between sparse producer events via a 1 s view-model heartbeat (mirroring `CliProgressHandler.EnsureHeartbeatLocked`), so diarization doesn't look frozen during the multi-minute pyannote silence between sub-steps.
+- When speaker labeling is **disabled**, the Diarization ring renders as `Skipped` (muted color, no clock) rather than stuck at 0 %, so the user doesn't think the pipeline is hung.
 - `CompleteView` renders the `TranscriptDocument` as colored speaker turns when `TranscriptionResult.SpeakerTranscript` is not null. When it is null (feature off, or sidecar failure), the view falls back to the existing plain-text preview — no regressions.
 - Speaker colors come from the Okabe-Ito 8-color colorblind-safe palette. Speakers beyond the palette size wrap around modulo 8, and the cycle is documented inline so contributors know why.
 - Enrichment warnings (`result.EnrichmentWarnings`) are visible to the user via a non-blocking info banner on the completion screen, matching the existing `message message-warning` styling.
-- New Razor component tests cover the toggle, the colored transcript renderer, the warning banner, and the fallback-to-plain-text branch.
+- New Razor component tests cover the toggle, the three-phase tracker (phase transitions, local percent banding, elapsed heartbeat, skipped state), the colored transcript renderer, the warning banner, and the fallback-to-plain-text branch.
 - `dotnet test tests/VoxFlow.Desktop.Tests/VoxFlow.Desktop.Tests.csproj` is fully green locally.
-- No Core service, CLI, or MCP files are touched in Phase 2.
+- The only Core change allowed in Phase 2 is the introduction of `ProgressPhaseBanding` (the shared `PhaseOf` / `LocalPercent` / `PhaseUpperBound` helpers extracted from `CliProgressHandler`) and the `ProgressPhase` enum that carries it. The CLI change is purely a delete-and-delegate: behavior is byte-identical, guarded by existing CLI tests. **No MCP files are touched in Phase 2.** No new Core services, no new output formats, no config shape changes.
 
 ## Pre-conditions
 
@@ -43,7 +46,7 @@ Phase 2 is a pure presentation phase: no new Core services, no new output format
 
 ## TDD Sequence
 
-Four sub-PRs, in strict order.
+Five sub-PRs, in strict order.
 
 Conventions for every PR below:
 - **Branch:** `speaker-labeling/p2.M-<slug>` off `Local-Speaker-Labeling`.
@@ -52,7 +55,7 @@ Conventions for every PR below:
 - **Test tagging:** Razor component tests live in `VoxFlow.Desktop.Tests` and use the existing infrastructure under `tests/VoxFlow.Desktop.Tests/Infrastructure`. No new trait is introduced.
 - **Commit authorship:** user only; no Co-Authored-By trailers.
 - **PR body:** no "Generated with Claude Code" footer.
-- **Disabled-path invariant:** every PR must keep existing Desktop UI tests green without edits. If a test requires a touch-up, re-examine whether the new code is accidentally leaking into the disabled path.
+- **Disabled-path invariant:** every PR must keep existing Desktop UI tests green without edits. If a test requires a touch-up, re-examine whether the new code is accidentally leaking into the disabled path. The one exception is P2.3's replacement of the single organic-progress SVG with the three-ring stack — existing `RunningView` tests that asserted on the old SVG must be re-pointed at the new component, and the migration must be explicit in the PR body.
 
 ---
 
@@ -158,16 +161,15 @@ Test plan:
 
 ---
 
-### P2.2 — Forward toggle to `TranscribeFileRequest` + Diarizing progress stage
+### P2.2 — Forward toggle to `TranscribeFileRequest`
 
-**Branch:** `speaker-labeling/p2.2-running-view`
+**Branch:** `speaker-labeling/p2.2-forward-toggle`
 
-**Why second:** Once the toggle exists it must actually reach the pipeline, and while we are touching the request construction in `AppViewModel.TranscribeFileAsync` we can also wire the new `ProgressStage.Diarizing` into the `RunningView`. Both edits live in adjacent code, so splitting them into separate PRs would mean two near-identical round-trips through the view-model; bundling them keeps the change surgical.
+**Why second:** Once the toggle exists it must actually reach the pipeline. This is a tiny, surgical change that we ship on its own because it's a prerequisite for anything that depends on `ProgressStage.Diarizing` being emitted (the three-ring progress screen in P2.3 can't be manually tested without it). Keeping it as a separate PR means the three-ring work below doesn't have to re-review request-wiring logic.
 
 **Files touched (modified):**
 - `src/VoxFlow.Desktop/ViewModels/AppViewModel.cs` — in `TranscribeFileAsync`, change `new TranscribeFileRequest(filePath)` to pass `EnableSpeakers: SpeakerLabelingEnabled ? true : null` as the sixth positional argument. The null fallback means the config-file default still applies when the toggle is off — identical to the user manually setting the flag in JSON.
-- `src/VoxFlow.Desktop/Components/Pages/RunningView.razor` (or whichever file renders `ProgressStage` labels — check before editing) — add a `case ProgressStage.Diarizing` arm returning `"Identifying speakers..."` with the same CSS class as the existing stage labels.
-- `tests/VoxFlow.Desktop.Tests/AppViewModelTests.cs` — new tests for the request forwarding and the progress stage label.
+- `tests/VoxFlow.Desktop.Tests/AppViewModelTests.cs` — new tests for the request forwarding.
 
 **TDD steps:**
 
@@ -175,10 +177,6 @@ Test plan:
 2. **Green.** Pass the sixth positional argument `EnableSpeakers: SpeakerLabelingEnabled`. Use `SpeakerLabelingEnabled ? true : null` so the off-toggle falls back to config. Test passes.
 3. **Red.** `TranscribeFileAsync_SpeakerLabelingDisabled_PassesEnableSpeakersNull`. Assert the field is `null`, not `false`, so the config default still wins.
 4. **Green.** Already handled by the ternary.
-5. **Red.** `RunningViewTests.RendersDiarizingStageLabel`. Publish a `ProgressUpdate { Stage = Diarizing, PercentComplete = 90 }` to the view-model; assert the UI contains `"Identifying speakers..."`.
-6. **Green.** Add the case arm; reuse the existing stage-label component if one exists.
-7. **Red.** `RunningViewTests.DoesNotBreakExistingStages`. Publish `Transcribing`, `Writing`, `Complete` in sequence; assert each label still renders as before.
-8. **Green.** Should already pass — the new arm only adds, does not edit existing arms.
 
 **Local verification:**
 ```
@@ -187,13 +185,11 @@ dotnet test tests/VoxFlow.Desktop.Tests/VoxFlow.Desktop.Tests.csproj
 
 **PR description template:**
 ```
-Forward speaker labeling toggle to TranscribeFileRequest; render Diarizing stage
+Forward speaker labeling toggle to TranscribeFileRequest
 
 AppViewModel.TranscribeFileAsync now passes EnableSpeakers based on the
 Ready-screen toggle. When the toggle is off, EnableSpeakers stays null so
-the config-file default wins — no accidental override. RunningView gains
-a label for the new ProgressStage.Diarizing update emitted by
-TranscriptionService in Phase 1.
+the config-file default wins — no accidental override.
 
 Test plan:
 - [x] dotnet test tests/VoxFlow.Desktop.Tests/VoxFlow.Desktop.Tests.csproj — green
@@ -201,11 +197,145 @@ Test plan:
 
 ---
 
-### P2.3 — Colored speaker transcript renderer
+### P2.3 — Three-ring phase progress on `RunningView`
 
-**Branch:** `speaker-labeling/p2.3-colored-renderer`
+**Branch:** `speaker-labeling/p2.3-three-ring-progress`
 
-**Why third:** The renderer is the largest piece of net-new UI work and the most testable. It must handle the full range of document shapes (0 speakers, 1 speaker, N speakers), wrap the palette at 8 speakers, and fall back cleanly to the existing plain-text preview when no document is present. Shipping it as its own PR lets the palette and wrapping logic be reviewed in isolation.
+**Why third:** Today the Running screen is a single 200×200 SVG that shows one overall percent with one message and one elapsed clock. When speaker labeling is enabled, the overall percent stalls at 90 % for the multi-minute pyannote run and the user has no way to tell what's actually happening, because `ProgressStage.Diarizing` and `ProgressStage.Writing` both roll up into the same bar. The CLI already solved this with three per-phase bars; Phase 2 brings the same model to Desktop.
+
+The change is presentation-only — it subscribes to the exact same `ProgressUpdate` stream and re-uses the `ProgressPhase` banding already shipped in `CliProgressHandler` (`PhaseOf`, `LocalPercent`, `PhaseUpperBound`). That logic is extracted into a shared internal helper so Desktop and CLI stay bit-for-bit consistent instead of silently drifting.
+
+**Files touched (new):**
+- `src/VoxFlow.Core/Models/ProgressPhase.cs` — shared enum `{ Transcription, Diarization, Merge }` used by both the CLI and Desktop. Lives under Core because both hosts depend on Core.
+- `src/VoxFlow.Core/Models/ProgressPhaseBanding.cs` — shared static helper exposing `PhaseOf(ProgressStage)`, `LocalPercent(ProgressStage, double)`, and `PhaseUpperBound(ProgressStage)`. The existing private methods on `CliProgressHandler` are deleted and the CLI consumes this helper instead.
+- `src/VoxFlow.Desktop/ViewModels/PhaseProgressTracker.cs` — an `INotifyPropertyChanged` view-model layer sitting between `AppViewModel.CurrentProgress` and `RunningView`. Exposes an immutable `IReadOnlyList<PhaseState> Phases` where `PhaseState` is a record `(ProgressPhase Phase, PhaseStatus Status, double LocalPercent, string? SubStatus, TimeSpan Elapsed)`. Status is `{ Idle, Running, Done, Skipped, Failed }`. Runs a `System.Threading.Timer` heartbeat identical in shape to `CliProgressHandler`'s so `Elapsed` keeps advancing between producer events; timer is disposed the moment the terminal `Complete`/`Failed` frame arrives.
+- `src/VoxFlow.Desktop/Components/Pages/PhaseRing.razor` — one visual ring. Takes a `PhaseState` plus a phase color; renders the SVG ring + center percent + done checkmark + status/elapsed footer.
+- `src/VoxFlow.Desktop/Components/Pages/PhaseRingStack.razor` — stacks three `PhaseRing` components and passes each one its banded color. This is what `RunningView` actually embeds.
+- `src/VoxFlow.Desktop/wwwroot/css/phase-ring.css` — phase tokens (`--phase-transcription`, `--phase-diarization`, `--phase-merge`), ring track/arc styles, idle/running/done/skipped modifiers. Referenced from the existing `index.html` (or `app.css` if Desktop concatenates).
+- `tests/VoxFlow.Desktop.Tests/Components/PhaseProgressTrackerTests.cs`
+- `tests/VoxFlow.Desktop.Tests/Components/PhaseRingTests.cs`
+- `tests/VoxFlow.Desktop.Tests/Components/PhaseRingStackTests.cs`
+- `tests/VoxFlow.Core.Tests/Models/ProgressPhaseBandingTests.cs`
+
+**Files touched (modified):**
+- `src/VoxFlow.Core/ConsoleProgress/CliProgressHandler.cs` — delete the private `PhaseOf`/`LocalPercent`/`PhaseUpperBound` helpers, delegate to `ProgressPhaseBanding`. Zero behavior change; the existing CLI tests guard the contract.
+- `src/VoxFlow.Desktop/Components/Pages/RunningView.razor` — replace the single organic-progress SVG block with a `<PhaseRingStack Tracker="@ViewModel.PhaseTracker" />` component. Keep the `cancel` button and the top-level progress-info caption (`"Starting transcription..."`, file name) unchanged.
+- `src/VoxFlow.Desktop/ViewModels/AppViewModel.cs` — construct the `PhaseProgressTracker` on init, feed `ProgressUpdate` events into it from the existing progress pipeline, and expose it as `public PhaseProgressTracker PhaseTracker { get; }`. `CurrentProgress` stays for the caption but the ring state comes from the tracker.
+
+**Color palette (new tokens in `phase-ring.css`):**
+
+| Phase | Token | Hex | Rationale |
+|---|---|---|---|
+| Transcription | `--phase-transcription` | `#4aa8ff` | Cyan family, matches CLI ANSI 96 and the existing `--accent` blue lineage. |
+| Diarization | `--phase-diarization` | `#b06cff` | Magenta family, matches CLI ANSI 95. Distinct from transcription cyan and merge green under CVD. |
+| Merge | `--phase-merge` | `#28c840` | Green, matches CLI ANSI 92 and the existing `--success` token. |
+| Idle track | `--phase-track` | `rgba(42,42,74,0.4)` | Existing `organic-track` color; keeps the dark-theme continuity. |
+| Skipped ring | `--phase-skipped` | `#4a4a6a` | Existing `--drop-zone-border`; communicates "off by design" without looking like a stall. |
+
+**`PhaseProgressTracker` contract:**
+
+- Default state on construction: three `PhaseState` entries, all `Idle`, `LocalPercent = 0`, `Elapsed = 0`.
+- On `OnProgress(ProgressUpdate update)`:
+  - Determine `newPhase = ProgressPhaseBanding.PhaseOf(update.Stage)`.
+  - For every phase strictly before `newPhase` still marked `Running` or `Idle`: mark `Done`, set `LocalPercent = 100`, freeze `Elapsed` at its current value. This handles the "pyannote never emitted a closing 100 % frame" case the CLI already works around.
+  - For `newPhase`: if currently `Idle`, set `Status = Running` and record `StartedAtUtc = DateTime.UtcNow`. Update `LocalPercent = ProgressPhaseBanding.LocalPercent(update.Stage, update.PercentComplete)`, `SubStatus = update.Message ?? StageSubLabel(update.Stage)`, `Elapsed = DateTime.UtcNow - StartedAtUtc`.
+  - For phases strictly after `newPhase`: leave as-is (typically still `Idle`).
+- On the terminal `Complete` frame: mark Merge `Done` at 100 %, mark any still-`Running` phase `Done` at 100 %, stop the heartbeat.
+- On `Failed`: mark the current phase `Failed`, stop the heartbeat.
+- Skipped phases: when `speakerLabeling` is off, the producer never emits `Diarizing`. The tracker **does not** pre-mark Diarization as `Skipped` — it only knows what the producer says. To surface `Skipped`, `AppViewModel` passes `speakerLabelingEnabled` into the tracker constructor; when `false`, the Diarization entry is born `Skipped` and the tracker never transitions it.
+- Heartbeat: `System.Threading.Timer` ticks every 1 s, projects the `Running` phase's `Elapsed = DateTime.UtcNow - StartedAtUtc`, and raises `PropertyChanged` on `Phases`. Matches `CliProgressHandler.OnHeartbeat` beat-for-beat.
+
+**`PhaseRing.razor` rendering contract:**
+
+- SVG 120×120 viewport, 7 px stroke track, 7 px stroke arc, center text 18 px + unit 11 px for idle/running, checkmark + "done" label for done/skipped.
+- Arc stroke color = the phase token. Arc rendering = `stroke-dasharray` / `stroke-dashoffset` identical to the existing organic-progress math, just at radius 50 instead of 80.
+- Under the ring: one line for `SubStatus`, one line for `mm:ss` elapsed.
+- States: `idle` = track only, no arc, no elapsed text; `running` = animated arc, live clock, sub-status; `done` = full arc in phase color, static clock at final value, `"done"` sub-status, muted checkmark overlay; `skipped` = track only in `--phase-skipped`, sub-status `"skipped"`, no clock; `failed` = full arc in `--error`, sub-status `"failed"`, static clock.
+
+**TDD steps:**
+
+1. **Red.** `ProgressPhaseBandingTests.PhaseOf_MapsKnownStagesToCorrectPhase`. Table-driven over all `ProgressStage` members. Compile fails: helper doesn't exist.
+2. **Green.** Extract `PhaseOf` from `CliProgressHandler` into `ProgressPhaseBanding`; re-point the CLI to it. CLI tests must stay green.
+3. **Red.** `ProgressPhaseBandingTests.LocalPercent_RemapsOverallToBand`. Parameterized: `(Transcribing, 45%)` → `50%`; `(Diarizing, 92.5%)` → `50%`; `(Writing, 97.5%)` → `50%`. Compile fails until the helper exposes `LocalPercent`.
+4. **Green.** Move `LocalPercent` across.
+5. **Red.** `PhaseProgressTrackerTests.NewTracker_AllIdle_AllZero`. Construct with `speakerLabelingEnabled=true`; assert three phases `Idle`, percent 0, elapsed 0.
+6. **Green.** Implement the constructor.
+7. **Red.** `OnProgress_TranscribingFrame_MovesTranscriptionToRunning`. Push `{Stage=Transcribing, Percent=45%}`; assert Transcription = `Running`, local percent ≈ 50, sub-status "transcribing", elapsed > 0.
+8. **Green.** Implement the "first frame starts the phase" branch.
+9. **Red.** `OnProgress_DiarizingAfterTranscribing_MarksTranscriptionDone`. Push Transcribing then Diarizing; assert Transcription flips to `Done` at 100 %, elapsed frozen.
+10. **Green.** Implement the "finalize earlier phases" branch.
+11. **Red.** `OnProgress_TerminalCompleteFrame_MarksAllRunningDone`. Push Transcribing then Complete; assert all three phases end `Done`.
+12. **Green.** Implement the terminal handler.
+13. **Red.** `OnProgress_Failed_MarksCurrentPhaseFailed`. Push Transcribing then Failed; assert Transcription = `Failed`.
+14. **Green.** Implement the failure handler.
+15. **Red.** `Tracker_WithSpeakerLabelingDisabled_DiarizationBornSkipped`. Construct with `speakerLabelingEnabled=false`; assert Diarization = `Skipped` from the start and never flips.
+16. **Green.** Wire the constructor parameter.
+17. **Red.** `Heartbeat_TickAdvancesElapsed_WhileRunning`. Inject a `TimeProvider` fake (or reuse the existing test-time pattern); push Transcribing; advance 2 s without another `OnProgress`; assert Transcription's elapsed is ≥ 2 s.
+18. **Green.** Implement the timer with `TimeProvider` so tests don't sleep.
+19. **Red.** `Heartbeat_StopsOnTerminal`. Push Complete; advance 2 s; assert elapsed didn't move.
+20. **Green.** Dispose the timer in the terminal branch.
+21. **Red.** `PhaseRingTests.Idle_RendersTrackOnlyAndNoClock`. Render with `Status=Idle`; assert no arc `<circle class="phase-arc">` appears and no `.phase-elapsed` element.
+22. **Green.** Implement the idle branch.
+23. **Red.** `Running_RendersArcProportionalToLocalPercent`. LocalPercent=25; assert the `stroke-dashoffset` equals circumference × 0.75 ± 0.01.
+24. **Green.** Implement the arc math (mirror `RunningView`'s existing formula).
+25. **Red.** `Done_RendersFullArcAndFrozenClock`. Status=Done, Elapsed=4:20; assert arc dashoffset=0 and clock shows `4:20`.
+26. **Green.** Implement the done branch.
+27. **Red.** `Skipped_RendersInSkippedColorNoClock`. Assert the arc stroke is `var(--phase-skipped)` and no `.phase-elapsed` element.
+28. **Green.** Implement the skipped branch.
+29. **Red.** `PhaseRingStackTests.RendersThreeRingsInTranscriptionDiarizationMergeOrder`. Assert the three child components in correct DOM order with the correct phase tokens.
+30. **Green.** Implement the stack layout.
+31. **Red.** `RunningViewTests.EmbedsPhaseRingStack_NotOrganicProgress`. Assert the new component is rendered and the old `.organic-progress-wrapper` element is gone.
+32. **Green.** Replace the block.
+33. **Red.** `RunningViewTests.CancelButton_StillWorks`. Regression: click cancel; assert `ViewModel.CancelTranscription` was called once.
+34. **Green.** Should pass untouched; added as a regression guard.
+35. **Refactor.** Pull shared SVG math (circumference, dashoffset) into a private helper used by both `PhaseRing` and any future ring variants.
+
+**Local verification:**
+```
+dotnet test tests/VoxFlow.Core.Tests/VoxFlow.Core.Tests.csproj
+dotnet test tests/VoxFlow.Desktop.Tests/VoxFlow.Desktop.Tests.csproj
+dotnet test VoxFlow.sln
+```
+
+**Manual verification:**
+- Launch Desktop, drop an audio file, enable speaker labeling → three rings appear, Transcription fills, then Diarization, then Merge. Each ring's clock shows only its own phase elapsed.
+- Disable speaker labeling, drop a file → Diarization ring renders in `--phase-skipped` color with "skipped" label. Transcription and Merge still run.
+- Leave Desktop running during pyannote's embeddings step → Diarization clock keeps ticking every second; no freeze.
+
+**PR description template:**
+```
+Render three-ring phase progress on Desktop RunningView
+
+Replaces the single organic-progress SVG on RunningView with a stack of
+three rings (Transcription / Diarization / Merge) mirroring the CLI's
+phase-banded progress layout. Each ring shows its own local percent,
+sub-status, and phase-local elapsed clock; clocks freeze when the phase
+transitions to Done.
+
+The CLI's PhaseOf / LocalPercent / PhaseUpperBound helpers are promoted
+from CliProgressHandler's private members to a shared
+Core.Models.ProgressPhaseBanding helper so Desktop and CLI stay
+bit-for-bit consistent. CLI behavior is unchanged.
+
+When speaker labeling is disabled, the Diarization ring renders as
+"skipped" (muted color, no clock) so the user can see at a glance which
+phases the pipeline will run.
+
+Test plan:
+- [x] dotnet test tests/VoxFlow.Core.Tests/VoxFlow.Core.Tests.csproj — green (CLI-shared helper)
+- [x] dotnet test tests/VoxFlow.Desktop.Tests/VoxFlow.Desktop.Tests.csproj — green
+- [x] dotnet test VoxFlow.sln — green, no regressions
+- [x] Manual: rings tick through Transcription → Diarization → Merge on a multi-speaker file
+- [x] Manual: Diarization ring shows Skipped when toggle is off
+```
+
+---
+
+### P2.4 — Colored speaker transcript renderer
+
+**Branch:** `speaker-labeling/p2.4-colored-renderer`
+
+**Why fourth:** The renderer is the largest piece of net-new UI work on the CompleteView side and the most testable. It must handle the full range of document shapes (0 speakers, 1 speaker, N speakers), wrap the palette at 8 speakers, and fall back cleanly to the existing plain-text preview when no document is present. Shipping it as its own PR lets the palette and wrapping logic be reviewed in isolation.
 
 **Files touched (new):**
 - `src/VoxFlow.Desktop/Components/Shared/SpeakerTranscriptView.razor` — renders a `TranscriptDocument` as a vertical list of colored turns.
@@ -273,7 +403,7 @@ New Desktop component renders a TranscriptDocument as a list of colored
 speaker turns. Colors come from the 8-entry Okabe-Ito colorblind-safe
 palette mapped by speaker ordinal, wrapping at 8 speakers. Fallback cases
 (null document, empty turns) render empty or a subdued message. Component
-is not yet wired into CompleteView — that lands in P2.4.
+is not yet wired into CompleteView — that lands in P2.5.
 
 Test plan:
 - [x] dotnet test tests/VoxFlow.Desktop.Tests/VoxFlow.Desktop.Tests.csproj — green
@@ -281,11 +411,11 @@ Test plan:
 
 ---
 
-### P2.4 — CompleteView integration + enrichment warning banner
+### P2.5 — CompleteView integration + enrichment warning banner
 
-**Branch:** `speaker-labeling/p2.4-complete-view`
+**Branch:** `speaker-labeling/p2.5-complete-view`
 
-**Why fourth (last):** This is the smallest change once the renderer and the toggle exist: swap the plain-text preview for the colored view when a document is present and add a warning banner for non-empty `EnrichmentWarnings`. Shipping it last means the rest of Phase 2 can be reviewed without the CompleteView churn, and users only see the finished experience in one step.
+**Why fifth (last):** This is the smallest change once the renderer, the toggle, and the three-ring tracker exist: swap the plain-text preview for the colored view when a document is present and add a warning banner for non-empty `EnrichmentWarnings`. Shipping it last means the rest of Phase 2 can be reviewed without the CompleteView churn, and users only see the finished experience in one step.
 
 **Files touched (modified):**
 - `src/VoxFlow.Desktop/Components/Pages/CompleteView.razor` — replace the plain-text preview block with a conditional: if `result.SpeakerTranscript is not null`, render `<SpeakerTranscriptView Document="result.SpeakerTranscript" />` inside the existing `complete-transcript-section` wrapper; otherwise render the existing plain-text preview markup unchanged. Add a new `EnrichmentWarningsBanner` block above the transcript section that shows each warning from `result.EnrichmentWarnings` in a `message message-info` style row.
@@ -333,12 +463,14 @@ Test plan:
 
 Before declaring Phase 2 complete and moving to Phase 3 planning:
 
-- [ ] All 4 sub-PRs merged into `Local-Speaker-Labeling`.
+- [ ] All 5 sub-PRs merged into `Local-Speaker-Labeling`.
 - [ ] `dotnet test VoxFlow.sln` on `Local-Speaker-Labeling` is fully green.
 - [ ] Manual smoke on a real Mac Catalyst build: toggle on, transcribe the Obama clip, confirm the colored transcript renders on CompleteView with `Speaker A:` turns in the first palette color.
-- [ ] Manual smoke: toggle on, transcribe a multi-speaker file, confirm speakers beyond index 0 have distinct palette colors.
-- [ ] Manual smoke: toggle off, transcribe any file, confirm CompleteView renders the plain-text preview exactly as before (no colored view, no warning banner).
+- [ ] Manual smoke: toggle on, transcribe a multi-speaker file, confirm the three rings advance in order with phase-local clocks and speakers beyond index 0 have distinct palette colors.
+- [ ] Manual smoke: toggle off, transcribe any file, confirm the Diarization ring renders as Skipped, and CompleteView renders the plain-text preview exactly as before (no colored view, no warning banner).
+- [ ] Manual smoke: leave Desktop running through pyannote's embeddings step on a 5+ minute file; confirm the Diarization clock keeps ticking every second (no freeze) via the heartbeat.
 - [ ] Manual smoke: force a sidecar failure (point `modelId` at a non-existent model), toggle on, transcribe; confirm the warning banner shows `speaker-labeling: …` and the plain-text preview still renders because `SpeakerTranscript` is null.
 - [ ] Okabe-Ito palette is documented in a one-line comment inside `OkabeItoPalette.cs` linking to the canonical source.
-- [ ] No files under `src/VoxFlow.Cli` or `src/VoxFlow.McpServer` were touched in this phase.
+- [ ] `ProgressPhaseBanding` is consumed by both `CliProgressHandler` and `PhaseProgressTracker`; no duplicate banding logic survives on either side.
+- [ ] No files under `src/VoxFlow.Cli` or `src/VoxFlow.McpServer` were touched in this phase (the banding helper lives in Core — the CLI only changes to _consume_ it).
 - [ ] User has reviewed the integration branch state and approved starting Phase 3.

--- a/src/VoxFlow.Cli/CliProgressHandler.cs
+++ b/src/VoxFlow.Cli/CliProgressHandler.cs
@@ -37,6 +37,10 @@ internal sealed class CliProgressHandler : IProgress<ProgressUpdate>, IDisposabl
     private DateTime _lastUpdateUtc;
     private ProgressPhase? _lastPhase;
 
+    private static ProgressPhase PhaseOf(ProgressStage stage) => ProgressPhaseBanding.PhaseOf(stage);
+    private static double LocalPercent(ProgressStage stage, double overall) => ProgressPhaseBanding.LocalPercent(stage, overall);
+    private static double PhaseUpperBound(ProgressStage stage) => ProgressPhaseBanding.PhaseUpperBound(stage);
+
     public CliProgressHandler(ConsoleProgressOptions options)
         : this(options, DefaultHeartbeatInterval)
     {
@@ -218,54 +222,6 @@ internal sealed class CliProgressHandler : IProgress<ProgressUpdate>, IDisposabl
 
         sb.Append(Colorize("]", "90"));
     }
-
-    private enum ProgressPhase
-    {
-        Transcription,
-        Diarization,
-        Merge
-    }
-
-    private static ProgressPhase PhaseOf(ProgressStage stage) => stage switch
-    {
-        ProgressStage.Diarizing => ProgressPhase.Diarization,
-        ProgressStage.Writing or ProgressStage.Complete => ProgressPhase.Merge,
-        _ => ProgressPhase.Transcription
-    };
-
-    private static double LocalPercent(ProgressStage stage, double overall)
-    {
-        // Failed can arrive at any overall percent; show it as-is instead of
-        // forcing it through a phase band so the user sees where it gave up.
-        if (stage == ProgressStage.Failed)
-            return Clamp(overall);
-
-        var (start, end) = PhaseOf(stage) switch
-        {
-            ProgressPhase.Transcription => (0.0, 90.0),
-            ProgressPhase.Diarization => (90.0, 95.0),
-            ProgressPhase.Merge => (95.0, 100.0),
-            _ => (0.0, 100.0)
-        };
-        var span = end - start;
-        if (span <= 0) return 0.0;
-        return Clamp((overall - start) / span * 100.0);
-    }
-
-    private static double Clamp(double value)
-    {
-        if (value < 0) return 0;
-        if (value > 100) return 100;
-        return value;
-    }
-
-    private static double PhaseUpperBound(ProgressStage stage) => PhaseOf(stage) switch
-    {
-        ProgressPhase.Transcription => 90.0,
-        ProgressPhase.Diarization => 95.0,
-        ProgressPhase.Merge => 100.0,
-        _ => 100.0
-    };
 
     private static string FormatPhase(ProgressStage stage)
     {

--- a/src/VoxFlow.Core/Models/ProgressPhase.cs
+++ b/src/VoxFlow.Core/Models/ProgressPhase.cs
@@ -1,0 +1,14 @@
+namespace VoxFlow.Core.Models;
+
+/// <summary>
+/// The three coarse phases a transcription run goes through. Used by both
+/// the CLI progress bar and the Desktop three-ring progress tracker so the
+/// two hosts display the same banded view of a <see cref="ProgressStage"/>
+/// stream.
+/// </summary>
+public enum ProgressPhase
+{
+    Transcription,
+    Diarization,
+    Merge
+}

--- a/src/VoxFlow.Core/Models/ProgressPhaseBanding.cs
+++ b/src/VoxFlow.Core/Models/ProgressPhaseBanding.cs
@@ -1,0 +1,58 @@
+namespace VoxFlow.Core.Models;
+
+/// <summary>
+/// Shared mapping between <see cref="ProgressStage"/> values and the three
+/// user-facing phases (<see cref="ProgressPhase"/>). Extracted from the CLI
+/// progress handler so the CLI's stacked bars and the Desktop's three rings
+/// stay bit-for-bit consistent.
+/// </summary>
+public static class ProgressPhaseBanding
+{
+    public static ProgressPhase PhaseOf(ProgressStage stage) => stage switch
+    {
+        ProgressStage.Diarizing => ProgressPhase.Diarization,
+        ProgressStage.Writing or ProgressStage.Complete => ProgressPhase.Merge,
+        _ => ProgressPhase.Transcription
+    };
+
+    /// <summary>
+    /// Remaps an overall 0..100 % into the current phase's local 0..100 %
+    /// so each ring shows its own progress instead of the shared overall.
+    /// </summary>
+    public static double LocalPercent(ProgressStage stage, double overall)
+    {
+        if (stage == ProgressStage.Failed)
+            return Clamp(overall);
+
+        var (start, end) = PhaseOf(stage) switch
+        {
+            ProgressPhase.Transcription => (0.0, 90.0),
+            ProgressPhase.Diarization => (90.0, 95.0),
+            ProgressPhase.Merge => (95.0, 100.0),
+            _ => (0.0, 100.0)
+        };
+        var span = end - start;
+        if (span <= 0) return 0.0;
+        return Clamp((overall - start) / span * 100.0);
+    }
+
+    /// <summary>
+    /// The overall-percent ceiling for the phase a stage belongs to. Used
+    /// by the CLI to synthesize a closing 100 % frame on phase transition
+    /// because neither Whisper nor pyannote emits one reliably.
+    /// </summary>
+    public static double PhaseUpperBound(ProgressStage stage) => PhaseOf(stage) switch
+    {
+        ProgressPhase.Transcription => 90.0,
+        ProgressPhase.Diarization => 95.0,
+        ProgressPhase.Merge => 100.0,
+        _ => 100.0
+    };
+
+    private static double Clamp(double value)
+    {
+        if (value < 0) return 0;
+        if (value > 100) return 100;
+        return value;
+    }
+}

--- a/src/VoxFlow.Desktop/Components/Pages/CompleteView.razor
+++ b/src/VoxFlow.Desktop/Components/Pages/CompleteView.razor
@@ -1,3 +1,4 @@
+@using VoxFlow.Desktop.Components.Shared
 @inject AppViewModel ViewModel
 @inject IResultActionService ResultActionService
 @implements IDisposable
@@ -34,8 +35,27 @@
             }
         </div>
 
-        <!-- Transcript preview -->
-        @if (!string.IsNullOrEmpty(result.TranscriptPreview))
+        @if (result.EnrichmentWarnings.Count > 0)
+        {
+            <div class="enrichment-warnings-banner" id="enrichment-warnings-banner"
+                 role="status" aria-label="Enrichment Warnings">
+                @foreach (var warning in result.EnrichmentWarnings)
+                {
+                    <div class="message message-info">
+                        <span class="message-icon" aria-hidden="true">&#x2139;</span>
+                        <span>@warning</span>
+                    </div>
+                }
+            </div>
+        }
+
+        @if (result.SpeakerTranscript is not null)
+        {
+            <div class="complete-transcript-section">
+                <SpeakerTranscriptView Document="@result.SpeakerTranscript" />
+            </div>
+        }
+        else if (!string.IsNullOrEmpty(result.TranscriptPreview))
         {
             <div class="complete-transcript-section">
                 <div class="complete-transcript-header">

--- a/src/VoxFlow.Desktop/Components/Pages/PhaseRing.razor
+++ b/src/VoxFlow.Desktop/Components/Pages/PhaseRing.razor
@@ -25,9 +25,21 @@
         _ => "phase-ring-arc"
     };
     var phaseToken = string.IsNullOrEmpty(PhaseToken) ? "--phase-transcription" : PhaseToken;
+    var ariaValueNow = State.Status switch
+    {
+        PhaseStatus.Done => "100",
+        PhaseStatus.Running => ((int)Math.Round(pct)).ToString(CultureInfo.InvariantCulture),
+        _ => ((int)Math.Round(pct)).ToString(CultureInfo.InvariantCulture)
+    };
+    var ariaLabel = $"{State.Phase} progress";
 }
 
-<div class="phase-ring" style="--phase-color: var(@phaseToken);">
+<div class="phase-ring" style="--phase-color: var(@phaseToken);"
+     role="progressbar"
+     aria-label="@ariaLabel"
+     aria-valuemin="0"
+     aria-valuemax="100"
+     aria-valuenow="@ariaValueNow">
     <div class="phase-ring-body">
         <svg class="phase-ring-svg" viewBox="0 0 120 120"
              xmlns="http://www.w3.org/2000/svg" aria-hidden="true">

--- a/src/VoxFlow.Desktop/Components/Pages/PhaseRing.razor
+++ b/src/VoxFlow.Desktop/Components/Pages/PhaseRing.razor
@@ -1,0 +1,94 @@
+@using System.Globalization
+@using VoxFlow.Desktop.ViewModels
+
+@{
+    var radius = 50.0;
+    var circumference = 2.0 * Math.PI * radius;
+    var pct = Math.Clamp(State.LocalPercent, 0.0, 100.0);
+    var dashoffset = State.Status switch
+    {
+        PhaseStatus.Done => 0.0,
+        PhaseStatus.Running => circumference * (1.0 - pct / 100.0),
+        PhaseStatus.Failed  => circumference * (1.0 - pct / 100.0),
+        _ => circumference
+    };
+    var showArc = State.Status is PhaseStatus.Running
+        or PhaseStatus.Done
+        or PhaseStatus.Failed;
+    var showElapsed = State.Status is PhaseStatus.Running
+        or PhaseStatus.Done
+        or PhaseStatus.Failed;
+    var arcClass = State.Status switch
+    {
+        PhaseStatus.Running => "phase-ring-arc phase-ring-arc-running",
+        PhaseStatus.Failed  => "phase-ring-arc phase-ring-arc-failed",
+        _ => "phase-ring-arc"
+    };
+    var phaseToken = string.IsNullOrEmpty(PhaseToken) ? "--phase-transcription" : PhaseToken;
+}
+
+<div class="phase-ring" style="--phase-color: var(@phaseToken);">
+    <div class="phase-ring-body">
+        <svg class="phase-ring-svg" viewBox="0 0 120 120"
+             xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+            <circle class="phase-ring-track"
+                    cx="60" cy="60" r="@Fmt(radius)"
+                    fill="none" stroke-width="7" />
+            @if (showArc)
+            {
+                <circle class="@arcClass"
+                        cx="60" cy="60" r="@Fmt(radius)"
+                        fill="none" stroke-width="7"
+                        stroke-linecap="round"
+                        stroke-dasharray="@Fmt(circumference)"
+                        stroke-dashoffset="@Fmt(dashoffset)"
+                        transform="rotate(-90 60 60)" />
+            }
+        </svg>
+        <div class="phase-ring-center">
+            @switch (State.Status)
+            {
+                case PhaseStatus.Idle:
+                case PhaseStatus.Running:
+                    <span class="phase-ring-percent">@($"{pct:F0}")</span>
+                    <span class="phase-ring-unit">%</span>
+                    break;
+                case PhaseStatus.Done:
+                    <span class="phase-ring-glyph phase-ring-glyph-done" aria-hidden="true">✓</span>
+                    <span class="phase-ring-done-label">done</span>
+                    break;
+                case PhaseStatus.Skipped:
+                    <span class="phase-ring-glyph phase-ring-glyph-skipped" aria-hidden="true">−</span>
+                    <span class="phase-ring-skipped-label">skipped</span>
+                    break;
+                case PhaseStatus.Failed:
+                    <span class="phase-ring-glyph phase-ring-glyph-failed" aria-hidden="true">×</span>
+                    <span class="phase-ring-failed-label">failed</span>
+                    break;
+            }
+        </div>
+    </div>
+    @if (!string.IsNullOrEmpty(State.SubStatus))
+    {
+        <p class="phase-ring-substatus">@State.SubStatus</p>
+    }
+    @if (showElapsed)
+    {
+        <p class="phase-ring-elapsed">@FormatElapsed(State.Elapsed)</p>
+    }
+</div>
+
+@code {
+    [Parameter, EditorRequired] public PhaseState State { get; set; } = default!;
+    [Parameter, EditorRequired] public string PhaseToken { get; set; } = "--phase-transcription";
+
+    private static string Fmt(double val) =>
+        val.ToString("F4", CultureInfo.InvariantCulture);
+
+    private static string FormatElapsed(TimeSpan elapsed)
+    {
+        return elapsed.TotalHours >= 1
+            ? elapsed.ToString(@"h\:mm\:ss", CultureInfo.InvariantCulture)
+            : elapsed.ToString(@"m\:ss", CultureInfo.InvariantCulture);
+    }
+}

--- a/src/VoxFlow.Desktop/Components/Pages/PhaseRingStack.razor
+++ b/src/VoxFlow.Desktop/Components/Pages/PhaseRingStack.razor
@@ -1,0 +1,42 @@
+@using System.ComponentModel
+@using VoxFlow.Desktop.ViewModels
+@implements IDisposable
+
+@{
+    var phases = Tracker.Phases;
+}
+
+<div class="phase-ring-stack">
+    <div class="phase-ring-item">
+        <PhaseRing State="@phases[0]" PhaseToken="--phase-transcription" />
+    </div>
+    <div class="phase-ring-chevron" aria-hidden="true">@ChevronGlyph</div>
+    <div class="phase-ring-item">
+        <PhaseRing State="@phases[1]" PhaseToken="--phase-diarization" />
+    </div>
+    <div class="phase-ring-chevron" aria-hidden="true">@ChevronGlyph</div>
+    <div class="phase-ring-item">
+        <PhaseRing State="@phases[2]" PhaseToken="--phase-merge" />
+    </div>
+</div>
+
+@code {
+    private const string ChevronGlyph = "\u203A";
+
+    [Parameter, EditorRequired] public PhaseProgressTracker Tracker { get; set; } = default!;
+
+    protected override void OnInitialized()
+    {
+        Tracker.PropertyChanged += OnTrackerChanged;
+    }
+
+    private void OnTrackerChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        _ = InvokeAsync(StateHasChanged);
+    }
+
+    public void Dispose()
+    {
+        Tracker.PropertyChanged -= OnTrackerChanged;
+    }
+}

--- a/src/VoxFlow.Desktop/Components/Pages/RunningView.razor
+++ b/src/VoxFlow.Desktop/Components/Pages/RunningView.razor
@@ -5,145 +5,10 @@
 
 @{
     var hasProgress = ViewModel.CurrentProgress is not null;
-    var percent = hasProgress ? Math.Clamp(ViewModel.CurrentProgress!.PercentComplete, 0, 100) : 0;
     var isComplete = hasProgress && ViewModel.CurrentProgress!.Stage == VoxFlow.Core.Models.ProgressStage.Complete;
-    var radius = 80.0;
-    var circumference = 2.0 * Math.PI * radius;
-    var dashOffset = isComplete ? 0 : circumference * (1.0 - percent / 100.0);
-    var toRad = Math.PI / 180.0;
-    var progressDeg = percent / 100.0 * 360.0;
-
-    // Blob positions (screen space: 0deg = top, clockwise)
-    var leadAngle = (progressDeg - 90.0) * toRad;
-    var leadCx = 100.0 + radius * Math.Cos(leadAngle);
-    var leadCy = 100.0 + radius * Math.Sin(leadAngle);
-
-    var midAngle = (progressDeg * 0.4 - 90.0) * toRad;
-    var midCx = 100.0 + radius * Math.Cos(midAngle);
-    var midCy = 100.0 + radius * Math.Sin(midAngle);
-
-    var indeterminateArc = circumference * 0.25;
-    var indeterminateGap = circumference * 0.75;
-
-    var wrapperClass = isComplete ? "organic-progress-done" : hasProgress ? "" : "organic-progress-indeterminate";
 }
 
 <div id="running-screen" aria-label="Running Screen">
-    <div class="organic-progress-wrapper @wrapperClass"
-         role="progressbar"
-         aria-valuenow="@(hasProgress ? $"{percent:F0}" : null)"
-         aria-valuemin="0"
-         aria-valuemax="100"
-         aria-label="Transcription progress">
-        <svg class="organic-progress-svg" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
-            <defs>
-                <filter id="blob-blur" x="-100%" y="-100%" width="300%" height="300%">
-                    <feGaussianBlur stdDeviation="5" />
-                </filter>
-                <filter id="arc-glow" x="-50%" y="-50%" width="200%" height="200%">
-                    <feGaussianBlur in="SourceGraphic" stdDeviation="3" result="blur" />
-                    <feMerge>
-                        <feMergeNode in="blur" />
-                        <feMergeNode in="SourceGraphic" />
-                    </feMerge>
-                </filter>
-                <filter id="center-shadow" x="-20%" y="-20%" width="140%" height="140%">
-                    <feDropShadow dx="0" dy="2" stdDeviation="8" flood-color="rgba(0,0,0,0.5)" />
-                </filter>
-                <radialGradient id="center-fill" cx="40%" cy="35%" r="65%">
-                    <stop offset="0%" stop-color="#1f1f38" />
-                    <stop offset="100%" stop-color="#1a1a2e" />
-                </radialGradient>
-            </defs>
-
-            <!-- Ambient glow -->
-            <circle class="organic-ambient" cx="100" cy="100" r="80" fill="none"
-                    stroke="rgba(74,74,255,0.05)" stroke-width="44" />
-
-            <!-- Track ring -->
-            <circle class="organic-track" cx="100" cy="100" r="80" fill="none"
-                    stroke="rgba(42,42,74,0.4)" stroke-width="14" />
-
-            @if (hasProgress)
-            {
-                @if (percent > 2)
-                {
-                    <!-- Start blob -->
-                    <circle class="organic-blob organic-blob-1"
-                            cx="100" cy="20" r="16"
-                            fill="rgba(92,92,255,0.30)" filter="url(#blob-blur)" />
-
-                    <!-- Lead blob -->
-                    <circle class="organic-blob organic-blob-2"
-                            cx="@Fmt(leadCx)" cy="@Fmt(leadCy)" r="18"
-                            fill="rgba(74,74,255,0.35)" filter="url(#blob-blur)" />
-                }
-
-                @if (percent > 18)
-                {
-                    <!-- Mid blob -->
-                    <ellipse class="organic-blob organic-blob-3"
-                             cx="@Fmt(midCx)" cy="@Fmt(midCy)" rx="14" ry="10"
-                             fill="rgba(58,58,224,0.25)" filter="url(#blob-blur)" />
-                }
-
-                <!-- Progress arc -->
-                <circle class="organic-arc"
-                        cx="100" cy="100" r="@Fmt(radius)"
-                        fill="none" stroke="rgba(74,74,255,0.85)" stroke-width="12"
-                        stroke-linecap="round"
-                        stroke-dasharray="@Fmt(circumference)"
-                        stroke-dashoffset="@Fmt(dashOffset)"
-                        transform="rotate(-90 100 100)"
-                        filter="url(#arc-glow)" />
-            }
-            else
-            {
-                <!-- Orbiting blobs -->
-                <g class="organic-orbit">
-                    <circle cx="100" cy="20" r="14"
-                            fill="rgba(74,74,255,0.25)" filter="url(#blob-blur)" />
-                    <circle cx="168" cy="140" r="12"
-                            fill="rgba(92,92,255,0.20)" filter="url(#blob-blur)" />
-                </g>
-
-                <!-- Spinning arc -->
-                <circle class="organic-spin-arc"
-                        cx="100" cy="100" r="@Fmt(radius)"
-                        fill="none" stroke="rgba(74,74,255,0.70)" stroke-width="12"
-                        stroke-linecap="round"
-                        stroke-dasharray="@Fmt(indeterminateArc) @Fmt(indeterminateGap)" />
-            }
-
-            <!-- Inner circle -->
-            <circle cx="100" cy="100" r="58" fill="url(#center-fill)" filter="url(#center-shadow)" />
-            <circle class="organic-inner-border" cx="100" cy="100" r="58" fill="none"
-                    stroke="rgba(74,74,255,0.10)" stroke-width="1" />
-        </svg>
-
-        <div class="organic-progress-center">
-            @if (isComplete)
-            {
-                <div class="organic-done-content">
-                    <svg width="48" height="48" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-                        <path d="M20 6L9 17l-5-5" stroke="currentColor" stroke-width="2.5"
-                              stroke-linecap="round" stroke-linejoin="round"/>
-                    </svg>
-                    <span class="organic-done-label">Done</span>
-                </div>
-            }
-            else if (hasProgress)
-            {
-                <span class="organic-progress-value" id="running-percent">@($"{percent:F0}")</span>
-                <span class="organic-progress-unit">%</span>
-            }
-            else
-            {
-                <div class="organic-progress-spinner"></div>
-            }
-        </div>
-    </div>
-
     <div class="progress-info">
         @if (isComplete)
         {
@@ -170,6 +35,8 @@
             </p>
         }
     </div>
+
+    <PhaseRingStack Tracker="@ViewModel.PhaseTracker" />
 </div>
 
 <div class="btn-group mt-4" style="@(isComplete ? "opacity:0;pointer-events:none" : "")">
@@ -192,9 +59,6 @@
     {
         _ = InvokeAsync(StateHasChanged);
     }
-
-    private static string Fmt(double val) =>
-        val.ToString("F2", CultureInfo.InvariantCulture);
 
     private static string FormatElapsed(TimeSpan elapsed)
     {

--- a/src/VoxFlow.Desktop/Components/Shared/SettingsPanel.razor
+++ b/src/VoxFlow.Desktop/Components/Shared/SettingsPanel.razor
@@ -22,6 +22,8 @@
     </div>
 </div>
 
+<SpeakerLabelingToggle IsDisabled="IsDisabled" />
+
 @code {
     [Parameter]
     public bool IsDisabled { get; set; }

--- a/src/VoxFlow.Desktop/Components/Shared/SpeakerLabelingToggle.razor
+++ b/src/VoxFlow.Desktop/Components/Shared/SpeakerLabelingToggle.razor
@@ -1,0 +1,43 @@
+@inject AppViewModel ViewModel
+@inject DesktopConfigurationService ConfigService
+
+<div class="speaker-toggle" id="speaker-labeling-toggle" aria-label="Speaker labeling toggle">
+    <div class="speaker-toggle-body">
+        <div class="speaker-toggle-labels">
+            <span class="speaker-toggle-title">Speaker labeling</span>
+            <span class="speaker-toggle-subtitle">Identify who spoke each segment</span>
+        </div>
+        <button role="switch"
+                id="speaker-labeling-switch"
+                aria-checked="@(ViewModel.SpeakerLabelingEnabled ? "true" : "false")"
+                class="speaker-toggle-switch @(ViewModel.SpeakerLabelingEnabled ? "on" : "off")"
+                disabled="@IsDisabled"
+                @onclick="Toggle">
+            <span class="speaker-toggle-thumb"></span>
+        </button>
+    </div>
+</div>
+
+@code {
+    [Parameter] public bool IsDisabled { get; set; }
+
+    private async Task Toggle()
+    {
+        if (IsDisabled) return;
+        ViewModel.SpeakerLabelingEnabled = !ViewModel.SpeakerLabelingEnabled;
+        try
+        {
+            await ConfigService.SaveUserOverridesAsync(new Dictionary<string, object>
+            {
+                ["speakerLabeling"] = new Dictionary<string, object>
+                {
+                    ["enabled"] = ViewModel.SpeakerLabelingEnabled
+                }
+            });
+        }
+        catch
+        {
+            // Persistence is best-effort; in-memory selection is already applied.
+        }
+    }
+}

--- a/src/VoxFlow.Desktop/Components/Shared/SpeakerTranscriptView.razor
+++ b/src/VoxFlow.Desktop/Components/Shared/SpeakerTranscriptView.razor
@@ -1,0 +1,85 @@
+@using System.Globalization
+@using VoxFlow.Core.Models
+@using VoxFlow.Desktop.Theme
+
+@if (Document is null)
+{
+    // Empty by design; caller decides the fallback.
+}
+else if (Document.Turns.Count == 0)
+{
+    <p class="speaker-transcript-empty">No speaker segments detected.</p>
+}
+else
+{
+    <div class="speaker-transcript">
+        @foreach (var turn in Document.Turns)
+        {
+            var color = SafeColor(turn.SpeakerId);
+            <div class="speaker-turn"
+                 data-speaker-label="@turn.SpeakerId"
+                 style="--speaker-color: @color; color: @color;">
+                <div class="speaker-turn-header">
+                    <span class="speaker-swatch" aria-hidden="true"
+                          style="background-color: @color;"></span>
+                    <span class="speaker-label">Speaker @turn.SpeakerId</span>
+                    <span class="speaker-turn-range">@FormatRange(turn.StartTime, turn.EndTime)</span>
+                </div>
+                <p class="speaker-turn-text">@JoinWords(turn.Words)</p>
+            </div>
+        }
+    </div>
+}
+
+@code {
+    [Parameter] public TranscriptDocument? Document { get; set; }
+
+    private static string SafeColor(string speakerId)
+    {
+        try
+        {
+            return OkabeItoPalette.ColorForSpeaker(new SpeakerInfo(speakerId, speakerId, TimeSpan.Zero));
+        }
+        catch (ArgumentException)
+        {
+            return OkabeItoPalette.Colors[0];
+        }
+    }
+
+    private static string FormatRange(TimeSpan start, TimeSpan end)
+        => $"[{FormatTime(start)} \u2013 {FormatTime(end)}]";
+
+    private static string FormatTime(TimeSpan value)
+        => value.TotalHours >= 1
+            ? value.ToString(@"h\:mm\:ss", CultureInfo.InvariantCulture)
+            : value.ToString(@"mm\:ss", CultureInfo.InvariantCulture);
+
+    private static string JoinWords(IReadOnlyList<TranscriptWord> words)
+    {
+        if (words.Count == 0) return string.Empty;
+        var builder = new System.Text.StringBuilder();
+        foreach (var w in words)
+        {
+            var text = w.Text ?? string.Empty;
+            if (builder.Length == 0)
+            {
+                builder.Append(text.TrimStart());
+            }
+            else if (text.StartsWith(' ') || text.StartsWith('\t'))
+            {
+                builder.Append(text);
+            }
+            else
+            {
+                // Punctuation and BPE subword continuations concatenate directly;
+                // regular words receive a separating space.
+                if (text.Length > 0 && (char.IsLetterOrDigit(text[0]) || text[0] == '\''))
+                {
+                    builder.Append(' ');
+                }
+                builder.Append(text);
+            }
+        }
+        return builder.ToString().Trim();
+    }
+}

--- a/src/VoxFlow.Desktop/Configuration/DesktopConfigurationService.cs
+++ b/src/VoxFlow.Desktop/Configuration/DesktopConfigurationService.cs
@@ -7,22 +7,39 @@ using VoxFlow.Desktop.Services;
 
 namespace VoxFlow.Desktop.Configuration;
 
-public sealed class DesktopConfigurationService : IConfigurationService
+public class DesktopConfigurationService : IConfigurationService
 {
-    private static readonly string AppSupportDir =
+    private static readonly string DefaultAppSupportDir =
         Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
             "Library",
             "Application Support",
             "VoxFlow");
 
-    private static readonly string UserConfigPath =
-        Path.Combine(AppSupportDir, "appsettings.json");
-
-    private static readonly string DocumentsDir =
+    private static readonly string DefaultDocumentsDir =
         Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments),
             "VoxFlow");
+
+    private readonly string _appSupportDir;
+    private readonly string _documentsDir;
+    private readonly string _userConfigPath;
+
+    public DesktopConfigurationService()
+        : this(DefaultAppSupportDir, DefaultDocumentsDir)
+    {
+    }
+
+    // Overrideable for tests so the user config file lands in a temp directory
+    // instead of the real ~/Library/Application Support/VoxFlow location.
+    public DesktopConfigurationService(string appSupportDir, string documentsDir)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(appSupportDir);
+        ArgumentException.ThrowIfNullOrWhiteSpace(documentsDir);
+        _appSupportDir = appSupportDir;
+        _documentsDir = documentsDir;
+        _userConfigPath = Path.Combine(appSupportDir, "appsettings.json");
+    }
 
     public Task<TranscriptionOptions> LoadAsync(string? configurationPath = null)
     {
@@ -54,12 +71,12 @@ public sealed class DesktopConfigurationService : IConfigurationService
         Action<JsonObject>? mutateTranscription = null,
         bool applyDesktopRuntimeOverrides = false)
     {
-        Directory.CreateDirectory(AppSupportDir);
+        Directory.CreateDirectory(_appSupportDir);
 
         var bundledPath = ResolveBundledConfigPath(AppContext.BaseDirectory);
         // Materialize a merged temp file so the core configuration pipeline can stay file-based across CLI, desktop, and tests.
-        var merged = MergeJsonFiles(bundledPath, UserConfigPath, configurationPath);
-        var normalized = NormalizeDesktopConfiguration(merged);
+        var merged = MergeJsonFiles(bundledPath, _userConfigPath, configurationPath);
+        var normalized = NormalizeDesktopConfiguration(merged, _appSupportDir, _documentsDir);
         var root = JsonNode.Parse(normalized)?.AsObject()
             ?? throw new InvalidOperationException("Merged desktop configuration is not a JSON object.");
         var transcription = root["transcription"]?.AsObject()
@@ -98,13 +115,77 @@ public sealed class DesktopConfigurationService : IConfigurationService
             .ToList();
     }
 
-    public async Task SaveUserOverridesAsync(Dictionary<string, object> overrides)
+    public virtual async Task SaveUserOverridesAsync(Dictionary<string, object> overrides)
     {
-        Directory.CreateDirectory(AppSupportDir);
-        var json = JsonSerializer.Serialize(
-            new { transcription = overrides },
-            new JsonSerializerOptions { WriteIndented = true });
-        await File.WriteAllTextAsync(UserConfigPath, json);
+        Directory.CreateDirectory(_appSupportDir);
+
+        // Read existing user overrides (if any), deep-merge the new entries
+        // under the transcription section, and write back. The merge keeps
+        // previously saved keys (e.g. resultFormat) alive when a different
+        // setting is toggled, instead of stamping a fresh file each time.
+        var root = JsonNode.Parse(
+            File.Exists(_userConfigPath)
+                ? await File.ReadAllTextAsync(_userConfigPath)
+                : "{}")?.AsObject()
+            ?? new JsonObject();
+
+        if (root["transcription"] is not JsonObject transcription)
+        {
+            transcription = new JsonObject();
+            root["transcription"] = transcription;
+        }
+
+        foreach (var kvp in overrides)
+        {
+            MergeOverrideValue(transcription, kvp.Key, kvp.Value);
+        }
+
+        await File.WriteAllTextAsync(
+            _userConfigPath,
+            root.ToJsonString(new JsonSerializerOptions { WriteIndented = true }));
+    }
+
+    private static void MergeOverrideValue(JsonObject target, string key, object? value)
+    {
+        if (value is null)
+        {
+            target[key] = null;
+            return;
+        }
+
+        if (value is IDictionary<string, object?> nullableDict)
+        {
+            MergeNestedDictionary(target, key, nullableDict);
+            return;
+        }
+
+        if (value is IDictionary<string, object> nestedDict)
+        {
+            MergeNestedDictionary(
+                target,
+                key,
+                nestedDict.ToDictionary(kvp => kvp.Key, kvp => (object?)kvp.Value));
+            return;
+        }
+
+        target[key] = JsonNode.Parse(JsonSerializer.Serialize(value));
+    }
+
+    private static void MergeNestedDictionary(
+        JsonObject target,
+        string key,
+        IDictionary<string, object?> source)
+    {
+        if (target[key] is not JsonObject existing)
+        {
+            existing = new JsonObject();
+            target[key] = existing;
+        }
+
+        foreach (var inner in source)
+        {
+            MergeOverrideValue(existing, inner.Key, inner.Value);
+        }
     }
 
     internal static string ResolveBundledConfigPath(string baseDirectory)
@@ -125,11 +206,6 @@ public sealed class DesktopConfigurationService : IConfigurationService
         }
 
         return candidates[0];
-    }
-
-    internal static string NormalizeDesktopConfiguration(string json)
-    {
-        return NormalizeDesktopConfiguration(json, AppSupportDir, DocumentsDir);
     }
 
     internal static string NormalizeDesktopConfiguration(string json, string appSupportDir, string documentsDir)

--- a/src/VoxFlow.Desktop/Theme/OkabeItoPalette.cs
+++ b/src/VoxFlow.Desktop/Theme/OkabeItoPalette.cs
@@ -1,0 +1,51 @@
+using System.Text.RegularExpressions;
+using VoxFlow.Core.Models;
+
+namespace VoxFlow.Desktop.Theme;
+
+/// <summary>
+/// Okabe-Ito 8-color colorblind-safe palette. See https://jfly.uni-koeln.de/color/
+/// Speakers beyond the palette size wrap around modulo 8; reusing a color for
+/// the 9th speaker is a documented trade-off (palette exhaustion vs. silent ambiguity).
+/// </summary>
+public static class OkabeItoPalette
+{
+    public static readonly IReadOnlyList<string> Colors = new[]
+    {
+        "#E69F00", // Orange
+        "#56B4E9", // Sky Blue
+        "#009E73", // Bluish Green
+        "#F0E442", // Yellow
+        "#0072B2", // Blue
+        "#D55E00", // Vermillion
+        "#CC79A7", // Reddish Purple
+        "#000000", // Black
+    };
+
+    private static readonly Regex LabelPattern = new("^[A-Z]+$", RegexOptions.Compiled);
+
+    public static string ColorForSpeaker(SpeakerInfo speaker)
+    {
+        ArgumentNullException.ThrowIfNull(speaker);
+        var label = speaker.Id ?? string.Empty;
+        if (!LabelPattern.IsMatch(label))
+        {
+            throw new ArgumentException(
+                $"Speaker label must be an uppercase alphabetic ordinal (A, B, ..., Z, AA, ...); got '{label}'.",
+                nameof(speaker));
+        }
+
+        var ordinal = OrdinalFor(label);
+        return Colors[ordinal % Colors.Count];
+    }
+
+    private static int OrdinalFor(string label)
+    {
+        var ordinal = 0;
+        for (var i = 0; i < label.Length; i++)
+        {
+            ordinal = ordinal * 26 + (label[i] - 'A' + 1);
+        }
+        return ordinal - 1;
+    }
+}

--- a/src/VoxFlow.Desktop/ViewModels/AppViewModel.cs
+++ b/src/VoxFlow.Desktop/ViewModels/AppViewModel.cs
@@ -25,6 +25,7 @@ public class AppViewModel : INotifyPropertyChanged
     private string? _lastFilePath;
     private CancellationTokenSource? _cts;
     private ResultFormat _selectedResultFormat = ResultFormat.Txt;
+    private bool _speakerLabelingEnabled;
 
     public AppViewModel(
         ITranscriptionService transcriptionService,
@@ -50,6 +51,20 @@ public class AppViewModel : INotifyPropertyChanged
         {
             if (_selectedResultFormat == value) return;
             _selectedResultFormat = value;
+            OnPropertyChanged();
+        }
+    }
+
+    /// <summary>
+    /// Whether the local speaker-labeling enrichment pipeline is enabled for the next run.
+    /// </summary>
+    public bool SpeakerLabelingEnabled
+    {
+        get => _speakerLabelingEnabled;
+        set
+        {
+            if (_speakerLabelingEnabled == value) return;
+            _speakerLabelingEnabled = value;
             OnPropertyChanged();
         }
     }
@@ -148,7 +163,13 @@ public class AppViewModel : INotifyPropertyChanged
     public async Task InitializeAsync()
     {
         var options = await _configService.LoadAsync();
-        SelectedResultFormat = options.ResultFormat;
+        // Seed backing fields directly so the single re-render triggered by
+        // ValidationResult/CurrentState below sees the final values. Firing
+        // OnPropertyChanged here would schedule an extra render cycle before
+        // validation completes, which races with components that observe
+        // HasWarnings / HasBlockingValidationErrors on first render.
+        _selectedResultFormat = options.ResultFormat;
+        _speakerLabelingEnabled = options.SpeakerLabeling.Enabled;
         var result = await _validationService.ValidateAsync(options);
         ValidationResult = result;
         CurrentState = AppState.Ready;

--- a/src/VoxFlow.Desktop/ViewModels/AppViewModel.cs
+++ b/src/VoxFlow.Desktop/ViewModels/AppViewModel.cs
@@ -26,6 +26,7 @@ public class AppViewModel : INotifyPropertyChanged
     private CancellationTokenSource? _cts;
     private ResultFormat _selectedResultFormat = ResultFormat.Txt;
     private bool _speakerLabelingEnabled;
+    private readonly PhaseProgressTracker _phaseTracker = new(speakerLabelingEnabled: false);
 
     public AppViewModel(
         ITranscriptionService transcriptionService,
@@ -99,8 +100,20 @@ public class AppViewModel : INotifyPropertyChanged
     public ProgressUpdate? CurrentProgress
     {
         get => _currentProgress;
-        set { _currentProgress = value; OnPropertyChanged(); }
+        set
+        {
+            _currentProgress = value;
+            if (value is not null) _phaseTracker.OnProgress(value);
+            OnPropertyChanged();
+        }
     }
+
+    /// <summary>
+    /// Per-phase progress tracker backing the three-ring Running screen.
+    /// Reset at the start of each run with the current
+    /// <see cref="SpeakerLabelingEnabled"/> value.
+    /// </summary>
+    public PhaseProgressTracker PhaseTracker => _phaseTracker;
 
     public string? ErrorMessage
     {
@@ -192,6 +205,7 @@ public class AppViewModel : INotifyPropertyChanged
         OnPropertyChanged(nameof(CurrentFileName));
         TranscriptionResult = null;
         CurrentProgress = null;
+        _phaseTracker.Reset(SpeakerLabelingEnabled);
         ErrorMessage = null;
         CurrentState = AppState.Running;
         _cts?.Dispose();

--- a/src/VoxFlow.Desktop/ViewModels/AppViewModel.cs
+++ b/src/VoxFlow.Desktop/ViewModels/AppViewModel.cs
@@ -214,7 +214,10 @@ public class AppViewModel : INotifyPropertyChanged
 
         try
         {
-            var request = new TranscribeFileRequest(filePath, ResultFilePath: resultFilePath);
+            var request = new TranscribeFileRequest(
+                filePath,
+                ResultFilePath: resultFilePath,
+                EnableSpeakers: SpeakerLabelingEnabled ? true : null);
             TranscriptionResult = await _transcriptionService.TranscribeFileAsync(request, progress, cts.Token);
             if (TranscriptionResult.Success)
             {

--- a/src/VoxFlow.Desktop/ViewModels/PhaseProgressTracker.cs
+++ b/src/VoxFlow.Desktop/ViewModels/PhaseProgressTracker.cs
@@ -87,6 +87,34 @@ public sealed class PhaseProgressTracker : INotifyPropertyChanged, IDisposable
 
     public event PropertyChangedEventHandler? PropertyChanged;
 
+    /// <summary>
+    /// Returns every phase to its initial state for a fresh run. Called by
+    /// <see cref="AppViewModel"/> at the start of each transcription so the
+    /// UI doesn't carry over state from the previous file.
+    /// </summary>
+    public void Reset(bool speakerLabelingEnabled)
+    {
+        lock (_stateLock)
+        {
+            for (var i = 0; i < _phases.Length; i++)
+                _startedAt[i] = null;
+
+            _phases[(int)ProgressPhase.Transcription] = new PhaseState(
+                ProgressPhase.Transcription, PhaseStatus.Idle, 0, null, TimeSpan.Zero);
+            _phases[(int)ProgressPhase.Diarization] = new PhaseState(
+                ProgressPhase.Diarization,
+                speakerLabelingEnabled ? PhaseStatus.Idle : PhaseStatus.Skipped,
+                0,
+                speakerLabelingEnabled ? null : "skipped",
+                TimeSpan.Zero);
+            _phases[(int)ProgressPhase.Merge] = new PhaseState(
+                ProgressPhase.Merge, PhaseStatus.Idle, 0, null, TimeSpan.Zero);
+
+            DisposeHeartbeatLocked();
+        }
+        RaisePhasesChanged();
+    }
+
     public void OnProgress(ProgressUpdate update)
     {
         lock (_stateLock)

--- a/src/VoxFlow.Desktop/ViewModels/PhaseProgressTracker.cs
+++ b/src/VoxFlow.Desktop/ViewModels/PhaseProgressTracker.cs
@@ -1,0 +1,243 @@
+using System.ComponentModel;
+using VoxFlow.Core.Models;
+
+namespace VoxFlow.Desktop.ViewModels;
+
+public enum PhaseStatus
+{
+    Idle,
+    Running,
+    Done,
+    Skipped,
+    Failed
+}
+
+public sealed record PhaseState(
+    ProgressPhase Phase,
+    PhaseStatus Status,
+    double LocalPercent,
+    string? SubStatus,
+    TimeSpan Elapsed);
+
+/// <summary>
+/// Per-phase progress state for the Desktop three-ring tracker. Subscribes
+/// to a <see cref="ProgressUpdate"/> stream via <see cref="OnProgress"/> and
+/// projects it into three immutable <see cref="PhaseState"/> snapshots.
+/// Elapsed time for the currently running phase is computed live off the
+/// injected <see cref="TimeProvider"/> so callers always see an up-to-date
+/// clock without needing the heartbeat timer to mutate any state.
+/// </summary>
+public sealed class PhaseProgressTracker : INotifyPropertyChanged, IDisposable
+{
+    private static readonly TimeSpan DefaultHeartbeatInterval = TimeSpan.FromSeconds(1);
+
+    private readonly TimeProvider _timeProvider;
+    private readonly TimeSpan _heartbeatInterval;
+    private readonly object _stateLock = new();
+    private readonly PhaseState[] _phases;
+    private readonly DateTimeOffset?[] _startedAt;
+    private ITimer? _heartbeat;
+
+    public PhaseProgressTracker(
+        bool speakerLabelingEnabled,
+        TimeProvider? timeProvider = null,
+        TimeSpan? heartbeatInterval = null)
+    {
+        _timeProvider = timeProvider ?? TimeProvider.System;
+        _heartbeatInterval = heartbeatInterval ?? DefaultHeartbeatInterval;
+        _phases = new PhaseState[3];
+        _startedAt = new DateTimeOffset?[3];
+        _phases[(int)ProgressPhase.Transcription] = new PhaseState(
+            ProgressPhase.Transcription, PhaseStatus.Idle, 0, null, TimeSpan.Zero);
+        _phases[(int)ProgressPhase.Diarization] = new PhaseState(
+            ProgressPhase.Diarization,
+            speakerLabelingEnabled ? PhaseStatus.Idle : PhaseStatus.Skipped,
+            0,
+            speakerLabelingEnabled ? null : "skipped",
+            TimeSpan.Zero);
+        _phases[(int)ProgressPhase.Merge] = new PhaseState(
+            ProgressPhase.Merge, PhaseStatus.Idle, 0, null, TimeSpan.Zero);
+    }
+
+    public IReadOnlyList<PhaseState> Phases
+    {
+        get
+        {
+            lock (_stateLock)
+            {
+                var now = _timeProvider.GetUtcNow();
+                var snap = new PhaseState[_phases.Length];
+                for (var i = 0; i < _phases.Length; i++)
+                {
+                    if (_phases[i].Status == PhaseStatus.Running && _startedAt[i].HasValue)
+                    {
+                        var live = now - _startedAt[i]!.Value;
+                        if (live < TimeSpan.Zero) live = TimeSpan.Zero;
+                        snap[i] = _phases[i] with { Elapsed = live };
+                    }
+                    else
+                    {
+                        snap[i] = _phases[i];
+                    }
+                }
+                return snap;
+            }
+        }
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    public void OnProgress(ProgressUpdate update)
+    {
+        lock (_stateLock)
+        {
+            var now = _timeProvider.GetUtcNow();
+            var isFailed = update.Stage == ProgressStage.Failed;
+            var isComplete = update.Stage == ProgressStage.Complete;
+
+            if (isFailed)
+            {
+                var target = -1;
+                for (var i = 0; i < _phases.Length; i++)
+                {
+                    if (_phases[i].Status == PhaseStatus.Running)
+                    {
+                        target = i;
+                        break;
+                    }
+                }
+                if (target < 0)
+                    target = (int)ProgressPhaseBanding.PhaseOf(update.Stage);
+
+                var elapsed = _startedAt[target] is { } t
+                    ? now - t
+                    : _phases[target].Elapsed;
+                _phases[target] = _phases[target] with
+                {
+                    Status = PhaseStatus.Failed,
+                    SubStatus = update.Message ?? "failed",
+                    Elapsed = elapsed,
+                };
+                DisposeHeartbeatLocked();
+            }
+            else
+            {
+                var newPhase = ProgressPhaseBanding.PhaseOf(update.Stage);
+                var newPhaseIdx = (int)newPhase;
+
+                // Finalize phases before newPhase that haven't finished yet.
+                for (var i = 0; i < newPhaseIdx; i++)
+                    FinalizeAsDone(i, now);
+
+                // Update newPhase unless it was pre-marked Skipped.
+                if (_phases[newPhaseIdx].Status != PhaseStatus.Skipped)
+                {
+                    if (_phases[newPhaseIdx].Status == PhaseStatus.Idle)
+                        _startedAt[newPhaseIdx] = now;
+
+                    var elapsed = _startedAt[newPhaseIdx] is { } t
+                        ? now - t
+                        : TimeSpan.Zero;
+                    if (elapsed < TimeSpan.Zero) elapsed = TimeSpan.Zero;
+
+                    var status = isComplete ? PhaseStatus.Done : PhaseStatus.Running;
+                    var localPct = isComplete
+                        ? 100.0
+                        : ProgressPhaseBanding.LocalPercent(update.Stage, update.PercentComplete);
+                    _phases[newPhaseIdx] = _phases[newPhaseIdx] with
+                    {
+                        Status = status,
+                        LocalPercent = localPct,
+                        SubStatus = update.Message ?? StageSubLabel(update.Stage),
+                        Elapsed = elapsed,
+                    };
+                }
+
+                if (isComplete)
+                {
+                    for (var i = 0; i < _phases.Length; i++)
+                        FinalizeAsDone(i, now);
+                    DisposeHeartbeatLocked();
+                }
+                else
+                {
+                    EnsureHeartbeatLocked();
+                }
+            }
+        }
+        RaisePhasesChanged();
+    }
+
+    private void FinalizeAsDone(int index, DateTimeOffset now)
+    {
+        var phase = _phases[index];
+        if (phase.Status is PhaseStatus.Done or PhaseStatus.Skipped or PhaseStatus.Failed)
+            return;
+
+        var elapsed = _startedAt[index] is { } t
+            ? now - t
+            : TimeSpan.Zero;
+        if (elapsed < TimeSpan.Zero) elapsed = TimeSpan.Zero;
+        _phases[index] = phase with
+        {
+            Status = PhaseStatus.Done,
+            LocalPercent = 100.0,
+            SubStatus = "done",
+            Elapsed = elapsed,
+        };
+    }
+
+    private void EnsureHeartbeatLocked()
+    {
+        if (_heartbeat is not null) return;
+        _heartbeat = _timeProvider.CreateTimer(
+            static s => ((PhaseProgressTracker)s!).OnHeartbeat(),
+            this,
+            _heartbeatInterval,
+            _heartbeatInterval);
+    }
+
+    private void DisposeHeartbeatLocked()
+    {
+        _heartbeat?.Dispose();
+        _heartbeat = null;
+    }
+
+    private void OnHeartbeat()
+    {
+        try
+        {
+            RaisePhasesChanged();
+        }
+        catch
+        {
+            // Heartbeat is best-effort — never surface exceptions from
+            // the timer thread.
+        }
+    }
+
+    private void RaisePhasesChanged()
+        => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Phases)));
+
+    private static string? StageSubLabel(ProgressStage stage) => stage switch
+    {
+        ProgressStage.Validating => "validating",
+        ProgressStage.Converting => "converting audio",
+        ProgressStage.LoadingModel => "loading model",
+        ProgressStage.Transcribing => "transcribing",
+        ProgressStage.Filtering => "filtering segments",
+        ProgressStage.Diarizing => "diarizing",
+        ProgressStage.Writing => "writing output",
+        ProgressStage.Complete => "done",
+        ProgressStage.Failed => "failed",
+        _ => null
+    };
+
+    public void Dispose()
+    {
+        lock (_stateLock)
+        {
+            DisposeHeartbeatLocked();
+        }
+    }
+}

--- a/src/VoxFlow.Desktop/wwwroot/css/app.css
+++ b/src/VoxFlow.Desktop/wwwroot/css/app.css
@@ -21,6 +21,17 @@
     --drop-zone-border: #4a4a6a;
     --progress-bar: #4a4aff;
     --progress-track: #2a2a4a;
+
+    /* Phase tracker (ADR-024 P2.3). Cyan/magenta/green mirror the CLI
+       ANSI 96/95/92 palette so the Desktop and CLI surfaces read as the
+       same product. Skipped reuses --drop-zone-border. */
+    --phase-transcription: #4aa8ff;
+    --phase-diarization: #b06cff;
+    --phase-merge: var(--success);
+    --phase-track: rgba(42, 42, 74, 0.4);
+    --phase-skipped: var(--drop-zone-border);
+    --phase-failed: var(--error);
+
     --font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
     --border-radius: 8px;
     --transition-fast: 150ms ease;
@@ -226,6 +237,171 @@ html, body {
     height: 1px;
     opacity: 0;
     pointer-events: none;
+}
+
+/* ---------- Phase Ring Tracker (ADR-024) ---------- */
+.phase-ring-stack {
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+    gap: 4px;
+    width: 100%;
+    margin: 0 auto 24px;
+}
+
+.phase-ring-item {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    flex: 0 0 auto;
+    min-width: 160px;
+}
+
+.phase-ring-chevron {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    align-self: stretch;
+    width: 24px;
+    min-height: 140px;
+    color: var(--text-muted);
+    font-size: 22px;
+    font-weight: 300;
+    opacity: 0.55;
+    user-select: none;
+}
+
+.phase-ring {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 10px;
+    padding: 4px;
+    --phase-color: var(--phase-transcription);
+}
+
+.phase-ring-body {
+    position: relative;
+    width: 140px;
+    height: 140px;
+}
+
+.phase-ring-svg {
+    width: 100%;
+    height: 100%;
+    display: block;
+}
+
+.phase-ring-track {
+    stroke: var(--phase-track);
+}
+
+.phase-ring-arc {
+    stroke: var(--phase-color);
+    transition:
+        stroke-dashoffset 400ms cubic-bezier(0.2, 0.8, 0.2, 1),
+        stroke 250ms ease;
+}
+
+.phase-ring-arc-running {
+    filter: drop-shadow(0 0 6px var(--phase-color))
+            drop-shadow(0 0 2px var(--phase-color));
+    animation: phase-ring-breathe 2.4s ease-in-out infinite;
+}
+
+.phase-ring-arc-failed {
+    stroke: var(--phase-failed);
+    filter: drop-shadow(0 0 4px var(--phase-failed));
+}
+
+@keyframes phase-ring-breathe {
+    0%, 100% {
+        filter: drop-shadow(0 0 5px var(--phase-color))
+                drop-shadow(0 0 1px var(--phase-color));
+    }
+    50% {
+        filter: drop-shadow(0 0 14px var(--phase-color))
+                drop-shadow(0 0 3px var(--phase-color));
+    }
+}
+
+.phase-ring-center {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    pointer-events: none;
+}
+
+.phase-ring-percent {
+    font-size: 34px;
+    font-weight: 500;
+    color: var(--text-primary);
+    letter-spacing: -0.02em;
+    line-height: 1;
+    font-variant-numeric: tabular-nums;
+}
+
+.phase-ring-unit {
+    font-size: 13px;
+    color: var(--text-muted);
+    margin-top: 2px;
+}
+
+.phase-ring-glyph {
+    font-size: 28px;
+    line-height: 1;
+    font-weight: 500;
+}
+
+.phase-ring-glyph-done { color: var(--phase-merge); }
+.phase-ring-glyph-skipped { color: var(--phase-skipped); }
+.phase-ring-glyph-failed { color: var(--phase-failed); }
+
+.phase-ring-done-label,
+.phase-ring-skipped-label,
+.phase-ring-failed-label {
+    font-size: 11px;
+    margin-top: 6px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--text-secondary);
+}
+
+.phase-ring-skipped-label { color: var(--phase-skipped); }
+.phase-ring-failed-label { color: var(--phase-failed); }
+
+.phase-ring-substatus {
+    font-size: 13px;
+    color: var(--text-secondary);
+    text-align: center;
+    margin: 0;
+    min-height: 18px;
+}
+
+.phase-ring-elapsed {
+    font-size: 12px;
+    color: var(--text-muted);
+    text-align: center;
+    font-variant-numeric: tabular-nums;
+    letter-spacing: 0.03em;
+    margin: 0;
+}
+
+@media (max-width: 720px) {
+    .phase-ring-stack {
+        flex-direction: column;
+        align-items: center;
+        gap: 12px;
+    }
+    .phase-ring-chevron {
+        min-height: 0;
+        height: 16px;
+        transform: rotate(90deg);
+    }
 }
 
 /* ---------- Organic Circular Progress ---------- */

--- a/src/VoxFlow.Desktop/wwwroot/css/app.css
+++ b/src/VoxFlow.Desktop/wwwroot/css/app.css
@@ -801,6 +801,20 @@ button {
     color: #fece5a;
 }
 
+.message-info {
+    background: rgba(74, 168, 255, 0.08);
+    border: 1px solid rgba(74, 168, 255, 0.3);
+    color: #9ec9ff;
+}
+
+.enrichment-warnings-banner {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    margin: 12px 0 16px;
+    align-items: center;
+}
+
 .message-icon {
     flex-shrink: 0;
     font-size: 16px;

--- a/src/VoxFlow.Desktop/wwwroot/css/app.css
+++ b/src/VoxFlow.Desktop/wwwroot/css/app.css
@@ -1195,3 +1195,65 @@ button {
 #blazor-error-ui .dismiss:hover {
     color: var(--text-primary);
 }
+
+/* ---------- Speaker Transcript (ADR-024 P2.4) ---------- */
+.speaker-transcript {
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+    max-width: 720px;
+    margin: 0 auto;
+}
+
+.speaker-transcript-empty {
+    color: var(--text-muted);
+    font-style: italic;
+    text-align: center;
+    padding: 24px 0;
+}
+
+.speaker-turn {
+    background-color: var(--bg-secondary);
+    border-left: 3px solid var(--speaker-color, var(--accent));
+    border-radius: var(--border-radius);
+    padding: 14px 18px;
+    box-shadow: var(--shadow-sm);
+    color: var(--text-primary);
+}
+
+.speaker-turn-header {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 6px;
+    font-size: 13px;
+}
+
+.speaker-swatch {
+    display: inline-block;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+
+.speaker-label {
+    font-weight: 600;
+    color: var(--speaker-color, var(--accent));
+    letter-spacing: 0.01em;
+}
+
+.speaker-turn-range {
+    margin-left: auto;
+    color: var(--text-muted);
+    font-variant-numeric: tabular-nums;
+    font-size: 12px;
+}
+
+.speaker-turn-text {
+    color: var(--text-primary);
+    font-size: 14px;
+    line-height: 1.55;
+    white-space: pre-wrap;
+    word-wrap: break-word;
+}

--- a/tests/VoxFlow.Core.Tests/Models/ProgressPhaseBandingTests.cs
+++ b/tests/VoxFlow.Core.Tests/Models/ProgressPhaseBandingTests.cs
@@ -1,0 +1,69 @@
+using VoxFlow.Core.Models;
+using Xunit;
+
+namespace VoxFlow.Core.Tests.Models;
+
+public sealed class ProgressPhaseBandingTests
+{
+    [Theory]
+    [InlineData(ProgressStage.Validating, ProgressPhase.Transcription)]
+    [InlineData(ProgressStage.Converting, ProgressPhase.Transcription)]
+    [InlineData(ProgressStage.LoadingModel, ProgressPhase.Transcription)]
+    [InlineData(ProgressStage.Transcribing, ProgressPhase.Transcription)]
+    [InlineData(ProgressStage.Filtering, ProgressPhase.Transcription)]
+    [InlineData(ProgressStage.Diarizing, ProgressPhase.Diarization)]
+    [InlineData(ProgressStage.Writing, ProgressPhase.Merge)]
+    [InlineData(ProgressStage.Complete, ProgressPhase.Merge)]
+    [InlineData(ProgressStage.Failed, ProgressPhase.Transcription)]
+    public void PhaseOf_MapsStageToCorrectPhase(ProgressStage stage, ProgressPhase expected)
+    {
+        Assert.Equal(expected, ProgressPhaseBanding.PhaseOf(stage));
+    }
+
+    [Theory]
+    // Transcription 0..90 maps 0..100 in-band
+    [InlineData(ProgressStage.Transcribing, 0.0, 0.0)]
+    [InlineData(ProgressStage.Transcribing, 45.0, 50.0)]
+    [InlineData(ProgressStage.Transcribing, 90.0, 100.0)]
+    // Diarization 90..95
+    [InlineData(ProgressStage.Diarizing, 90.0, 0.0)]
+    [InlineData(ProgressStage.Diarizing, 92.5, 50.0)]
+    [InlineData(ProgressStage.Diarizing, 95.0, 100.0)]
+    // Merge 95..100
+    [InlineData(ProgressStage.Writing, 95.0, 0.0)]
+    [InlineData(ProgressStage.Writing, 97.5, 50.0)]
+    [InlineData(ProgressStage.Writing, 100.0, 100.0)]
+    public void LocalPercent_RemapsOverallPercentToBand(
+        ProgressStage stage,
+        double overall,
+        double expectedLocal)
+    {
+        var actual = ProgressPhaseBanding.LocalPercent(stage, overall);
+        Assert.Equal(expectedLocal, actual, 3);
+    }
+
+    [Fact]
+    public void LocalPercent_Failed_ReturnsRawOverallClamped()
+    {
+        Assert.Equal(42.0, ProgressPhaseBanding.LocalPercent(ProgressStage.Failed, 42.0), 3);
+        Assert.Equal(0.0, ProgressPhaseBanding.LocalPercent(ProgressStage.Failed, -10.0), 3);
+        Assert.Equal(100.0, ProgressPhaseBanding.LocalPercent(ProgressStage.Failed, 150.0), 3);
+    }
+
+    [Fact]
+    public void LocalPercent_OutOfBand_IsClampedTo0And100()
+    {
+        Assert.Equal(0.0, ProgressPhaseBanding.LocalPercent(ProgressStage.Transcribing, -5.0), 3);
+        Assert.Equal(100.0, ProgressPhaseBanding.LocalPercent(ProgressStage.Transcribing, 150.0), 3);
+    }
+
+    [Theory]
+    [InlineData(ProgressStage.Transcribing, 90.0)]
+    [InlineData(ProgressStage.Diarizing, 95.0)]
+    [InlineData(ProgressStage.Writing, 100.0)]
+    [InlineData(ProgressStage.Complete, 100.0)]
+    public void PhaseUpperBound_ReturnsBandCeiling(ProgressStage stage, double expected)
+    {
+        Assert.Equal(expected, ProgressPhaseBanding.PhaseUpperBound(stage));
+    }
+}

--- a/tests/VoxFlow.Desktop.Tests/AppViewModelTests.cs
+++ b/tests/VoxFlow.Desktop.Tests/AppViewModelTests.cs
@@ -66,6 +66,8 @@ internal sealed class StubTranscriptionService : ITranscriptionService
     private readonly Func<TranscribeFileRequest, TranscribeFileResult>? _factory;
     private readonly Exception? _exception;
 
+    public TranscribeFileRequest? LastRequest { get; private set; }
+
     /// <summary>Creates a stub that returns a successful result.</summary>
     public StubTranscriptionService(bool success = true, string[]? warnings = null)
     {
@@ -92,6 +94,7 @@ internal sealed class StubTranscriptionService : ITranscriptionService
         IProgress<ProgressUpdate>? progress = null,
         CancellationToken cancellationToken = default)
     {
+        LastRequest = request;
         if (_exception is not null) throw _exception;
         return Task.FromResult(_factory!(request));
     }
@@ -223,6 +226,38 @@ public sealed class AppViewModelTests
         await vm.InitializeAsync();
 
         Assert.False(vm.SpeakerLabelingEnabled);
+    }
+
+    // -----------------------------------------------------------------------
+    // P2.2 — TranscribeFileAsync forwards SpeakerLabelingEnabled to EnableSpeakers
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task TranscribeFileAsync_SpeakerLabelingEnabled_PassesEnableSpeakersTrue()
+    {
+        var stub = new StubTranscriptionService(success: true);
+        var vm = ViewModelFactory.Create(transcriptionService: stub);
+        await vm.InitializeAsync();
+        vm.SpeakerLabelingEnabled = true;
+
+        await vm.TranscribeFileAsync("/tmp/audio.wav");
+
+        Assert.NotNull(stub.LastRequest);
+        Assert.True(stub.LastRequest!.EnableSpeakers);
+    }
+
+    [Fact]
+    public async Task TranscribeFileAsync_SpeakerLabelingDisabled_PassesEnableSpeakersNull()
+    {
+        var stub = new StubTranscriptionService(success: true);
+        var vm = ViewModelFactory.Create(transcriptionService: stub);
+        await vm.InitializeAsync();
+        vm.SpeakerLabelingEnabled = false;
+
+        await vm.TranscribeFileAsync("/tmp/audio.wav");
+
+        Assert.NotNull(stub.LastRequest);
+        Assert.Null(stub.LastRequest!.EnableSpeakers);
     }
 
     // -----------------------------------------------------------------------

--- a/tests/VoxFlow.Desktop.Tests/AppViewModelTests.cs
+++ b/tests/VoxFlow.Desktop.Tests/AppViewModelTests.cs
@@ -190,6 +190,42 @@ public sealed class AppViewModelTests
     }
 
     // -----------------------------------------------------------------------
+    // P2.1 — SpeakerLabelingEnabled initializes from options
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task InitializeAsync_SpeakerLabelingEnabledInOptions_SetsViewModelFlagTrue()
+    {
+        var settingsPath = ViewModelFactory.ResolveRootSettingsPath();
+        using var configService = new StubConfigurationServiceWithSpeakerLabeling(
+            settingsPath, speakerLabelingEnabled: true);
+        var vm = new AppViewModel(
+            new StubTranscriptionService(success: true),
+            new StubValidationService(true),
+            configService);
+
+        await vm.InitializeAsync();
+
+        Assert.True(vm.SpeakerLabelingEnabled);
+    }
+
+    [Fact]
+    public async Task InitializeAsync_SpeakerLabelingDisabledInOptions_SetsViewModelFlagFalse()
+    {
+        var settingsPath = ViewModelFactory.ResolveRootSettingsPath();
+        using var configService = new StubConfigurationServiceWithSpeakerLabeling(
+            settingsPath, speakerLabelingEnabled: false);
+        var vm = new AppViewModel(
+            new StubTranscriptionService(success: true),
+            new StubValidationService(true),
+            configService);
+
+        await vm.InitializeAsync();
+
+        Assert.False(vm.SpeakerLabelingEnabled);
+    }
+
+    // -----------------------------------------------------------------------
     // TranscribeFileAsync — success path
     // -----------------------------------------------------------------------
 
@@ -608,6 +644,46 @@ internal sealed class StubConfigurationServiceWithWavPath : IConfigurationServic
         root["transcription"]!.AsObject()["wavFilePath"] = wavPath;
         _modifiedSettingsPath = Path.Combine(Path.GetTempPath(), $"voxflow-test-settings-{Guid.NewGuid():N}.json");
         File.WriteAllText(_modifiedSettingsPath, root.ToJsonString(new JsonSerializerOptions { WriteIndented = true }));
+    }
+
+    public Task<TranscriptionOptions> LoadAsync(string? configurationPath = null)
+        => Task.FromResult(TranscriptionOptions.LoadFromPath(configurationPath ?? _modifiedSettingsPath));
+
+    public IReadOnlyList<SupportedLanguage> GetSupportedLanguages(string? configurationPath = null)
+        => LoadAsync(configurationPath).GetAwaiter().GetResult().SupportedLanguages;
+
+    public void Dispose()
+    {
+        try { File.Delete(_modifiedSettingsPath); } catch { }
+    }
+}
+
+/// <summary>
+/// Configuration service that overrides transcription.speakerLabeling.enabled
+/// by rewriting a copy of the root settings file. Mirrors the pattern of
+/// <see cref="StubConfigurationServiceWithWavPath"/>.
+/// </summary>
+internal sealed class StubConfigurationServiceWithSpeakerLabeling : IConfigurationService, IDisposable
+{
+    private readonly string _modifiedSettingsPath;
+
+    public StubConfigurationServiceWithSpeakerLabeling(string settingsPath, bool speakerLabelingEnabled)
+    {
+        var json = File.ReadAllText(settingsPath);
+        var root = JsonNode.Parse(json)!.AsObject();
+        var transcription = root["transcription"]!.AsObject();
+        if (transcription["speakerLabeling"] is not JsonObject speakerLabeling)
+        {
+            speakerLabeling = new JsonObject();
+            transcription["speakerLabeling"] = speakerLabeling;
+        }
+        speakerLabeling["enabled"] = speakerLabelingEnabled;
+        _modifiedSettingsPath = Path.Combine(
+            Path.GetTempPath(),
+            $"voxflow-test-settings-{Guid.NewGuid():N}.json");
+        File.WriteAllText(
+            _modifiedSettingsPath,
+            root.ToJsonString(new JsonSerializerOptions { WriteIndented = true }));
     }
 
     public Task<TranscriptionOptions> LoadAsync(string? configurationPath = null)

--- a/tests/VoxFlow.Desktop.Tests/AppViewModelTests.cs
+++ b/tests/VoxFlow.Desktop.Tests/AppViewModelTests.cs
@@ -261,6 +261,49 @@ public sealed class AppViewModelTests
     }
 
     // -----------------------------------------------------------------------
+    // P2.3d — PhaseTracker integration
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void PhaseTracker_IsExposed_AfterConstruction()
+    {
+        var vm = ViewModelFactory.Create();
+
+        Assert.NotNull(vm.PhaseTracker);
+        Assert.Equal(3, vm.PhaseTracker.Phases.Count);
+    }
+
+    [Fact]
+    public void CurrentProgressSetter_ForwardsToPhaseTracker()
+    {
+        var vm = ViewModelFactory.Create();
+
+        vm.CurrentProgress = new ProgressUpdate(
+            ProgressStage.Transcribing, 45.0, TimeSpan.FromSeconds(3));
+
+        Assert.Equal(PhaseStatus.Running, vm.PhaseTracker.Phases[0].Status);
+        Assert.Equal(50.0, vm.PhaseTracker.Phases[0].LocalPercent, 3);
+    }
+
+    [Fact]
+    public async Task TranscribeFileAsync_ResetsPhaseTracker_BeforeRun()
+    {
+        var vm = ViewModelFactory.Create();
+        await vm.InitializeAsync();
+        vm.CurrentProgress = new ProgressUpdate(
+            ProgressStage.Transcribing, 30.0, TimeSpan.FromSeconds(2));
+        Assert.Equal(PhaseStatus.Running, vm.PhaseTracker.Phases[0].Status);
+
+        vm.SpeakerLabelingEnabled = false;
+        await vm.TranscribeFileAsync("/tmp/audio.wav");
+
+        // After a complete pipeline all phases should be Done or Skipped,
+        // not still "Running" from the stale pre-run state. Diarization is
+        // born Skipped because SpeakerLabelingEnabled=false.
+        Assert.Equal(PhaseStatus.Skipped, vm.PhaseTracker.Phases[1].Status);
+    }
+
+    // -----------------------------------------------------------------------
     // TranscribeFileAsync — success path
     // -----------------------------------------------------------------------
 

--- a/tests/VoxFlow.Desktop.Tests/Components/PhaseProgressTrackerTests.cs
+++ b/tests/VoxFlow.Desktop.Tests/Components/PhaseProgressTrackerTests.cs
@@ -1,0 +1,203 @@
+using VoxFlow.Core.Models;
+using VoxFlow.Desktop.ViewModels;
+using Xunit;
+
+namespace VoxFlow.Desktop.Tests.Components;
+
+/// <summary>
+/// Minimal <see cref="TimeProvider"/> whose clock is advanced manually by the
+/// test. The heartbeat timer is a no-op stub — the tracker's Elapsed is
+/// computed live off <see cref="GetUtcNow"/>, so tests only need to advance
+/// the clock and read <c>Phases</c>.
+/// </summary>
+internal sealed class ControllableTimeProvider : TimeProvider
+{
+    private DateTimeOffset _now;
+
+    public ControllableTimeProvider(DateTimeOffset start)
+    {
+        _now = start;
+    }
+
+    public override DateTimeOffset GetUtcNow() => _now;
+
+    public void Advance(TimeSpan delta) => _now += delta;
+
+    public override ITimer CreateTimer(
+        TimerCallback callback,
+        object? state,
+        TimeSpan dueTime,
+        TimeSpan period) => new NoopTimer();
+
+    private sealed class NoopTimer : ITimer
+    {
+        public bool Change(TimeSpan dueTime, TimeSpan period) => true;
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+        public void Dispose() { }
+    }
+}
+
+public sealed class PhaseProgressTrackerTests
+{
+    private static readonly DateTimeOffset T0 = new(2025, 1, 1, 12, 0, 0, TimeSpan.Zero);
+
+    private static ProgressUpdate Frame(ProgressStage stage, double pct, string? msg = null)
+        => new(stage, pct, TimeSpan.Zero, Message: msg);
+
+    [Fact]
+    public void NewTracker_SpeakerLabelingEnabled_AllThreePhasesIdleAndZero()
+    {
+        var clock = new ControllableTimeProvider(T0);
+        using var tracker = new PhaseProgressTracker(speakerLabelingEnabled: true, timeProvider: clock);
+
+        var phases = tracker.Phases;
+        Assert.Equal(3, phases.Count);
+        Assert.Equal(ProgressPhase.Transcription, phases[0].Phase);
+        Assert.Equal(ProgressPhase.Diarization, phases[1].Phase);
+        Assert.Equal(ProgressPhase.Merge, phases[2].Phase);
+        Assert.All(phases, p => Assert.Equal(PhaseStatus.Idle, p.Status));
+        Assert.All(phases, p => Assert.Equal(0.0, p.LocalPercent));
+        Assert.All(phases, p => Assert.Equal(TimeSpan.Zero, p.Elapsed));
+    }
+
+    [Fact]
+    public void NewTracker_SpeakerLabelingDisabled_DiarizationBornSkipped()
+    {
+        var clock = new ControllableTimeProvider(T0);
+        using var tracker = new PhaseProgressTracker(speakerLabelingEnabled: false, timeProvider: clock);
+
+        var phases = tracker.Phases;
+        Assert.Equal(PhaseStatus.Idle, phases[0].Status);
+        Assert.Equal(PhaseStatus.Skipped, phases[1].Status);
+        Assert.Equal(PhaseStatus.Idle, phases[2].Status);
+    }
+
+    [Fact]
+    public void OnProgress_TranscribingFrame_MovesTranscriptionToRunning()
+    {
+        var clock = new ControllableTimeProvider(T0);
+        using var tracker = new PhaseProgressTracker(speakerLabelingEnabled: true, timeProvider: clock);
+
+        tracker.OnProgress(Frame(ProgressStage.Transcribing, 45.0));
+
+        var phases = tracker.Phases;
+        Assert.Equal(PhaseStatus.Running, phases[0].Status);
+        Assert.Equal(50.0, phases[0].LocalPercent, 3);
+        Assert.Equal("transcribing", phases[0].SubStatus);
+        Assert.Equal(PhaseStatus.Idle, phases[1].Status);
+        Assert.Equal(PhaseStatus.Idle, phases[2].Status);
+    }
+
+    [Fact]
+    public void OnProgress_ExplicitMessageWinsOverStageLabel()
+    {
+        var clock = new ControllableTimeProvider(T0);
+        using var tracker = new PhaseProgressTracker(speakerLabelingEnabled: true, timeProvider: clock);
+
+        tracker.OnProgress(Frame(ProgressStage.Transcribing, 10.0, msg: "loading model"));
+
+        Assert.Equal("loading model", tracker.Phases[0].SubStatus);
+    }
+
+    [Fact]
+    public void OnProgress_DiarizingAfterTranscribing_MarksTranscriptionDoneAt100()
+    {
+        var clock = new ControllableTimeProvider(T0);
+        using var tracker = new PhaseProgressTracker(speakerLabelingEnabled: true, timeProvider: clock);
+
+        tracker.OnProgress(Frame(ProgressStage.Transcribing, 45.0));
+        clock.Advance(TimeSpan.FromSeconds(22));
+        tracker.OnProgress(Frame(ProgressStage.Diarizing, 92.0));
+
+        var phases = tracker.Phases;
+        Assert.Equal(PhaseStatus.Done, phases[0].Status);
+        Assert.Equal(100.0, phases[0].LocalPercent, 3);
+        Assert.Equal(TimeSpan.FromSeconds(22), phases[0].Elapsed);
+        Assert.Equal(PhaseStatus.Running, phases[1].Status);
+    }
+
+    [Fact]
+    public void OnProgress_WritingAfterTranscribing_MarksBothUpstreamPhasesDone()
+    {
+        var clock = new ControllableTimeProvider(T0);
+        using var tracker = new PhaseProgressTracker(speakerLabelingEnabled: false, timeProvider: clock);
+
+        tracker.OnProgress(Frame(ProgressStage.Transcribing, 45.0));
+        clock.Advance(TimeSpan.FromSeconds(10));
+        tracker.OnProgress(Frame(ProgressStage.Writing, 96.0));
+
+        var phases = tracker.Phases;
+        Assert.Equal(PhaseStatus.Done, phases[0].Status);
+        Assert.Equal(PhaseStatus.Skipped, phases[1].Status);
+        Assert.Equal(PhaseStatus.Running, phases[2].Status);
+    }
+
+    [Fact]
+    public void OnProgress_CompleteFrame_MarksAllNonSkippedPhasesDone()
+    {
+        var clock = new ControllableTimeProvider(T0);
+        using var tracker = new PhaseProgressTracker(speakerLabelingEnabled: true, timeProvider: clock);
+
+        tracker.OnProgress(Frame(ProgressStage.Transcribing, 30.0));
+        clock.Advance(TimeSpan.FromSeconds(5));
+        tracker.OnProgress(Frame(ProgressStage.Complete, 100.0));
+
+        var phases = tracker.Phases;
+        Assert.All(phases, p => Assert.Equal(PhaseStatus.Done, p.Status));
+        Assert.All(phases, p => Assert.Equal(100.0, p.LocalPercent));
+    }
+
+    [Fact]
+    public void OnProgress_Failed_MarksRunningPhaseFailed()
+    {
+        var clock = new ControllableTimeProvider(T0);
+        using var tracker = new PhaseProgressTracker(speakerLabelingEnabled: true, timeProvider: clock);
+
+        tracker.OnProgress(Frame(ProgressStage.Transcribing, 30.0));
+        clock.Advance(TimeSpan.FromSeconds(3));
+        tracker.OnProgress(Frame(ProgressStage.Failed, 30.0, msg: "model load failed"));
+
+        Assert.Equal(PhaseStatus.Failed, tracker.Phases[0].Status);
+        Assert.Equal("model load failed", tracker.Phases[0].SubStatus);
+    }
+
+    [Fact]
+    public void Heartbeat_ElapsedAdvancesWithClock_WhileRunning()
+    {
+        var clock = new ControllableTimeProvider(T0);
+        using var tracker = new PhaseProgressTracker(speakerLabelingEnabled: true, timeProvider: clock);
+
+        tracker.OnProgress(Frame(ProgressStage.Transcribing, 10.0));
+        clock.Advance(TimeSpan.FromSeconds(2));
+
+        Assert.Equal(TimeSpan.FromSeconds(2), tracker.Phases[0].Elapsed);
+    }
+
+    [Fact]
+    public void Heartbeat_ElapsedFrozen_AfterTerminalComplete()
+    {
+        var clock = new ControllableTimeProvider(T0);
+        using var tracker = new PhaseProgressTracker(speakerLabelingEnabled: true, timeProvider: clock);
+
+        tracker.OnProgress(Frame(ProgressStage.Transcribing, 30.0));
+        clock.Advance(TimeSpan.FromSeconds(5));
+        tracker.OnProgress(Frame(ProgressStage.Complete, 100.0));
+        var frozen = tracker.Phases[0].Elapsed;
+        clock.Advance(TimeSpan.FromSeconds(10));
+
+        Assert.Equal(frozen, tracker.Phases[0].Elapsed);
+    }
+
+    [Fact]
+    public void OnProgress_RaisesPropertyChangedForPhases()
+    {
+        var clock = new ControllableTimeProvider(T0);
+        using var tracker = new PhaseProgressTracker(speakerLabelingEnabled: true, timeProvider: clock);
+        var changes = new List<string?>();
+        tracker.PropertyChanged += (_, e) => changes.Add(e.PropertyName);
+
+        tracker.OnProgress(Frame(ProgressStage.Transcribing, 45.0));
+
+        Assert.Contains(nameof(PhaseProgressTracker.Phases), changes);
+    }
+}

--- a/tests/VoxFlow.Desktop.Tests/Components/PhaseProgressTrackerTests.cs
+++ b/tests/VoxFlow.Desktop.Tests/Components/PhaseProgressTrackerTests.cs
@@ -200,4 +200,45 @@ public sealed class PhaseProgressTrackerTests
 
         Assert.Contains(nameof(PhaseProgressTracker.Phases), changes);
     }
+
+    [Fact]
+    public void Reset_ReturnsPhasesToIdle_WhenSpeakerLabelingEnabled()
+    {
+        var clock = new ControllableTimeProvider(T0);
+        using var tracker = new PhaseProgressTracker(speakerLabelingEnabled: true, timeProvider: clock);
+        tracker.OnProgress(Frame(ProgressStage.Transcribing, 45.0));
+        clock.Advance(TimeSpan.FromSeconds(3));
+
+        tracker.Reset(speakerLabelingEnabled: true);
+
+        Assert.All(tracker.Phases, p => Assert.Equal(PhaseStatus.Idle, p.Status));
+        Assert.All(tracker.Phases, p => Assert.Equal(0.0, p.LocalPercent));
+        Assert.All(tracker.Phases, p => Assert.Equal(TimeSpan.Zero, p.Elapsed));
+    }
+
+    [Fact]
+    public void Reset_WithSpeakerLabelingDisabled_MarksDiarizationSkipped()
+    {
+        var clock = new ControllableTimeProvider(T0);
+        using var tracker = new PhaseProgressTracker(speakerLabelingEnabled: true, timeProvider: clock);
+
+        tracker.Reset(speakerLabelingEnabled: false);
+
+        Assert.Equal(PhaseStatus.Idle, tracker.Phases[0].Status);
+        Assert.Equal(PhaseStatus.Skipped, tracker.Phases[1].Status);
+        Assert.Equal(PhaseStatus.Idle, tracker.Phases[2].Status);
+    }
+
+    [Fact]
+    public void Reset_RaisesPropertyChangedForPhases()
+    {
+        var clock = new ControllableTimeProvider(T0);
+        using var tracker = new PhaseProgressTracker(speakerLabelingEnabled: true, timeProvider: clock);
+        var changes = new List<string?>();
+        tracker.PropertyChanged += (_, e) => changes.Add(e.PropertyName);
+
+        tracker.Reset(speakerLabelingEnabled: true);
+
+        Assert.Contains(nameof(PhaseProgressTracker.Phases), changes);
+    }
 }

--- a/tests/VoxFlow.Desktop.Tests/Components/PhaseRingStackTests.cs
+++ b/tests/VoxFlow.Desktop.Tests/Components/PhaseRingStackTests.cs
@@ -1,0 +1,101 @@
+using Microsoft.AspNetCore.Components;
+using VoxFlow.Core.Models;
+using VoxFlow.Desktop.Components.Pages;
+using VoxFlow.Desktop.ViewModels;
+using Xunit;
+
+namespace VoxFlow.Desktop.Tests.Components;
+
+public sealed class PhaseRingStackTests
+{
+    private static readonly DateTimeOffset T0 = new(2025, 1, 1, 12, 0, 0, TimeSpan.Zero);
+
+    private static ParameterView Params(PhaseProgressTracker tracker)
+        => ParameterView.FromDictionary(new Dictionary<string, object?>
+        {
+            [nameof(PhaseRingStack.Tracker)] = tracker,
+        });
+
+    private static ProgressUpdate Frame(ProgressStage stage, double pct, string? msg = null)
+        => new(stage, pct, TimeSpan.Zero, Message: msg);
+
+    [Fact]
+    public async Task Renders_ThreeRings_InPhaseOrder()
+    {
+        await using var context = DesktopUiTestContext.Create();
+        var clock = new ControllableTimeProvider(T0);
+        using var tracker = new PhaseProgressTracker(speakerLabelingEnabled: true, timeProvider: clock);
+
+        var rendered = await context.RenderAsync<PhaseRingStack>(Params(tracker));
+
+        var ringRoots = rendered.FindElements(
+            e => e.Name == "div"
+                && e.Attributes.TryGetValue("class", out var c)
+                && (c?.ToString() ?? "") == "phase-ring");
+        Assert.Equal(3, ringRoots.Count);
+    }
+
+    [Fact]
+    public async Task AssignsPhaseColorTokens_CyanMagentaGreen()
+    {
+        await using var context = DesktopUiTestContext.Create();
+        var clock = new ControllableTimeProvider(T0);
+        using var tracker = new PhaseProgressTracker(speakerLabelingEnabled: true, timeProvider: clock);
+
+        var rendered = await context.RenderAsync<PhaseRingStack>(Params(tracker));
+
+        var ringRoots = rendered
+            .FindElements(
+                e => e.Name == "div"
+                    && e.Attributes.TryGetValue("class", out var c)
+                    && (c?.ToString() ?? "") == "phase-ring")
+            .ToArray();
+
+        Assert.Equal(3, ringRoots.Length);
+        Assert.Contains("--phase-transcription", ringRoots[0].Attributes["style"]?.ToString() ?? "");
+        Assert.Contains("--phase-diarization", ringRoots[1].Attributes["style"]?.ToString() ?? "");
+        Assert.Contains("--phase-merge", ringRoots[2].Attributes["style"]?.ToString() ?? "");
+    }
+
+    [Fact]
+    public async Task RendersChevronSeparatorsBetweenRings()
+    {
+        await using var context = DesktopUiTestContext.Create();
+        var clock = new ControllableTimeProvider(T0);
+        using var tracker = new PhaseProgressTracker(speakerLabelingEnabled: true, timeProvider: clock);
+
+        var rendered = await context.RenderAsync<PhaseRingStack>(Params(tracker));
+
+        var chevrons = rendered.FindElements(
+            e => e.Attributes.TryGetValue("class", out var c)
+                && (c?.ToString() ?? "").Contains("phase-ring-chevron"));
+        Assert.Equal(2, chevrons.Count);
+    }
+
+    [Fact]
+    public async Task ReflectsRunningPhase_AfterTrackerProgressUpdate()
+    {
+        await using var context = DesktopUiTestContext.Create();
+        var clock = new ControllableTimeProvider(T0);
+        using var tracker = new PhaseProgressTracker(speakerLabelingEnabled: true, timeProvider: clock);
+
+        var rendered = await context.RenderAsync<PhaseRingStack>(Params(tracker));
+        tracker.OnProgress(Frame(ProgressStage.Transcribing, 45.0));
+        await rendered.SynchronizeAsync();
+
+        Assert.Contains("50", rendered.TextContent);
+        Assert.Contains("transcribing", rendered.TextContent);
+    }
+
+    [Fact]
+    public async Task SkippedDiarization_RendersSkippedRingInMiddle()
+    {
+        await using var context = DesktopUiTestContext.Create();
+        var clock = new ControllableTimeProvider(T0);
+        using var tracker = new PhaseProgressTracker(speakerLabelingEnabled: false, timeProvider: clock);
+
+        var rendered = await context.RenderAsync<PhaseRingStack>(Params(tracker));
+
+        Assert.Contains("skipped", rendered.TextContent, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/tests/VoxFlow.Desktop.Tests/Components/PhaseRingTests.cs
+++ b/tests/VoxFlow.Desktop.Tests/Components/PhaseRingTests.cs
@@ -1,0 +1,136 @@
+using Microsoft.AspNetCore.Components;
+using VoxFlow.Core.Models;
+using VoxFlow.Desktop.Components.Pages;
+using VoxFlow.Desktop.ViewModels;
+using Xunit;
+
+namespace VoxFlow.Desktop.Tests.Components;
+
+public sealed class PhaseRingTests
+{
+    // Ring geometry kept in sync with the component: r=50, circumference=2πr.
+    private const double Radius = 50.0;
+    private static readonly double Circumference = 2.0 * Math.PI * Radius;
+
+    private static ParameterView Params(PhaseState state, string phaseToken = "--phase-transcription")
+        => ParameterView.FromDictionary(new Dictionary<string, object?>
+        {
+            [nameof(PhaseRing.State)] = state,
+            [nameof(PhaseRing.PhaseToken)] = phaseToken,
+        });
+
+    [Fact]
+    public async Task Idle_RendersTrackCircleOnly_NoArcNoElapsed()
+    {
+        await using var context = DesktopUiTestContext.Create();
+        var state = new PhaseState(ProgressPhase.Transcription, PhaseStatus.Idle, 0, null, TimeSpan.Zero);
+
+        var rendered = await context.RenderAsync<PhaseRing>(Params(state));
+
+        var tracks = rendered.FindElements(
+            e => e.Name == "circle"
+                && e.Attributes.TryGetValue("class", out var c)
+                && (c?.ToString() ?? "").Contains("phase-ring-track"));
+        Assert.Single(tracks);
+
+        var arcs = rendered.FindElements(
+            e => e.Name == "circle"
+                && e.Attributes.TryGetValue("class", out var c)
+                && (c?.ToString() ?? "").Contains("phase-ring-arc"));
+        Assert.Empty(arcs);
+
+        var elapsed = rendered.FindElements(
+            e => e.Attributes.TryGetValue("class", out var c)
+                && (c?.ToString() ?? "").Contains("phase-ring-elapsed"));
+        Assert.Empty(elapsed);
+    }
+
+    [Fact]
+    public async Task Running_RendersArc_WithDashoffsetProportionalToLocalPercent()
+    {
+        await using var context = DesktopUiTestContext.Create();
+        var state = new PhaseState(ProgressPhase.Transcription, PhaseStatus.Running, 25.0, "transcribing", TimeSpan.FromSeconds(3));
+
+        var rendered = await context.RenderAsync<PhaseRing>(Params(state));
+
+        var arc = rendered.FindElement(
+            e => e.Name == "circle"
+                && e.Attributes.TryGetValue("class", out var c)
+                && (c?.ToString() ?? "").Contains("phase-ring-arc"),
+            "phase-ring arc");
+
+        var dashoffsetValue = arc.Attributes["stroke-dashoffset"]?.ToString() ?? "";
+        var parsed = double.Parse(dashoffsetValue, System.Globalization.CultureInfo.InvariantCulture);
+        var expected = Circumference * 0.75;
+        Assert.InRange(parsed, expected - 0.5, expected + 0.5);
+    }
+
+    [Fact]
+    public async Task Running_ShowsLocalPercentValueInCenter()
+    {
+        await using var context = DesktopUiTestContext.Create();
+        var state = new PhaseState(ProgressPhase.Transcription, PhaseStatus.Running, 45.0, "transcribing", TimeSpan.FromSeconds(12));
+
+        var rendered = await context.RenderAsync<PhaseRing>(Params(state));
+
+        Assert.Contains("45", rendered.TextContent);
+        Assert.Contains("%", rendered.TextContent);
+        Assert.Contains("transcribing", rendered.TextContent);
+        Assert.Contains("0:12", rendered.TextContent);
+    }
+
+    [Fact]
+    public async Task Done_RendersFullArc_AndDoneLabel_AndFrozenElapsed()
+    {
+        await using var context = DesktopUiTestContext.Create();
+        var state = new PhaseState(ProgressPhase.Transcription, PhaseStatus.Done, 100.0, "done", TimeSpan.FromSeconds(22));
+
+        var rendered = await context.RenderAsync<PhaseRing>(Params(state));
+
+        var arc = rendered.FindElement(
+            e => e.Name == "circle"
+                && e.Attributes.TryGetValue("class", out var c)
+                && (c?.ToString() ?? "").Contains("phase-ring-arc"),
+            "phase-ring arc");
+
+        var dashoffsetValue = arc.Attributes["stroke-dashoffset"]?.ToString() ?? "";
+        var parsed = double.Parse(dashoffsetValue, System.Globalization.CultureInfo.InvariantCulture);
+        Assert.InRange(parsed, -0.5, 0.5);
+
+        Assert.Contains("done", rendered.TextContent, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("0:22", rendered.TextContent);
+    }
+
+    [Fact]
+    public async Task Skipped_RendersSkippedLabel_NoElapsed_NoArc()
+    {
+        await using var context = DesktopUiTestContext.Create();
+        var state = new PhaseState(ProgressPhase.Diarization, PhaseStatus.Skipped, 0, "skipped", TimeSpan.Zero);
+
+        var rendered = await context.RenderAsync<PhaseRing>(Params(state, "--phase-diarization"));
+
+        Assert.Contains("skipped", rendered.TextContent, StringComparison.OrdinalIgnoreCase);
+
+        var arcs = rendered.FindElements(
+            e => e.Name == "circle"
+                && e.Attributes.TryGetValue("class", out var c)
+                && (c?.ToString() ?? "").Contains("phase-ring-arc"));
+        Assert.Empty(arcs);
+
+        var elapsed = rendered.FindElements(
+            e => e.Attributes.TryGetValue("class", out var c)
+                && (c?.ToString() ?? "").Contains("phase-ring-elapsed"));
+        Assert.Empty(elapsed);
+    }
+
+    [Fact]
+    public async Task Failed_RendersFailedLabel()
+    {
+        await using var context = DesktopUiTestContext.Create();
+        var state = new PhaseState(ProgressPhase.Transcription, PhaseStatus.Failed, 30.0, "model load failed", TimeSpan.FromSeconds(5));
+
+        var rendered = await context.RenderAsync<PhaseRing>(Params(state));
+
+        Assert.Contains("failed", rendered.TextContent, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/tests/VoxFlow.Desktop.Tests/Components/SettingsPanelTests.cs
+++ b/tests/VoxFlow.Desktop.Tests/Components/SettingsPanelTests.cs
@@ -1,0 +1,52 @@
+using VoxFlow.Desktop.Components.Shared;
+using Xunit;
+
+namespace VoxFlow.Desktop.Tests.Components;
+
+public sealed class SettingsPanelTests
+{
+    [Fact]
+    public async Task SettingsPanel_RendersSpeakerLabelingToggle()
+    {
+        await using var context = DesktopUiTestContext.Create();
+
+        var rendered = await context.RenderAsync<SettingsPanel>();
+
+        var toggle = rendered.FindElements(
+            e => e.Attributes.TryGetValue("id", out var id)
+                && (id?.ToString() ?? string.Empty) == "speaker-labeling-toggle");
+        Assert.Single(toggle);
+    }
+
+    [Fact]
+    public async Task SettingsPanel_RendersSpeakerToggleAfterFormatPicker()
+    {
+        await using var context = DesktopUiTestContext.Create();
+
+        var rendered = await context.RenderAsync<SettingsPanel>();
+
+        Assert.Contains("Speaker labeling", rendered.TextContent);
+        Assert.Contains("Output Format", rendered.TextContent);
+        var formatIndex = rendered.TextContent.IndexOf("Output Format", StringComparison.Ordinal);
+        var speakerIndex = rendered.TextContent.IndexOf("Speaker labeling", StringComparison.Ordinal);
+        Assert.True(speakerIndex > formatIndex, "Speaker toggle must render after format picker");
+    }
+
+    [Fact]
+    public async Task SettingsPanel_WhenDisabled_PropagatesIsDisabledToToggle()
+    {
+        await using var context = DesktopUiTestContext.Create();
+        context.ViewModel.SpeakerLabelingEnabled = false;
+        var parameters = Microsoft.AspNetCore.Components.ParameterView.FromDictionary(
+            new Dictionary<string, object?> { [nameof(SettingsPanel.IsDisabled)] = true });
+
+        var rendered = await context.RenderAsync<SettingsPanel>(parameters);
+
+        var switchEl = rendered.FindElement(
+            e => e.Name == "button"
+                && e.Attributes.TryGetValue("role", out var role)
+                && (role?.ToString() ?? string.Empty) == "switch",
+            "speaker-labeling switch");
+        Assert.True(switchEl.Attributes.ContainsKey("disabled"));
+    }
+}

--- a/tests/VoxFlow.Desktop.Tests/Components/SpeakerLabelingToggleTests.cs
+++ b/tests/VoxFlow.Desktop.Tests/Components/SpeakerLabelingToggleTests.cs
@@ -1,0 +1,136 @@
+using VoxFlow.Desktop.Components.Shared;
+using VoxFlow.Desktop.Configuration;
+using Xunit;
+
+namespace VoxFlow.Desktop.Tests.Components;
+
+internal sealed class RecordingDesktopConfigurationService : DesktopConfigurationService
+{
+    public RecordingDesktopConfigurationService()
+        : base(
+            Path.Combine(Path.GetTempPath(), $"voxflow-recording-cfg-{Guid.NewGuid():N}"),
+            Path.Combine(Path.GetTempPath(), $"voxflow-recording-docs-{Guid.NewGuid():N}"))
+    {
+    }
+
+    public List<Dictionary<string, object>> SavedOverrides { get; } = [];
+
+    public Exception? SaveException { get; set; }
+
+    public override Task SaveUserOverridesAsync(Dictionary<string, object> overrides)
+    {
+        if (SaveException is not null) throw SaveException;
+        SavedOverrides.Add(new Dictionary<string, object>(overrides));
+        return Task.CompletedTask;
+    }
+}
+
+public sealed class SpeakerLabelingToggleTests
+{
+    [Fact]
+    public async Task SpeakerLabelingToggle_WhenFlagDisabled_AriaCheckedIsFalse()
+    {
+        await using var context = DesktopUiTestContext.Create();
+        context.ViewModel.SpeakerLabelingEnabled = false;
+
+        var rendered = await context.RenderAsync<SpeakerLabelingToggle>();
+
+        var switchEl = rendered.FindElement(
+            e => e.Name == "button"
+                && e.Attributes.TryGetValue("role", out var role)
+                && (role?.ToString() ?? string.Empty) == "switch",
+            "speaker-labeling switch");
+        Assert.Equal("false", switchEl.Attributes["aria-checked"]?.ToString());
+    }
+
+    [Fact]
+    public async Task SpeakerLabelingToggle_WhenFlagEnabled_AriaCheckedIsTrue()
+    {
+        await using var context = DesktopUiTestContext.Create();
+        context.ViewModel.SpeakerLabelingEnabled = true;
+
+        var rendered = await context.RenderAsync<SpeakerLabelingToggle>();
+
+        var switchEl = rendered.FindElement(
+            e => e.Name == "button"
+                && e.Attributes.TryGetValue("role", out var role)
+                && (role?.ToString() ?? string.Empty) == "switch",
+            "speaker-labeling switch");
+        Assert.Equal("true", switchEl.Attributes["aria-checked"]?.ToString());
+    }
+
+    [Fact]
+    public async Task SpeakerLabelingToggle_Click_FlipsViewModelFlag()
+    {
+        await using var context = DesktopUiTestContext.Create();
+        context.ViewModel.SpeakerLabelingEnabled = false;
+
+        var rendered = await context.RenderAsync<SpeakerLabelingToggle>();
+
+        await rendered.ClickAsync(
+            e => e.Name == "button"
+                && e.Attributes.TryGetValue("role", out var role)
+                && (role?.ToString() ?? string.Empty) == "switch",
+            "speaker-labeling switch");
+
+        Assert.True(context.ViewModel.SpeakerLabelingEnabled);
+    }
+
+    [Fact]
+    public async Task SpeakerLabelingToggle_Click_WhenEnabled_TurnsOff()
+    {
+        await using var context = DesktopUiTestContext.Create();
+        context.ViewModel.SpeakerLabelingEnabled = true;
+
+        var rendered = await context.RenderAsync<SpeakerLabelingToggle>();
+
+        await rendered.ClickAsync(
+            e => e.Name == "button"
+                && e.Attributes.TryGetValue("role", out var role)
+                && (role?.ToString() ?? string.Empty) == "switch",
+            "speaker-labeling switch");
+
+        Assert.False(context.ViewModel.SpeakerLabelingEnabled);
+    }
+
+    [Fact]
+    public async Task SpeakerLabelingToggle_Click_PersistsNestedSpeakerLabelingOverride()
+    {
+        var recorder = new RecordingDesktopConfigurationService();
+        await using var context = DesktopUiTestContext.Create(desktopConfigurationService: recorder);
+        context.ViewModel.SpeakerLabelingEnabled = false;
+
+        var rendered = await context.RenderAsync<SpeakerLabelingToggle>();
+
+        await rendered.ClickAsync(
+            e => e.Name == "button"
+                && e.Attributes.TryGetValue("role", out var role)
+                && (role?.ToString() ?? string.Empty) == "switch",
+            "speaker-labeling switch");
+
+        var saved = Assert.Single(recorder.SavedOverrides);
+        var speakerLabeling = Assert.IsAssignableFrom<IDictionary<string, object>>(saved["speakerLabeling"]);
+        Assert.True((bool)speakerLabeling["enabled"]);
+    }
+
+    [Fact]
+    public async Task SpeakerLabelingToggle_Click_WhenPersistThrows_DoesNotBubbleAndKeepsInMemoryFlag()
+    {
+        var recorder = new RecordingDesktopConfigurationService
+        {
+            SaveException = new IOException("disk full"),
+        };
+        await using var context = DesktopUiTestContext.Create(desktopConfigurationService: recorder);
+        context.ViewModel.SpeakerLabelingEnabled = false;
+
+        var rendered = await context.RenderAsync<SpeakerLabelingToggle>();
+
+        await rendered.ClickAsync(
+            e => e.Name == "button"
+                && e.Attributes.TryGetValue("role", out var role)
+                && (role?.ToString() ?? string.Empty) == "switch",
+            "speaker-labeling switch");
+
+        Assert.True(context.ViewModel.SpeakerLabelingEnabled);
+    }
+}

--- a/tests/VoxFlow.Desktop.Tests/Components/SpeakerTranscriptViewTests.cs
+++ b/tests/VoxFlow.Desktop.Tests/Components/SpeakerTranscriptViewTests.cs
@@ -1,0 +1,148 @@
+using Microsoft.AspNetCore.Components;
+using VoxFlow.Core.Models;
+using VoxFlow.Desktop.Components.Shared;
+using Xunit;
+
+namespace VoxFlow.Desktop.Tests.Components;
+
+public sealed class SpeakerTranscriptViewTests
+{
+    private static TranscriptMetadata Meta() => new(
+        SchemaVersion: 1,
+        DiarizationModel: "test",
+        SidecarVersion: 1);
+
+    private static TranscriptWord Word(string speaker, double start, double end, string text) =>
+        new(TimeSpan.FromSeconds(start), TimeSpan.FromSeconds(end), text, speaker);
+
+    private static TranscriptDocument Doc(params SpeakerTurn[] turns)
+    {
+        var words = turns.SelectMany(t => t.Words).ToList();
+        var speakerIds = turns.Select(t => t.SpeakerId).Distinct().ToList();
+        var roster = speakerIds
+            .Select(id => new SpeakerInfo(id, id, TimeSpan.Zero))
+            .ToList();
+        return new TranscriptDocument(roster, words, turns, Meta());
+    }
+
+    private static SpeakerTurn Turn(string speaker, double start, double end, params string[] words)
+    {
+        var tokens = words
+            .Select((w, i) => Word(speaker, start + i * 0.1, start + (i + 1) * 0.1, w))
+            .ToList();
+        return new SpeakerTurn(speaker, TimeSpan.FromSeconds(start), TimeSpan.FromSeconds(end), tokens);
+    }
+
+    private static ParameterView Params(TranscriptDocument? doc) =>
+        ParameterView.FromDictionary(new Dictionary<string, object?>
+        {
+            [nameof(SpeakerTranscriptView.Document)] = doc,
+        });
+
+    [Fact]
+    public async Task Renders_NullDocument_ProducesEmptyMarkup()
+    {
+        await using var context = DesktopUiTestContext.Create();
+
+        var rendered = await context.RenderAsync<SpeakerTranscriptView>(Params(null));
+
+        Assert.Equal(string.Empty, rendered.TextContent.Trim());
+    }
+
+    [Fact]
+    public async Task Renders_EmptyTurns_ShowsNoSegmentsMessage()
+    {
+        await using var context = DesktopUiTestContext.Create();
+        var doc = new TranscriptDocument(
+            Array.Empty<SpeakerInfo>(),
+            Array.Empty<TranscriptWord>(),
+            Array.Empty<SpeakerTurn>(),
+            Meta());
+
+        var rendered = await context.RenderAsync<SpeakerTranscriptView>(Params(doc));
+
+        Assert.Contains("No speaker segments detected", rendered.TextContent);
+    }
+
+    [Fact]
+    public async Task Renders_SingleSpeakerTurn_HasCorrectLabelAndColor()
+    {
+        await using var context = DesktopUiTestContext.Create();
+        var doc = Doc(Turn("A", 0, 2, "hello", "world"));
+
+        var rendered = await context.RenderAsync<SpeakerTranscriptView>(Params(doc));
+
+        var turnElement = rendered.FindElement(
+            e => e.Attributes.TryGetValue("data-speaker-label", out var v) && v?.ToString() == "A",
+            "turn element with data-speaker-label=A");
+
+        Assert.Contains("hello world", rendered.TextContent);
+        var style = turnElement.Attributes["style"]?.ToString() ?? string.Empty;
+        Assert.Contains("#E69F00", style, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Renders_TwoSpeakers_AlternatingTurns_HaveDifferentColors()
+    {
+        await using var context = DesktopUiTestContext.Create();
+        var doc = Doc(
+            Turn("A", 0, 1, "one"),
+            Turn("B", 1, 2, "two"),
+            Turn("A", 2, 3, "three"),
+            Turn("B", 3, 4, "four"));
+
+        var rendered = await context.RenderAsync<SpeakerTranscriptView>(Params(doc));
+
+        var turns = rendered.FindElements(
+            e => e.Attributes.ContainsKey("data-speaker-label"));
+
+        Assert.Equal(4, turns.Count);
+        var aStyle = turns[0].Attributes["style"]?.ToString() ?? string.Empty;
+        var bStyle = turns[1].Attributes["style"]?.ToString() ?? string.Empty;
+        Assert.Contains("#E69F00", aStyle, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("#56B4E9", bStyle, StringComparison.OrdinalIgnoreCase);
+        Assert.NotEqual(aStyle, bStyle);
+    }
+
+    [Fact]
+    public async Task Renders_TimestampRange_PerTurn()
+    {
+        await using var context = DesktopUiTestContext.Create();
+        var doc = Doc(Turn("A", 3, 12, "hi"));
+
+        var rendered = await context.RenderAsync<SpeakerTranscriptView>(Params(doc));
+
+        Assert.Contains("00:03", rendered.TextContent);
+        Assert.Contains("00:12", rendered.TextContent);
+    }
+
+    [Fact]
+    public async Task Renders_NineSpeakers_ColorsWrapAroundPalette()
+    {
+        await using var context = DesktopUiTestContext.Create();
+        var labels = new[] { "A", "B", "C", "D", "E", "F", "G", "H", "I" };
+        var turns = labels.Select((l, i) => Turn(l, i, i + 1, "x")).ToArray();
+        var doc = Doc(turns);
+
+        var rendered = await context.RenderAsync<SpeakerTranscriptView>(Params(doc));
+
+        var turnElements = rendered.FindElements(
+            e => e.Attributes.ContainsKey("data-speaker-label"));
+
+        Assert.Equal(9, turnElements.Count);
+        var firstStyle = turnElements[0].Attributes["style"]?.ToString() ?? string.Empty;
+        var ninthStyle = turnElements[8].Attributes["style"]?.ToString() ?? string.Empty;
+        Assert.Equal(firstStyle, ninthStyle);
+    }
+
+    [Fact]
+    public async Task Renders_SpeakerLabel_InTurn()
+    {
+        await using var context = DesktopUiTestContext.Create();
+        var doc = Doc(Turn("A", 0, 1, "hello"));
+
+        var rendered = await context.RenderAsync<SpeakerTranscriptView>(Params(doc));
+
+        Assert.Contains("Speaker A", rendered.TextContent);
+    }
+}

--- a/tests/VoxFlow.Desktop.Tests/DesktopConfigurationTests.cs
+++ b/tests/VoxFlow.Desktop.Tests/DesktopConfigurationTests.cs
@@ -305,4 +305,102 @@ public sealed class DesktopConfigurationTests : IDisposable
         Assert.True(validation.GetProperty("enabled").GetBoolean());
         Assert.True(validation.GetProperty("checkModelDirectory").GetBoolean());
     }
+
+    // -----------------------------------------------------------------------
+    // SaveUserOverridesAsync — new override is added without wiping previously
+    // saved keys. Needed so toggling speakerLabeling.enabled does not clobber
+    // the resultFormat the format-picker saved on a previous click.
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task SaveUserOverridesAsync_NewKey_PreservesPreviouslySavedKeys()
+    {
+        var appSupport = Path.Combine(_tempDir, "app-support");
+        var documents = Path.Combine(_tempDir, "documents");
+        var service = new DesktopConfigurationService(appSupport, documents);
+        Directory.CreateDirectory(appSupport);
+        var userFile = Path.Combine(appSupport, "appsettings.json");
+        await File.WriteAllTextAsync(
+            userFile,
+            """
+            {
+              "transcription": {
+                "resultFormat": "md"
+              }
+            }
+            """);
+
+        await service.SaveUserOverridesAsync(new Dictionary<string, object>
+        {
+            ["speakerLabeling"] = new Dictionary<string, object>
+            {
+                ["enabled"] = true
+            }
+        });
+
+        using var doc = JsonDocument.Parse(await File.ReadAllTextAsync(userFile));
+        var transcription = doc.RootElement.GetProperty("transcription");
+        Assert.Equal("md", transcription.GetProperty("resultFormat").GetString());
+        Assert.True(
+            transcription.GetProperty("speakerLabeling").GetProperty("enabled").GetBoolean());
+    }
+
+    [Fact]
+    public async Task SaveUserOverridesAsync_SameKeyTwice_UpdatesValue()
+    {
+        var appSupport = Path.Combine(_tempDir, "app-support");
+        var documents = Path.Combine(_tempDir, "documents");
+        var service = new DesktopConfigurationService(appSupport, documents);
+
+        await service.SaveUserOverridesAsync(new Dictionary<string, object>
+        {
+            ["resultFormat"] = "txt"
+        });
+        await service.SaveUserOverridesAsync(new Dictionary<string, object>
+        {
+            ["resultFormat"] = "md"
+        });
+
+        var userFile = Path.Combine(appSupport, "appsettings.json");
+        using var doc = JsonDocument.Parse(await File.ReadAllTextAsync(userFile));
+        Assert.Equal(
+            "md",
+            doc.RootElement.GetProperty("transcription").GetProperty("resultFormat").GetString());
+    }
+
+    [Fact]
+    public async Task SaveUserOverridesAsync_NestedOverride_DeepMergesWithPrevious()
+    {
+        var appSupport = Path.Combine(_tempDir, "app-support");
+        var documents = Path.Combine(_tempDir, "documents");
+        var service = new DesktopConfigurationService(appSupport, documents);
+        Directory.CreateDirectory(appSupport);
+        var userFile = Path.Combine(appSupport, "appsettings.json");
+        await File.WriteAllTextAsync(
+            userFile,
+            """
+            {
+              "transcription": {
+                "speakerLabeling": {
+                  "timeoutSeconds": 900
+                }
+              }
+            }
+            """);
+
+        await service.SaveUserOverridesAsync(new Dictionary<string, object>
+        {
+            ["speakerLabeling"] = new Dictionary<string, object>
+            {
+                ["enabled"] = true
+            }
+        });
+
+        using var doc = JsonDocument.Parse(await File.ReadAllTextAsync(userFile));
+        var speakerLabeling = doc.RootElement
+            .GetProperty("transcription")
+            .GetProperty("speakerLabeling");
+        Assert.True(speakerLabeling.GetProperty("enabled").GetBoolean());
+        Assert.Equal(900, speakerLabeling.GetProperty("timeoutSeconds").GetInt32());
+    }
 }

--- a/tests/VoxFlow.Desktop.Tests/DesktopUiComponentTests.cs
+++ b/tests/VoxFlow.Desktop.Tests/DesktopUiComponentTests.cs
@@ -59,7 +59,7 @@ public sealed class DesktopUiComponentTests
             currentState: AppState.Running,
             currentProgress: new ProgressUpdate(
                 ProgressStage.Transcribing,
-                42,
+                45,
                 TimeSpan.FromSeconds(125),
                 "Processing audio",
                 "English"));
@@ -68,8 +68,8 @@ public sealed class DesktopUiComponentTests
 
         Assert.Contains("audio file", rendered.TextContent);
         Assert.Contains("Processing audio", rendered.TextContent);
-        Assert.Contains("2:05", rendered.TextContent);
-        Assert.Contains("42", rendered.TextContent);
+        // Transcribing at 45% overall → Transcription-local 50% (banding 0..90)
+        Assert.Contains("50", rendered.TextContent);
     }
 
     [Fact]
@@ -644,7 +644,7 @@ public sealed class DesktopUiComponentTests
             currentState: AppState.Running,
             currentProgress: new ProgressUpdate(
                 ProgressStage.Writing,
-                95,
+                97,
                 TimeSpan.FromSeconds(60),
                 "Writing result file",
                 null));
@@ -652,8 +652,8 @@ public sealed class DesktopUiComponentTests
         var rendered = await context.RenderAsync<RunningView>();
 
         Assert.Contains("Writing result file", rendered.TextContent);
-        Assert.Contains("1:00", rendered.TextContent);
-        Assert.Contains("95", rendered.TextContent);
+        // Writing at 97% overall → Merge-local 40% (banding 95..100)
+        Assert.Contains("40", rendered.TextContent);
         Assert.DoesNotContain("Language:", rendered.TextContent);
     }
 
@@ -751,13 +751,14 @@ public sealed class DesktopUiComponentTests
             currentState: AppState.Running,
             currentProgress: new ProgressUpdate(
                 ProgressStage.Transcribing,
-                67,
+                63,
                 TimeSpan.FromSeconds(30),
                 "Processing segments"));
 
         var rendered = await context.RenderAsync<RunningView>();
 
-        Assert.Contains("67", rendered.TextContent);
+        // Transcribing at 63% overall → Transcription-local 70% (banding 0..90)
+        Assert.Contains("70", rendered.TextContent);
         Assert.Contains("%", rendered.TextContent);
     }
 
@@ -778,14 +779,15 @@ public sealed class DesktopUiComponentTests
 
         context.ViewModel.CurrentProgress = new ProgressUpdate(
             ProgressStage.Transcribing,
-            38,
+            36,
             TimeSpan.FromSeconds(12),
             "Processing audio",
             "English");
 
         await rendered.SynchronizeAsync();
 
-        Assert.Contains("38", rendered.TextContent);
+        // Transcribing at 36% overall → Transcription-local 40% (banding 0..90)
+        Assert.Contains("40", rendered.TextContent);
         Assert.Contains("Processing audio", rendered.TextContent);
     }
 
@@ -817,18 +819,22 @@ public sealed class DesktopUiComponentTests
             currentState: AppState.Running,
             currentProgress: new ProgressUpdate(
                 ProgressStage.Transcribing,
-                50,
+                45,
                 TimeSpan.FromSeconds(10),
                 "Half done"));
 
         var rendered = await context.RenderAsync<RunningView>();
 
         var progressWrapper = rendered.FindElement(
-            element => element.Name == "div" && element.HasClass("organic-progress-wrapper")
-                       && element.Attributes.ContainsKey("role"),
-            "organic progress wrapper with role");
+            element => element.Name == "div"
+                       && element.HasClass("phase-ring")
+                       && element.Attributes.ContainsKey("role")
+                       && element.Attributes.TryGetValue("aria-label", out var label)
+                       && label?.ToString() == "Transcription progress",
+            "transcription phase ring with progressbar role");
 
         Assert.Equal("progressbar", progressWrapper.Attributes["role"]?.ToString());
+        // Transcribing at 45% overall → Transcription-local 50% (banding 0..90)
         Assert.Equal("50", progressWrapper.Attributes["aria-valuenow"]?.ToString());
     }
 

--- a/tests/VoxFlow.Desktop.Tests/DesktopUiComponentTests.cs
+++ b/tests/VoxFlow.Desktop.Tests/DesktopUiComponentTests.cs
@@ -914,6 +914,156 @@ public sealed class DesktopUiComponentTests
         Assert.Empty(context.ResultActionService.CopiedTexts);
     }
 
+    // -----------------------------------------------------------------------
+    // P2.5 — CompleteView: SpeakerTranscriptView integration + enrichment banner
+    // -----------------------------------------------------------------------
+
+    private static TranscriptDocument MakeSpeakerDoc(params (string Speaker, double Start, double End, string Word)[] words)
+    {
+        var meta = new TranscriptMetadata(SchemaVersion: 1, DiarizationModel: "test", SidecarVersion: 1);
+        var tokens = words
+            .Select(w => new TranscriptWord(
+                TimeSpan.FromSeconds(w.Start),
+                TimeSpan.FromSeconds(w.End),
+                w.Word,
+                w.Speaker))
+            .ToList();
+        var turns = SpeakerTurn.GroupConsecutive(tokens);
+        var roster = turns
+            .Select(t => t.SpeakerId)
+            .Distinct()
+            .Select(id => new SpeakerInfo(id, id, TimeSpan.Zero))
+            .ToList();
+        return new TranscriptDocument(roster, tokens, turns, meta);
+    }
+
+    [Fact]
+    public async Task CompleteView_NullDocument_RendersPlainTextPreview_Unchanged()
+    {
+        await using var context = DesktopUiTestContext.Create();
+        AppViewModelStateAccessor.SetState(
+            context.ViewModel,
+            currentState: AppState.Complete,
+            transcriptionResult: new TranscribeFileResult(
+                Success: true,
+                DetectedLanguage: "en",
+                ResultFilePath: "/tmp/result.txt",
+                AcceptedSegmentCount: 5,
+                SkippedSegmentCount: 0,
+                Duration: TimeSpan.FromSeconds(8),
+                Warnings: [],
+                TranscriptPreview: "Hello plain text."));
+
+        var rendered = await context.RenderAsync<CompleteView>();
+
+        Assert.Contains("Hello plain text.", rendered.TextContent);
+        var speakerTurns = rendered.FindElements(e => e.Attributes.ContainsKey("data-speaker-label"));
+        Assert.Empty(speakerTurns);
+    }
+
+    [Fact]
+    public async Task CompleteView_NonNullDocument_RendersSpeakerTranscriptView_AndHidesPlainTextPreview()
+    {
+        await using var context = DesktopUiTestContext.Create();
+        var doc = MakeSpeakerDoc(("A", 0, 1, "hi"), ("B", 1, 2, "there"));
+        AppViewModelStateAccessor.SetState(
+            context.ViewModel,
+            currentState: AppState.Complete,
+            transcriptionResult: new TranscribeFileResult(
+                Success: true,
+                DetectedLanguage: "en",
+                ResultFilePath: "/tmp/result.voxflow.json",
+                AcceptedSegmentCount: 2,
+                SkippedSegmentCount: 0,
+                Duration: TimeSpan.FromSeconds(2),
+                Warnings: [],
+                TranscriptPreview: "hi there",
+                SpeakerTranscript: doc));
+
+        var rendered = await context.RenderAsync<CompleteView>();
+
+        Assert.Contains("Speaker A", rendered.TextContent);
+        Assert.Contains("Speaker B", rendered.TextContent);
+        var speakerTurns = rendered.FindElements(e => e.Attributes.ContainsKey("data-speaker-label"));
+        Assert.Equal(2, speakerTurns.Count);
+        Assert.DoesNotContain("Transcript Preview", rendered.TextContent);
+        var plainPreview = rendered.FindElements(e => e.HasClass("transcript-preview"));
+        Assert.Empty(plainPreview);
+    }
+
+    [Fact]
+    public async Task CompleteView_EnrichmentWarnings_RendersBanner_WithEachMessage()
+    {
+        await using var context = DesktopUiTestContext.Create();
+        AppViewModelStateAccessor.SetState(
+            context.ViewModel,
+            currentState: AppState.Complete,
+            transcriptionResult: new TranscribeFileResult(
+                Success: true,
+                DetectedLanguage: "en",
+                ResultFilePath: "/tmp/result.txt",
+                AcceptedSegmentCount: 5,
+                SkippedSegmentCount: 0,
+                Duration: TimeSpan.FromSeconds(8),
+                Warnings: [],
+                TranscriptPreview: "preview",
+                EnrichmentWarnings: ["speaker-labeling: model load failed", "fell back to plain text"]));
+
+        var rendered = await context.RenderAsync<CompleteView>();
+
+        Assert.Contains("speaker-labeling: model load failed", rendered.TextContent);
+        Assert.Contains("fell back to plain text", rendered.TextContent);
+    }
+
+    [Fact]
+    public async Task CompleteView_EnrichmentWarnings_EmptyList_DoesNotRenderBanner()
+    {
+        await using var context = DesktopUiTestContext.Create();
+        AppViewModelStateAccessor.SetState(
+            context.ViewModel,
+            currentState: AppState.Complete,
+            transcriptionResult: new TranscribeFileResult(
+                Success: true,
+                DetectedLanguage: "en",
+                ResultFilePath: "/tmp/result.txt",
+                AcceptedSegmentCount: 5,
+                SkippedSegmentCount: 0,
+                Duration: TimeSpan.FromSeconds(8),
+                Warnings: [],
+                TranscriptPreview: "preview"));
+
+        var rendered = await context.RenderAsync<CompleteView>();
+
+        var banner = rendered.FindElements(e => e.HasClass("enrichment-warnings-banner"));
+        Assert.Empty(banner);
+    }
+
+    [Fact]
+    public async Task CompleteView_DocumentAndWarningsBoth_RendersBothSections()
+    {
+        await using var context = DesktopUiTestContext.Create();
+        var doc = MakeSpeakerDoc(("A", 0, 1, "hi"));
+        AppViewModelStateAccessor.SetState(
+            context.ViewModel,
+            currentState: AppState.Complete,
+            transcriptionResult: new TranscribeFileResult(
+                Success: true,
+                DetectedLanguage: "en",
+                ResultFilePath: "/tmp/result.voxflow.json",
+                AcceptedSegmentCount: 1,
+                SkippedSegmentCount: 0,
+                Duration: TimeSpan.FromSeconds(1),
+                Warnings: [],
+                TranscriptPreview: "hi",
+                SpeakerTranscript: doc,
+                EnrichmentWarnings: ["heads-up: partial coverage"]));
+
+        var rendered = await context.RenderAsync<CompleteView>();
+
+        Assert.Contains("heads-up: partial coverage", rendered.TextContent);
+        Assert.Contains("Speaker A", rendered.TextContent);
+    }
+
     private static string WriteSingleFileConfig(string repositoryRoot, string tempDir, string inputPath)
     {
         var rootConfigPath = Path.Combine(repositoryRoot, "appsettings.json");

--- a/tests/VoxFlow.Desktop.Tests/Infrastructure/UiTestInfrastructure.cs
+++ b/tests/VoxFlow.Desktop.Tests/Infrastructure/UiTestInfrastructure.cs
@@ -42,7 +42,8 @@ internal sealed class DesktopUiTestContext : IAsyncDisposable
     public static DesktopUiTestContext Create(
         IConfigurationService? configurationService = null,
         IValidationService? validationService = null,
-        DelegateTranscriptionService? transcriptionService = null)
+        DelegateTranscriptionService? transcriptionService = null,
+        DesktopConfigurationService? desktopConfigurationService = null)
     {
         VoxFlow.Desktop.Platform.MacFilePicker.Reset();
         FilePicker.Default = new FilePicker();
@@ -65,7 +66,14 @@ internal sealed class DesktopUiTestContext : IAsyncDisposable
         services.AddSingleton<IJSRuntime>(jsRuntime);
         services.AddSingleton(viewModel);
         services.AddSingleton<IResultActionService>(resultActionService);
-        services.AddSingleton<DesktopConfigurationService>();
+        if (desktopConfigurationService is not null)
+        {
+            services.AddSingleton(desktopConfigurationService);
+        }
+        else
+        {
+            services.AddSingleton<DesktopConfigurationService>();
+        }
 
         var renderer = new TestRenderer(services.BuildServiceProvider());
         return new DesktopUiTestContext(renderer, viewModel, jsRuntime, transcription, resultActionService);

--- a/tests/VoxFlow.Desktop.Tests/Infrastructure/UiTestInfrastructure.cs
+++ b/tests/VoxFlow.Desktop.Tests/Infrastructure/UiTestInfrastructure.cs
@@ -548,6 +548,10 @@ internal static class AppViewModelStateAccessor
         SetIfProvided(viewModel, "_currentProgress", currentProgress);
         SetIfProvided(viewModel, "_errorMessage", errorMessage);
         SetIfProvided(viewModel, "_lastFilePath", lastFilePath);
+        if (currentProgress is not null)
+        {
+            viewModel.PhaseTracker.OnProgress(currentProgress);
+        }
         viewModel.NotifyStateChanged();
     }
 

--- a/tests/VoxFlow.Desktop.Tests/Theme/OkabeItoPaletteTests.cs
+++ b/tests/VoxFlow.Desktop.Tests/Theme/OkabeItoPaletteTests.cs
@@ -1,0 +1,49 @@
+using VoxFlow.Core.Models;
+using VoxFlow.Desktop.Theme;
+using Xunit;
+
+namespace VoxFlow.Desktop.Tests.Theme;
+
+public sealed class OkabeItoPaletteTests
+{
+    private static SpeakerInfo Speaker(string label) =>
+        new(Id: label, DisplayName: label, TotalSpeechDuration: TimeSpan.Zero);
+
+    [Fact]
+    public void ColorForSpeaker_FirstEightSpeakers_ReturnsDistinctColors()
+    {
+        var labels = new[] { "A", "B", "C", "D", "E", "F", "G", "H" };
+        var colors = labels.Select(l => OkabeItoPalette.ColorForSpeaker(Speaker(l))).ToArray();
+
+        Assert.Equal(8, colors.Distinct().Count());
+        foreach (var c in colors)
+        {
+            Assert.Matches("^#[0-9A-Fa-f]{6}$", c);
+        }
+    }
+
+    [Fact]
+    public void ColorForSpeaker_NinthSpeaker_WrapsToFirstColor()
+    {
+        var first = OkabeItoPalette.ColorForSpeaker(Speaker("A"));
+        var ninth = OkabeItoPalette.ColorForSpeaker(Speaker("I"));
+
+        Assert.Equal(first, ninth);
+    }
+
+    [Fact]
+    public void ColorForSpeaker_InvalidLabel_ThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() => OkabeItoPalette.ColorForSpeaker(Speaker("zz")));
+        Assert.Throws<ArgumentException>(() => OkabeItoPalette.ColorForSpeaker(Speaker("")));
+        Assert.Throws<ArgumentException>(() => OkabeItoPalette.ColorForSpeaker(Speaker("1")));
+    }
+
+    [Fact]
+    public void ColorForSpeaker_KnownPaletteValues_MatchOkabeIto()
+    {
+        Assert.Equal("#E69F00", OkabeItoPalette.ColorForSpeaker(Speaker("A")));
+        Assert.Equal("#56B4E9", OkabeItoPalette.ColorForSpeaker(Speaker("B")));
+        Assert.Equal("#000000", OkabeItoPalette.ColorForSpeaker(Speaker("H")));
+    }
+}

--- a/tests/VoxFlow.Desktop.Tests/VoxFlow.Desktop.Tests.csproj
+++ b/tests/VoxFlow.Desktop.Tests/VoxFlow.Desktop.Tests.csproj
@@ -42,5 +42,6 @@
     <Compile Include="..\..\src\VoxFlow.Desktop\Services\DesktopCliSupport.cs" Link="Services\DesktopCliSupport.cs" />
     <Compile Include="..\..\src\VoxFlow.Desktop\Services\DesktopCliTranscriptionService.cs" Link="Services\DesktopCliTranscriptionService.cs" />
     <Compile Include="..\..\src\VoxFlow.Desktop\Services\ResultActionService.cs" Link="Services\ResultActionService.cs" />
+    <Compile Include="..\..\src\VoxFlow.Desktop\Theme\OkabeItoPalette.cs" Link="Theme\OkabeItoPalette.cs" />
   </ItemGroup>
 </Project>

--- a/tests/VoxFlow.Desktop.Tests/VoxFlow.Desktop.Tests.csproj
+++ b/tests/VoxFlow.Desktop.Tests/VoxFlow.Desktop.Tests.csproj
@@ -35,6 +35,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\src\VoxFlow.Desktop\ViewModels\AppViewModel.cs" Link="ViewModels\AppViewModel.cs" />
+    <Compile Include="..\..\src\VoxFlow.Desktop\ViewModels\PhaseProgressTracker.cs" Link="ViewModels\PhaseProgressTracker.cs" />
     <Compile Include="..\..\src\VoxFlow.Desktop\Configuration\DesktopConfigurationService.cs" Link="Configuration\DesktopConfigurationService.cs" />
     <Compile Include="..\..\src\VoxFlow.Desktop\Services\BlazorProgressHandler.cs" Link="Services\BlazorProgressHandler.cs" />
     <Compile Include="..\..\src\VoxFlow.Desktop\Services\DesktopCliInvocation.cs" Link="Services\DesktopCliInvocation.cs" />


### PR DESCRIPTION
## Summary

Implements Phase 2 of ADR-024 Local Speaker Labeling on the Mac Catalyst Blazor Desktop app. Replaces the single organic progress circle with a three-phase ring tracker mirroring the CLI's Transcription → Diarization → Merge semantics, threads the speaker-labeling toggle end-to-end, and renders enriched transcripts with per-speaker color in the Complete screen.

### Highlights
- **P2.1 / P2.2** — `AppViewModel.SpeakerLabelingEnabled` bound to `SettingsPanel`, forwarded into `TranscribeFileRequest.EnableSpeakers`; config overrides merge-preserved on save.
- **P2.3a** — Extract `ProgressPhaseBanding` / `ProgressPhase` from `CliProgressHandler` into Core so Desktop and CLI share one phase-banding source of truth.
- **P2.3b** — `PhaseProgressTracker` view-model with `TimeProvider`-driven heartbeat; tracks per-phase local percent, sub-status, and elapsed-time that freezes on phase completion.
- **P2.3c** — `PhaseRing` + `PhaseRingStack` Razor components; SVG ring geometry (r=50, rounded caps), per-phase color tokens, ARIA progressbar semantics, skipped/failed glyphs.
- **P2.3d** — `RunningView` now renders the three-ring stack in place of the single organic SVG, preserving file-name caption and Cancel button.
- **P2.4** — `OkabeItoPalette` (colorblind-safe 8-color palette, alphabetic-ordinal wrap-around) + `SpeakerTranscriptView` colored-turn renderer (per-speaker CSS custom property, swatch, timestamp range).
- **P2.5** — `CompleteView` auto-selects `SpeakerTranscriptView` when `TranscribeFileResult.SpeakerTranscript` is present, plain preview otherwise; enrichment warnings banner surfaces `EnrichmentWarnings` inline.

All work is TDD: tests red → verify → green → verify. 13 focused commits.

## Base

Targets `speaker-labeling/phase-1-enrichment` (Phase 2 sits on top of Phase 1). Per ADR-024 branching strategy these chain into `Local-Speaker-Labeling`, then master.

## Test plan

- [x] `dotnet test` — Core 334 passed / McpServer 35 / Cli 18 / Desktop 130, 0 failures, 9 gated skips (Python sidecar + real-audio E2E)
- [x] Visual check: `RunningView` renders three rings with correct phase colors (cyan Transcription, magenta Diarization, green Merge)
- [x] Visual check: Skipped state renders middle ring as muted when speaker labeling is off
- [x] Visual check: `CompleteView` shows colored speaker turns for enriched runs, plain preview for plain runs, enrichment-warnings banner when warnings present
- [ ] Real-audio E2E with `VOXFLOW_RUN_DIARIZATION_E2E=1` (gated — out of scope for this PR, validates after Phase 1 merges)
