### PR TITLE
fix(desktop): Phase 2 hotfix — toggle styling + Intel-Mac CLI bridge speaker forwarding

### DIFF
--- a/src/VoxFlow.Desktop/Services/DesktopCliTranscriptionService.cs
+++ b/src/VoxFlow.Desktop/Services/DesktopCliTranscriptionService.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Text;
+using System.Text.Json.Nodes;
 using VoxFlow.Core.Configuration;
 using VoxFlow.Core.Interfaces;
 using VoxFlow.Core.Models;
@@ -9,6 +10,28 @@ namespace VoxFlow.Desktop.Services;
 
 internal sealed class DesktopCliTranscriptionService : ITranscriptionService
 {
+    internal static Action<JsonObject> BuildTranscriptionMutator(TranscribeFileRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        return transcription =>
+        {
+            transcription["inputFilePath"] = request.InputPath;
+            if (!string.IsNullOrWhiteSpace(request.ResultFilePath))
+            {
+                transcription["resultFilePath"] = request.ResultFilePath;
+            }
+            if (request.EnableSpeakers.HasValue)
+            {
+                if (transcription["speakerLabeling"] is not JsonObject speakerLabeling)
+                {
+                    speakerLabeling = new JsonObject();
+                    transcription["speakerLabeling"] = speakerLabeling;
+                }
+                speakerLabeling["enabled"] = request.EnableSpeakers.Value;
+            }
+        };
+    }
+
     private readonly DesktopConfigurationService _configurationService;
     private readonly ITranscriptReader _transcriptReader;
 
@@ -34,14 +57,7 @@ internal sealed class DesktopCliTranscriptionService : ITranscriptionService
         // Run the CLI against a disposable merged snapshot so per-request paths never mutate the user's settings file.
         var configurationPath = _configurationService.WriteMergedConfigurationSnapshot(
             request.ConfigurationPath,
-            transcription =>
-            {
-                transcription["inputFilePath"] = request.InputPath;
-                if (!string.IsNullOrWhiteSpace(request.ResultFilePath))
-                {
-                    transcription["resultFilePath"] = request.ResultFilePath;
-                }
-            },
+            BuildTranscriptionMutator(request),
             applyDesktopRuntimeOverrides: false);
 
         try

--- a/src/VoxFlow.Desktop/wwwroot/css/app.css
+++ b/src/VoxFlow.Desktop/wwwroot/css/app.css
@@ -1181,6 +1181,98 @@ button {
     cursor: not-allowed;
 }
 
+/* ---------- Speaker Labeling Toggle ---------- */
+.speaker-toggle {
+    display: flex;
+    justify-content: center;
+    margin-top: 14px;
+    width: 100%;
+}
+
+.speaker-toggle-body {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    width: 100%;
+    max-width: 400px;
+    padding: 10px 14px;
+    background: rgba(22, 33, 62, 0.6);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+}
+
+.speaker-toggle-labels {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+}
+
+.speaker-toggle-title {
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--text-primary);
+    letter-spacing: 0.2px;
+}
+
+.speaker-toggle-subtitle {
+    font-size: 11px;
+    color: var(--text-muted);
+    letter-spacing: 0.2px;
+}
+
+.speaker-toggle-switch {
+    position: relative;
+    flex: 0 0 auto;
+    width: 36px;
+    height: 20px;
+    padding: 0;
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    background: rgba(42, 42, 74, 0.8);
+    cursor: pointer;
+    outline: none;
+    transition: background var(--transition-fast),
+                border-color var(--transition-fast),
+                box-shadow var(--transition-fast);
+}
+
+.speaker-toggle-switch.on {
+    background: rgba(74, 74, 255, 0.55);
+    border-color: rgba(74, 74, 255, 0.8);
+    box-shadow: 0 0 0 1px rgba(74, 74, 255, 0.25),
+                0 1px 4px rgba(0, 0, 0, 0.25);
+}
+
+.speaker-toggle-switch:focus-visible {
+    box-shadow: 0 0 0 2px rgba(74, 74, 255, 0.35);
+}
+
+.speaker-toggle-switch:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+}
+
+.speaker-toggle-thumb {
+    position: absolute;
+    top: 50%;
+    left: 2px;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background: var(--text-primary);
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.35);
+    transform: translateY(-50%);
+    transition: left var(--transition-fast),
+                background var(--transition-fast);
+}
+
+.speaker-toggle-switch.on .speaker-toggle-thumb {
+    left: 18px;
+    background: #ffffff;
+}
+
 /* ---------- Blazor Error UI ---------- */
 #blazor-error-ui {
     background: var(--bg-secondary);

--- a/tests/VoxFlow.Desktop.Tests/DesktopCliTranscriptionServiceTests.cs
+++ b/tests/VoxFlow.Desktop.Tests/DesktopCliTranscriptionServiceTests.cs
@@ -1,0 +1,122 @@
+using System.Text.Json.Nodes;
+using VoxFlow.Core.Models;
+using VoxFlow.Desktop.Services;
+using Xunit;
+
+namespace VoxFlow.Desktop.Tests;
+
+public sealed class DesktopCliTranscriptionServiceTests
+{
+    [Fact]
+    public void BuildTranscriptionMutator_WritesInputPath()
+    {
+        var request = new TranscribeFileRequest(InputPath: "/tmp/audio.m4a");
+        var transcription = new JsonObject();
+
+        DesktopCliTranscriptionService
+            .BuildTranscriptionMutator(request)
+            .Invoke(transcription);
+
+        Assert.Equal("/tmp/audio.m4a", transcription["inputFilePath"]?.GetValue<string>());
+    }
+
+    [Fact]
+    public void BuildTranscriptionMutator_WritesResultFilePath_WhenProvided()
+    {
+        var request = new TranscribeFileRequest(
+            InputPath: "/tmp/audio.m4a",
+            ResultFilePath: "/tmp/result.txt");
+        var transcription = new JsonObject();
+
+        DesktopCliTranscriptionService
+            .BuildTranscriptionMutator(request)
+            .Invoke(transcription);
+
+        Assert.Equal("/tmp/result.txt", transcription["resultFilePath"]?.GetValue<string>());
+    }
+
+    [Fact]
+    public void BuildTranscriptionMutator_EnableSpeakersTrue_SetsSpeakerLabelingEnabledTrue()
+    {
+        var request = new TranscribeFileRequest(
+            InputPath: "/tmp/audio.m4a",
+            EnableSpeakers: true);
+        var transcription = new JsonObject();
+
+        DesktopCliTranscriptionService
+            .BuildTranscriptionMutator(request)
+            .Invoke(transcription);
+
+        var speakerLabeling = transcription["speakerLabeling"]?.AsObject();
+        Assert.NotNull(speakerLabeling);
+        Assert.True(speakerLabeling["enabled"]?.GetValue<bool>());
+    }
+
+    [Fact]
+    public void BuildTranscriptionMutator_EnableSpeakersFalse_SetsSpeakerLabelingEnabledFalse()
+    {
+        var request = new TranscribeFileRequest(
+            InputPath: "/tmp/audio.m4a",
+            EnableSpeakers: false);
+        var transcription = new JsonObject
+        {
+            ["speakerLabeling"] = new JsonObject { ["enabled"] = true }
+        };
+
+        DesktopCliTranscriptionService
+            .BuildTranscriptionMutator(request)
+            .Invoke(transcription);
+
+        Assert.False(transcription["speakerLabeling"]?["enabled"]?.GetValue<bool>());
+    }
+
+    [Fact]
+    public void BuildTranscriptionMutator_EnableSpeakersNull_LeavesExistingSpeakerLabelingUntouched()
+    {
+        var request = new TranscribeFileRequest(
+            InputPath: "/tmp/audio.m4a",
+            EnableSpeakers: null);
+        var transcription = new JsonObject
+        {
+            ["speakerLabeling"] = new JsonObject
+            {
+                ["enabled"] = true,
+                ["timeoutSeconds"] = 900
+            }
+        };
+
+        DesktopCliTranscriptionService
+            .BuildTranscriptionMutator(request)
+            .Invoke(transcription);
+
+        Assert.True(transcription["speakerLabeling"]?["enabled"]?.GetValue<bool>());
+        Assert.Equal(900, transcription["speakerLabeling"]?["timeoutSeconds"]?.GetValue<int>());
+    }
+
+    [Fact]
+    public void BuildTranscriptionMutator_EnableSpeakersTrue_PreservesSiblingSpeakerLabelingKeys()
+    {
+        var request = new TranscribeFileRequest(
+            InputPath: "/tmp/audio.m4a",
+            EnableSpeakers: true);
+        var transcription = new JsonObject
+        {
+            ["speakerLabeling"] = new JsonObject
+            {
+                ["enabled"] = false,
+                ["timeoutSeconds"] = 900,
+                ["modelId"] = "pyannote/speaker-diarization-3.1"
+            }
+        };
+
+        DesktopCliTranscriptionService
+            .BuildTranscriptionMutator(request)
+            .Invoke(transcription);
+
+        var speakerLabeling = transcription["speakerLabeling"]?.AsObject();
+        Assert.NotNull(speakerLabeling);
+        Assert.True(speakerLabeling["enabled"]?.GetValue<bool>());
+        Assert.Equal(900, speakerLabeling["timeoutSeconds"]?.GetValue<int>());
+        Assert.Equal("pyannote/speaker-diarization-3.1", speakerLabeling["modelId"]?.GetValue<string>());
+    }
+}


### PR DESCRIPTION
## Summary

Two Phase 2 follow-up fixes found during manual verification on Intel Mac Catalyst.

### 1. `SpeakerLabelingToggle` visual fix (CSS only)

The P2.1 toggle component rendered markup but the CSS block was never added. Result: title and subtitle `<span>`s collapsed into a single inline line ("Speaker labeling Identify who spoke each segment"), and the `<button role="switch">` had no visible track/thumb — only a default-styled cursor-thin line.

Added CSS matching the existing `format-picker` language: pill-track 36×20px, sliding thumb, `--accent` fill when `on`, disabled/focus states. No markup changes, no new tokens.

### 2. Intel Mac CLI-bridge didn't forward `EnableSpeakers` (real bug)

On Intel Mac Catalyst, Desktop routes transcription through `DesktopCliTranscriptionService` (spawns `VoxFlow.Cli` as a child process), not the in-process `TranscriptionService`. The merged-config snapshot mutator only wrote `inputFilePath` / `resultFilePath` and **silently dropped `request.EnableSpeakers`**. Symptom: the Ready-screen speaker toggle flipped the in-memory ViewModel flag, but CLI ran with `speakerLabeling.enabled = false` from the bundled config, so diarization never ran on Intel.

Extracted the mutator into a testable static `DesktopCliTranscriptionService.BuildTranscriptionMutator(request)` and added the missing forwarding: when `request.EnableSpeakers.HasValue`, set `transcription.speakerLabeling.enabled` in the snapshot, preserving sibling keys (`timeoutSeconds`, `modelId`, etc.).

### Why Phase 2 missed this

- Phase 2 tests mock `ITranscriptionService` — never exercised the CLI-bridge path.
- Apple Silicon uses the in-process path (covered by Core Phase 1 tests).
- Intel-specific CLI-bridge + speaker-labeling combination had zero test coverage.

Six new unit tests on `BuildTranscriptionMutator` lock the behavior:
- `InputPath` / `ResultFilePath` write
- `EnableSpeakers` true / false / null paths
- Preservation of sibling `speakerLabeling` keys under all branches

This is a minimal hotfix; Phase 3 (P3.1) will replace the snapshot injection with a proper CLI `--speakers` flag.

## Base

`speaker-labeling/phase-2-desktop-hotfix` → `Local-Speaker-Labeling` per ADR-024 branching strategy.

## Test plan

- [x] `dotnet test` — Core 334 / McpServer 35 / Cli 18 / Desktop 136 (+6 new), 0 failures
- [x] RED-verified: tests failed with `CS0117 BuildTranscriptionMutator does not exist` before the fix
- [x] Manual (Intel Mac): toggle now renders as pill-switch with sliding thumb
- [ ] Manual (Intel Mac): enabling toggle + running transcription triggers Diarization ring (user to verify in-app)
