### PR TITLE
feat(desktop): Phase-2 redesign — shared TopBar, nested phase rings, Activity panel

### DIFF
--- a/docs/delivery/local-speaker-labeling/phase-2-desktop-ui.md
+++ b/docs/delivery/local-speaker-labeling/phase-2-desktop-ui.md
@@ -2,7 +2,7 @@
 
 **Parent:** [Local Speaker Labeling — Delivery Plan](README.md)
 **ADR:** [ADR-024](../../adr/024-local-speaker-labeling-pipeline.md)
-**Status:** Planned
+**Status:** Shipped on `speaker-labeling/phase-2-desktop-redesign` (PR #27 → `Local-Speaker-Labeling`). This document has been updated to match the implementation: P2.1 – P2.5 match the sub-PRs that landed; P2.6 (visual-system refresh) and P2.7 (sidecar packaging fix) are retrospective addenda covering work that shipped on the same branch but was not in the original plan.
 
 ---
 
@@ -17,10 +17,10 @@ Phase 2 is a pure presentation phase: no new Core services, no new output format
 - The Ready-screen `SettingsPanel` has a new speaker-labeling toggle whose initial state is bound to `TranscriptionOptions.SpeakerLabeling.Enabled`.
 - Toggling the switch persists back to `appsettings.json` via `DesktopConfigurationService.SaveUserOverridesAsync` under the `transcription.speakerLabeling.enabled` key.
 - `AppViewModel.TranscribeFileAsync` forwards the toggle state to the `TranscribeFileRequest` via `EnableSpeakers` so the user's last toggle is honored even if the underlying config has not been reloaded.
-- `RunningView` renders **three phase rings** (`Transcription`, `Diarization`, `Merge`) stacked vertically. Each ring shows its own local `0..100%` percent, its own sub-status line (`"loading model"`, `"embeddings"`, `"writing output"`, …), and its own phase-local elapsed time that freezes when the phase completes. The three rings use the same color semantics as the CLI (`Transcription` = cyan, `Diarization` = magenta, `Merge` = green) with hex values grounded in the existing `--accent` palette.
+- `RunningView` renders **three concentric phase rings** inside one 320×320 SVG container (outer = Transcription at `r=92`, middle = Diarization at `r=72`, inner = Merge at `r=52`). The center of the stack shows the **focus phase's** local `0..100%` percent plus a small phase label (`TRANSCRIPTION` / `DIARIZATION` / `MERGE`). Sub-status line (`"loading model"`, `"embeddings"`, `"writing output"`, …) and phase-local elapsed time live in a sibling **`.activity-panel`** card directly below the stack so the reader always sees a live heartbeat even when pyannote goes silent for minutes. Color tokens (`--phase-transcription` / `--phase-diarization` / `--phase-merge`) — see the P2.3 color table for the concrete hex values.
 - Phase state transitions (`Idle → Running → Done`) are driven off `ProgressStage` via the same `ProgressPhase` banding used by `CliProgressHandler` (`Transcribing/LoadingModel/Converting/...` → Transcription, `Diarizing` → Diarization, `Writing/Complete` → Merge). When a phase transitions to `Done` its ring renders at 100 %, shows `done`, and its elapsed clock stops.
 - The per-phase elapsed clock keeps ticking between sparse producer events via a 1 s view-model heartbeat (mirroring `CliProgressHandler.EnsureHeartbeatLocked`), so diarization doesn't look frozen during the multi-minute pyannote silence between sub-steps.
-- When speaker labeling is **disabled**, the Diarization ring renders as `Skipped` (muted color, no clock) rather than stuck at 0 %, so the user doesn't think the pipeline is hung.
+- When speaker labeling is **disabled**, the Diarization (middle) ring renders as `Skipped` (muted `--phase-skipped` color, no arc progression) rather than stuck at 0 %, so the user doesn't think the pipeline is hung.
 - `CompleteView` renders the `TranscriptDocument` as colored speaker turns when `TranscriptionResult.SpeakerTranscript` is not null. When it is null (feature off, or sidecar failure), the view falls back to the existing plain-text preview — no regressions.
 - Speaker colors come from the Okabe-Ito 8-color colorblind-safe palette. Speakers beyond the palette size wrap around modulo 8, and the cycle is documented inline so contributors know why.
 - Enrichment warnings (`result.EnrichmentWarnings`) are visible to the user via a non-blocking info banner on the completion screen, matching the existing `message message-warning` styling.
@@ -33,6 +33,7 @@ Phase 2 is a pure presentation phase: no new Core services, no new output format
 - Phase 1 is merged into `Local-Speaker-Labeling` and green on the integration branch.
 - `TranscribeFileResult.SpeakerTranscript` and `EnrichmentWarnings` are populated by `TranscriptionService` when the flag is on.
 - `DesktopConfigurationService` already supports `SaveUserOverridesAsync` with a `Dictionary<string, object>` — see [SettingsPanel.razor](../../../src/VoxFlow.Desktop/Components/Shared/SettingsPanel.razor) for the canonical usage pattern.
+- **Sidecar packaging contract.** The Intel Mac Catalyst CLI-bridge path resolves `voxflow_diarize.py` at `AppContext.BaseDirectory/python/voxflow_diarize.py`, which at runtime is `<app>/Contents/MonoBundle/cli/python/voxflow_diarize.py`. [VoxFlow.Desktop.csproj](../../../src/VoxFlow.Desktop/VoxFlow.Desktop.csproj)'s `CopyBundledCliBridge` target must copy `python/**/*` from the CLI output alongside the DLLs. Regression-covered by [DesktopCliBundleTests](../../../tests/VoxFlow.Desktop.Tests/DesktopCliBundleTests.cs).
 
 ## Non-goals
 
@@ -46,7 +47,7 @@ Phase 2 is a pure presentation phase: no new Core services, no new output format
 
 ## TDD Sequence
 
-Five sub-PRs, in strict order.
+Five sub-PRs planned in strict order, plus one retrospective addendum (P2.6) documenting the design-system refresh that shipped alongside P2.3 in the same integration branch.
 
 Conventions for every PR below:
 - **Branch:** `speaker-labeling/p2.M-<slug>` off `Local-Speaker-Labeling`.
@@ -208,13 +209,13 @@ The change is presentation-only — it subscribes to the exact same `ProgressUpd
 **Files touched (new):**
 - `src/VoxFlow.Core/Models/ProgressPhase.cs` — shared enum `{ Transcription, Diarization, Merge }` used by both the CLI and Desktop. Lives under Core because both hosts depend on Core.
 - `src/VoxFlow.Core/Models/ProgressPhaseBanding.cs` — shared static helper exposing `PhaseOf(ProgressStage)`, `LocalPercent(ProgressStage, double)`, and `PhaseUpperBound(ProgressStage)`. The existing private methods on `CliProgressHandler` are deleted and the CLI consumes this helper instead.
-- `src/VoxFlow.Desktop/ViewModels/PhaseProgressTracker.cs` — an `INotifyPropertyChanged` view-model layer sitting between `AppViewModel.CurrentProgress` and `RunningView`. Exposes an immutable `IReadOnlyList<PhaseState> Phases` where `PhaseState` is a record `(ProgressPhase Phase, PhaseStatus Status, double LocalPercent, string? SubStatus, TimeSpan Elapsed)`. Status is `{ Idle, Running, Done, Skipped, Failed }`. Runs a `System.Threading.Timer` heartbeat identical in shape to `CliProgressHandler`'s so `Elapsed` keeps advancing between producer events; timer is disposed the moment the terminal `Complete`/`Failed` frame arrives.
-- `src/VoxFlow.Desktop/Components/Pages/PhaseRing.razor` — one visual ring. Takes a `PhaseState` plus a phase color; renders the SVG ring + center percent + done checkmark + status/elapsed footer.
-- `src/VoxFlow.Desktop/Components/Pages/PhaseRingStack.razor` — stacks three `PhaseRing` components and passes each one its banded color. This is what `RunningView` actually embeds.
-- `src/VoxFlow.Desktop/wwwroot/css/phase-ring.css` — phase tokens (`--phase-transcription`, `--phase-diarization`, `--phase-merge`), ring track/arc styles, idle/running/done/skipped modifiers. Referenced from the existing `index.html` (or `app.css` if Desktop concatenates).
+- `src/VoxFlow.Desktop/ViewModels/PhaseProgressTracker.cs` — an `INotifyPropertyChanged` view-model layer sitting between `AppViewModel.CurrentProgress` and `RunningView`. Exposes an immutable `IReadOnlyList<PhaseState> Phases` where `PhaseState` is a record `(ProgressPhase Phase, PhaseStatus Status, double LocalPercent, string? SubStatus, TimeSpan Elapsed)`. Status is `{ Idle, Running, Done, Skipped, Failed }`. Runs a heartbeat (via `TimeProvider`) identical in shape to `CliProgressHandler`'s so `Elapsed` keeps advancing between producer events; timer is disposed the moment the terminal `Complete`/`Failed` frame arrives.
+- `src/VoxFlow.Desktop/Components/Pages/PhaseRingStack.razor` — **the only ring component `RunningView` actually embeds.** Renders all three phase arcs concentrically inside one SVG (radii `92 / 72 / 52`, viewBox `0 0 200 200`, stroke 6). The center shows the focus-phase percent + phase label; it does **not** render per-ring sub-status or elapsed (those live in the sibling `.activity-panel`).
+- `src/VoxFlow.Desktop/Components/Pages/PhaseRing.razor` — **auxiliary single-ring component** authored during early iterations (radius 50, its own arc math) but ultimately not rendered on RunningView after the concentric redesign. Kept in-tree with its own tests because it exercises the same `PhaseState` / `PhaseStatus` contract and guards against view-model regressions; may be reused by future single-ring affordances (e.g. a mini-tracker in the menu bar).
+- `src/VoxFlow.Desktop/wwwroot/css/app.css` — phase tokens (`--phase-transcription`, `--phase-diarization`, `--phase-merge`, `--phase-track`, `--phase-skipped`, `--phase-failed`), concentric `.phase-ring-stack` container, `.phase-track` / `.phase-arc` strokes, `.phase-center` sphere (96×96 radial-gradient via `::before`), and `.activity-panel` card. Rules are concatenated into the existing app-wide stylesheet; no separate `phase-ring.css` file was added.
 - `tests/VoxFlow.Desktop.Tests/Components/PhaseProgressTrackerTests.cs`
-- `tests/VoxFlow.Desktop.Tests/Components/PhaseRingTests.cs`
-- `tests/VoxFlow.Desktop.Tests/Components/PhaseRingStackTests.cs`
+- `tests/VoxFlow.Desktop.Tests/Components/PhaseRingTests.cs` — covers the auxiliary single-ring component.
+- `tests/VoxFlow.Desktop.Tests/Components/PhaseRingStackTests.cs` — covers the concentric contract (three arcs in phase order, `r=92/72/52`, per-phase color tokens, dash-offset from `LocalPercent`, `--phase-skipped` for skipped Diarization, center `.phase-center-percent` / `.phase-center-label`).
 - `tests/VoxFlow.Core.Tests/Models/ProgressPhaseBandingTests.cs`
 
 **Files touched (modified):**
@@ -222,15 +223,18 @@ The change is presentation-only — it subscribes to the exact same `ProgressUpd
 - `src/VoxFlow.Desktop/Components/Pages/RunningView.razor` — replace the single organic-progress SVG block with a `<PhaseRingStack Tracker="@ViewModel.PhaseTracker" />` component. Keep the `cancel` button and the top-level progress-info caption (`"Starting transcription..."`, file name) unchanged.
 - `src/VoxFlow.Desktop/ViewModels/AppViewModel.cs` — construct the `PhaseProgressTracker` on init, feed `ProgressUpdate` events into it from the existing progress pipeline, and expose it as `public PhaseProgressTracker PhaseTracker { get; }`. `CurrentProgress` stays for the caption but the ring state comes from the tracker.
 
-**Color palette (new tokens in `phase-ring.css`):**
+**Color palette (shipped in `app.css`; design traded CLI ANSI parity for the concentric mockup's outer-to-inner purple → cyan → green gradient):**
 
-| Phase | Token | Hex | Rationale |
+| Ring | Token | Hex | Rationale |
 |---|---|---|---|
-| Transcription | `--phase-transcription` | `#4aa8ff` | Cyan family, matches CLI ANSI 96 and the existing `--accent` blue lineage. |
-| Diarization | `--phase-diarization` | `#b06cff` | Magenta family, matches CLI ANSI 95. Distinct from transcription cyan and merge green under CVD. |
-| Merge | `--phase-merge` | `#28c840` | Green, matches CLI ANSI 92 and the existing `--success` token. |
-| Idle track | `--phase-track` | `rgba(42,42,74,0.4)` | Existing `organic-track` color; keeps the dark-theme continuity. |
-| Skipped ring | `--phase-skipped` | `#4a4a6a` | Existing `--drop-zone-border`; communicates "off by design" without looking like a stall. |
+| Transcription (outer, `r=92`) | `--phase-transcription` | `#a78bfa` | Purple; outermost ring leads the eye inward in the concentric layout. Replaces the original cyan from the early stacked-strip mockup. |
+| Diarization (middle, `r=72`) | `--phase-diarization` | `#4db8ff` | Cyan/blue; middle ring, distinct from both the outer purple and inner green under CVD. Replaces the original magenta. |
+| Merge (inner, `r=52`) | `--phase-merge` | `var(--success)` (`#28c840`) | Green; reuses the existing `--success` token. |
+| Idle track | `--phase-track` | `rgba(255,255,255,0.06)` | Near-invisible white wash; lets the concentric ring set feel embedded in the dark surface rather than sitting on a visible groove. |
+| Skipped ring | `--phase-skipped` | `var(--drop-zone-border)` (`#4a4a6a`) | Communicates "off by design" without looking like a stall. |
+| Failed arc | `--phase-failed` | `var(--error)` (`#ff5f57`) | Matches the app-wide error token used by `FailedView` and existing error banners. |
+
+*Note on CLI divergence:* the CLI still uses cyan/magenta/green (ANSI 96/95/92). Desktop's concentric stack deliberately remaps the outer/middle hues to purple/cyan so the rings read as a single cohesive gradient rather than three competing accents. `ProgressPhaseBanding` remains shared, so the phase *mapping* (stage → phase) is bit-for-bit identical across hosts — only the color presentation diverges.
 
 **`PhaseProgressTracker` contract:**
 
@@ -245,12 +249,25 @@ The change is presentation-only — it subscribes to the exact same `ProgressUpd
 - Skipped phases: when `speakerLabeling` is off, the producer never emits `Diarizing`. The tracker **does not** pre-mark Diarization as `Skipped` — it only knows what the producer says. To surface `Skipped`, `AppViewModel` passes `speakerLabelingEnabled` into the tracker constructor; when `false`, the Diarization entry is born `Skipped` and the tracker never transitions it.
 - Heartbeat: `System.Threading.Timer` ticks every 1 s, projects the `Running` phase's `Elapsed = DateTime.UtcNow - StartedAtUtc`, and raises `PropertyChanged` on `Phases`. Matches `CliProgressHandler.OnHeartbeat` beat-for-beat.
 
-**`PhaseRing.razor` rendering contract:**
+**`PhaseRingStack.razor` rendering contract (the concentric stack `RunningView` actually uses):**
 
-- SVG 120×120 viewport, 7 px stroke track, 7 px stroke arc, center text 18 px + unit 11 px for idle/running, checkmark + "done" label for done/skipped.
-- Arc stroke color = the phase token. Arc rendering = `stroke-dasharray` / `stroke-dashoffset` identical to the existing organic-progress math, just at radius 50 instead of 80.
-- Under the ring: one line for `SubStatus`, one line for `mm:ss` elapsed.
-- States: `idle` = track only, no arc, no elapsed text; `running` = animated arc, live clock, sub-status; `done` = full arc in phase color, static clock at final value, `"done"` sub-status, muted checkmark overlay; `skipped` = track only in `--phase-skipped`, sub-status `"skipped"`, no clock; `failed` = full arc in `--error`, sub-status `"failed"`, static clock.
+- One SVG, `viewBox="0 0 200 200"`, rendered inside a 320×320 CSS container with an ambient blue/cyan radial-gradient glow layered via `.phase-ring-stack::before` and a `drop-shadow` filter on the SVG itself (matches the desktop redesign mockup).
+- **Three tracks** (full circles) at `r=92/72/52`, each with `stroke: var(--phase-track)` and `stroke-width: 6`.
+- **Three arcs** at the same radii, one per phase, each with `stroke: var(--phase-{slug})` and rounded caps. Arc length is driven by `stroke-dasharray = 2πr` + `stroke-dashoffset = 2πr · (1 - localPct/100)`, so `LocalPercent` from `PhaseProgressTracker` drives each arc independently. A subtle `phase-arc-breathe` animation on `.phase-arc-running` keeps the live arc visually alive during pyannote's silent stretches.
+- **Center** is a 96×96 dark radial-gradient sphere (`.phase-center::before`) holding the focus-phase's percent (38 px, `.phase-center-percent`) + unit (`%`) on one baseline-aligned row, with the focus phase label (`TRANSCRIPTION` / `DIARIZATION` / `MERGE`) stacked underneath in `.phase-center-label` (uppercase tracking). Focus-phase selection: `Failed → Running → last Done → first Idle`.
+- **Per-phase states** (apply to each arc independently):
+  - `idle` — arc not emitted; only the track is visible.
+  - `running` — arc drawn at `circumference · (1 - localPct/100)`, breathing animation on.
+  - `done` — arc drawn at 100 %, no animation.
+  - `skipped` — arc uses `--phase-skipped`; no animation, no clock. The center never focuses a skipped phase.
+  - `failed` — arc uses `--phase-failed` with a `drop-shadow` halo; the center shows `!` + `FAILED` label via `FocusPercent` / `FocusLabel`.
+- **Sub-status and elapsed live outside the stack**, in the sibling `.activity-panel` card below. The card shows a color-pulsed dot (`.activity-pulse-{phase}` class, phase-tinted via `--phase-{slug}`) plus a single human-readable line synthesized from the focus phase's `SubStatus` + `mm:ss` elapsed (`RunningView.BuildActivityMessage`). This is what the user watches while pyannote is grinding.
+
+**`PhaseRing.razor` rendering contract (auxiliary single-ring component; not on RunningView today):**
+
+- SVG with `radius=50`, one track circle + one arc circle, center showing `LocalPercent` + phase-dependent glyph, footer with `SubStatus` + `mm:ss` elapsed.
+- Same `PhaseState` / `PhaseStatus` contract as the stack so either layout stays interchangeable.
+- Tests in `PhaseRingTests.cs` cover: `idle` = track only, no arc, no elapsed; `running` = animated arc at `circumference · (1 - localPct/100)`; `done` = full arc in phase color with frozen clock; `skipped` = track-only in `--phase-skipped`, no clock; `failed` = full arc in `--phase-failed` with static clock.
 
 **TDD steps:**
 
@@ -459,18 +476,73 @@ Test plan:
 
 ---
 
+### P2.6 — Visual-system refresh (retrospective addendum)
+
+**Status:** Shipped alongside P2.3 on `speaker-labeling/phase-2-desktop-redesign` (PR #27). Not a separate branch — documented here so future readers see that the "Desktop redesign" commits were part of Phase 2 scope, not undocumented drift.
+
+**Why this exists:** P2.3's three-ring stack forced a broader conversation about the Running screen's visual language — the old single-organic-circle aesthetic didn't scale cleanly to "three rings + a live heartbeat line". Rather than bolt the new ring stack onto the legacy chrome and accept a visual seam, the chrome around the rings was refreshed in lockstep: top bar, drop zone, settings panel, font stack, and the broader palette all moved to a single coherent dark-UI direction (purple-accented, Inter + JetBrains Mono, bottom-sheet Settings). The three-ring stack and the chrome were designed to read as one piece, so they were implemented as one piece.
+
+**What shipped (by commit on the branch):**
+
+- `986e1d9 — style(desktop): shift color palette + load Inter/JetBrains Mono fonts.` New font stack (Inter for UI, JetBrains Mono for numerics/timestamps) loaded from local `wwwroot/fonts/`. Palette shifted to dark purple-accented surfaces so the concentric ring gradient reads as intentional rather than out-of-place against the old Logic-Pro blue chrome.
+- `a78799c — feat(desktop): add TopBar component and bottom-sheet Settings shell.` New [`TopBar.razor`](../../../src/VoxFlow.Desktop/Components/Shared/TopBar.razor) (shared across Ready / Running / Complete / Failed views) carrying the app title and a settings trigger. Settings moved from an inline Ready-screen card into a bottom-sheet shell so the speaker toggle and format picker don't crowd the drop zone.
+- `f0fb6c6 — style(desktop): restyle drop zone as 180x180 purple pad with two outer rings.` [`DropZone.razor`](../../../src/VoxFlow.Desktop/Components/Shared/DropZone.razor) now renders a 180×180 purple landing pad surrounded by two concentric outer rings, visually rhyming with the three-ring progress stack on `RunningView`.
+- `bcf6548 — style(desktop): resize pill switch and segment the format picker into 5 columns.` The speaker-labeling pill switch and the output-format picker in `SettingsPanel` were reshaped into a consistent segmented-control style so they read as one family of controls in the bottom sheet.
+- `67f2e33 — feat(desktop): replace three horizontal phase rings with nested concentric arcs.` **The actual P2.3 pivot.** The originally-planned three-vertically-stacked rings were replaced with three concentric arcs in one SVG. The `PhaseState` / `PhaseProgressTracker` contract was preserved, so the view-model side of P2.3 needed no rewrite — only `PhaseRingStack.razor` and the CSS tokens changed. `PhaseRing.razor` remains in-tree as an auxiliary component (see P2.3 Files-touched note).
+- `d48fdcc — feat(desktop): add Activity panel with pulsing dot and phase-aware caption.` New `.activity-panel` card directly below the concentric ring stack. Renders a phase-tinted pulsing dot (`--phase-transcription` / `--phase-diarization` / `--phase-merge`) plus a synthesized `"<sub-status> · <mm:ss>"` line keyed off the focus phase. This is the surface that replaces the per-ring sub-status/elapsed footers from the original P2.3 plan — one shared heartbeat line for the focus phase instead of three parallel ones.
+- `75bc2a6 — feat(desktop): wire shared TopBar into CompleteView and FailedView.` `TopBar` now sits above every top-level view for consistent chrome.
+- `eeb2f75 — fix(desktop): anchor TopBar at top and center running-body in column.` Layout fix: `.page-column { flex: 1 0 auto; min-height: 100%; }` + `.running-body { flex: 1 1 auto; justify-content: center; }` so the TopBar stays docked and the ring stack sits visually centered in the remaining vertical space.
+- `2588617 — fix(desktop): match mockup sizing for concentric phase rings.` Container 240×240 → 320×320, SVG viewBox 240 → 200 (so `r=92` fills ~92 % instead of 77 %), stroke 10 → 6, center sphere 80×80 → 96×96 (drawn via `.phase-center::before` radial gradient), percent 30 → 38 px. Activity panel reshaped into a full-width bg-secondary card to match the `.activity` card in the mockup.
+
+**What did NOT follow strict TDD:** the visual-refresh commits were primarily CSS + markup restructuring driven by a live mockup ([`artifacts/design/running-screen.html`](../../../artifacts/design/running-screen.html) and a subsequent iteration owned by the user). Regression coverage comes from the P2.3 component tests (ring radii, phase tokens, dash-offset math, skipped state, percent/label assertions), the `DesktopUiComponentTests` that guard `progressbar` ARIA contracts, and the packaging test added in P2.7-adjacent work (see below). New visual affordances that *were* behavior-bearing (Activity panel's phase-pulse class, focus-phase label, skipped-state rendering) are covered directly in `PhaseRingStackTests` / `DesktopUiComponentTests` rather than through a standalone P2.6 TDD sequence.
+
+**Files touched (summary):**
+
+- `src/VoxFlow.Desktop/Components/Shared/TopBar.razor` (new)
+- `src/VoxFlow.Desktop/Components/Shared/DropZone.razor` (restyled)
+- `src/VoxFlow.Desktop/Components/Shared/SettingsPanel.razor` (moved into bottom-sheet shell, segmented controls)
+- `src/VoxFlow.Desktop/Components/Pages/RunningView.razor` (composes `TopBar` + `.running-body` + `PhaseRingStack` + `.activity-panel`)
+- `src/VoxFlow.Desktop/Components/Pages/CompleteView.razor` and `FailedView.razor` (adopt `TopBar`)
+- `src/VoxFlow.Desktop/Components/Pages/PhaseRingStack.razor` (concentric rewrite)
+- `src/VoxFlow.Desktop/wwwroot/css/app.css` (palette shift, new phase tokens, `.activity-panel`, `.page-column`, `.running-body`, sphere `::before`, drop-zone ring chrome)
+- `src/VoxFlow.Desktop/wwwroot/fonts/` (Inter + JetBrains Mono)
+- `artifacts/design/running-screen.html` (design source of truth — do not ship; referenced from this doc and P2.3)
+
+---
+
+### P2.7 — Mac Catalyst sidecar packaging fix (retrospective)
+
+**Status:** Shipped on `speaker-labeling/phase-2-desktop-redesign` (PR #27, commit [`47bec69`](../../../src/VoxFlow.Desktop/VoxFlow.Desktop.csproj)). Root cause sat dormant through Phase 1 and only surfaced once P2.1's toggle let a user actually request diarization from the Desktop app.
+
+**The bug:** The Intel Mac Catalyst build path spawns a bundled `VoxFlow.Cli.dll` child process. That child resolves `voxflow_diarize.py` via `ServiceCollectionExtensions.ResolveSidecarScriptPath()` as `{AppContext.BaseDirectory}/python/voxflow_diarize.py`, which at runtime is `<app>/Contents/MonoBundle/cli/python/voxflow_diarize.py`. The CLI project's `None Include` / `Link="python\voxflow_diarize.py"` correctly copies the script into `bin/<Configuration>/net9.0/python/` during the CLI build, but `CopyBundledCliBridge` in [`VoxFlow.Desktop.csproj`](../../../src/VoxFlow.Desktop/VoxFlow.Desktop.csproj) was globbing only `*.dll`, `*.deps.json`, `*.runtimeconfig.json`, `ggml-metal.metal`, and `runtimes/macos-*/**/*` — the `python/` subtree was silently dropped. At runtime the sidecar exited with code 2 (Python `[Errno 2] No such file or directory`), surfaced to the user as `speaker-labeling: process-crashed`.
+
+**The fix (TDD):**
+
+1. **Red.** `DesktopCliBundleTests.MonoBundleCli_IncludesPyannoteSidecarScript` + `MonoBundleCli_IncludesPythonRequirementsTxt` — locate the most-recently-built `.app` bundle (rank by `VoxFlow.Cli.dll` mtime so stale Release/arm64 outputs don't mask a fresh Debug/x64 build) and assert both files exist under `Contents/MonoBundle/cli/python/`. Tests initially fail; `SkippableFact` skip path kicks in when no bundle has been built (e.g., CI without the maccatalyst workload).
+2. **Green.** Add a `BundledCliSidecarFiles` ItemGroup (`python/**/*` off the CLI bin dir) and a second `Copy` step in `CopyBundledCliBridge` that preserves the `python/` subdirectory under `MonoBundle/cli/`. `Xunit.SkippableFact 1.4.13` added to `VoxFlow.Desktop.Tests.csproj` (already used in `VoxFlow.Core.Tests`).
+3. **Verify.** Debug rebuild produces `MonoBundle/cli/python/voxflow_diarize.py` and `python-requirements.txt`; Desktop suite 145/2 skipped green; full CLI + MCP suites green.
+
+**Files touched:**
+
+- `src/VoxFlow.Desktop/VoxFlow.Desktop.csproj` — new `BundledCliSidecarFiles` ItemGroup + second `Copy` step in `CopyBundledCliBridge`.
+- `tests/VoxFlow.Desktop.Tests/DesktopCliBundleTests.cs` (new) — bundle-contents regression tests.
+- `tests/VoxFlow.Desktop.Tests/VoxFlow.Desktop.Tests.csproj` — add `Xunit.SkippableFact` reference.
+
+---
+
 ## Post-Phase-2 Checklist
 
 Before declaring Phase 2 complete and moving to Phase 3 planning:
 
-- [ ] All 5 sub-PRs merged into `Local-Speaker-Labeling`.
+- [ ] All planned sub-PRs (P2.1 – P2.5) plus the retrospective addenda (P2.6 visual refresh, P2.7 sidecar packaging fix) are merged into `Local-Speaker-Labeling`.
 - [ ] `dotnet test VoxFlow.sln` on `Local-Speaker-Labeling` is fully green.
 - [ ] Manual smoke on a real Mac Catalyst build: toggle on, transcribe the Obama clip, confirm the colored transcript renders on CompleteView with `Speaker A:` turns in the first palette color.
-- [ ] Manual smoke: toggle on, transcribe a multi-speaker file, confirm the three rings advance in order with phase-local clocks and speakers beyond index 0 have distinct palette colors.
-- [ ] Manual smoke: toggle off, transcribe any file, confirm the Diarization ring renders as Skipped, and CompleteView renders the plain-text preview exactly as before (no colored view, no warning banner).
-- [ ] Manual smoke: leave Desktop running through pyannote's embeddings step on a 5+ minute file; confirm the Diarization clock keeps ticking every second (no freeze) via the heartbeat.
+- [ ] Manual smoke: toggle on, transcribe a multi-speaker file, confirm the concentric ring stack advances outer → middle → inner (Transcription → Diarization → Merge), the focus-phase percent in the center tracks the active ring, the sibling Activity panel pulses in the matching phase color, and CompleteView speakers beyond index 0 have distinct palette colors.
+- [ ] Manual smoke: toggle off, transcribe any file, confirm the Diarization (middle) ring renders as Skipped, and CompleteView renders the plain-text preview exactly as before (no colored view, no warning banner).
+- [ ] Manual smoke: leave Desktop running through pyannote's embeddings step on a 5+ minute file; confirm the Activity panel's `mm:ss` keeps ticking every second (no freeze) via the heartbeat, and the Diarization arc is breathing (not flat-lined).
 - [ ] Manual smoke: force a sidecar failure (point `modelId` at a non-existent model), toggle on, transcribe; confirm the warning banner shows `speaker-labeling: …` and the plain-text preview still renders because `SpeakerTranscript` is null.
 - [ ] Okabe-Ito palette is documented in a one-line comment inside `OkabeItoPalette.cs` linking to the canonical source.
 - [ ] `ProgressPhaseBanding` is consumed by both `CliProgressHandler` and `PhaseProgressTracker`; no duplicate banding logic survives on either side.
-- [ ] No files under `src/VoxFlow.Cli` or `src/VoxFlow.McpServer` were touched in this phase (the banding helper lives in Core — the CLI only changes to _consume_ it).
+- [ ] No files under `src/VoxFlow.Cli` or `src/VoxFlow.McpServer` were touched in this phase **for behavior changes**. The sidecar bundling fix (P2.7) edits `src/VoxFlow.Desktop/VoxFlow.Desktop.csproj` only — CLI / MCP stay untouched.
+- [ ] Built `.app` bundle contains `Contents/MonoBundle/cli/python/voxflow_diarize.py` and `Contents/MonoBundle/cli/python/python-requirements.txt` (verified by `DesktopCliBundleTests` and by running speaker labeling end-to-end against a real audio file).
 - [ ] User has reviewed the integration branch state and approved starting Phase 3.

--- a/src/VoxFlow.Desktop/Components/Pages/CompleteView.razor
+++ b/src/VoxFlow.Desktop/Components/Pages/CompleteView.razor
@@ -3,7 +3,10 @@
 @inject IResultActionService ResultActionService
 @implements IDisposable
 
-<div class="complete-screen" id="complete-screen" aria-label="Complete Screen">
+<div class="complete-screen page-column" id="complete-screen" aria-label="Complete Screen">
+
+    <TopBar />
+
     <!-- Success header -->
     <div class="complete-header">
         <div class="complete-success-icon" aria-hidden="true">

--- a/src/VoxFlow.Desktop/Components/Pages/FailedView.razor
+++ b/src/VoxFlow.Desktop/Components/Pages/FailedView.razor
@@ -1,7 +1,13 @@
+@using VoxFlow.Desktop.Components.Shared
 @inject AppViewModel ViewModel
 
-<div class="text-center" id="failed-screen" aria-label="Failed Screen">
-    <h2>Transcription Failed</h2>
+<div class="page-column" id="failed-screen" aria-label="Failed Screen">
+
+    <TopBar />
+
+    <div class="text-center">
+        <h2>Transcription Failed</h2>
+    </div>
 </div>
 
 @if (!string.IsNullOrEmpty(ViewModel.ErrorMessage))

--- a/src/VoxFlow.Desktop/Components/Pages/PhaseRingStack.razor
+++ b/src/VoxFlow.Desktop/Components/Pages/PhaseRingStack.razor
@@ -31,11 +31,11 @@
      aria-valuemin="0"
      aria-valuemax="100"
      aria-valuenow="@ariaValueNow">
-    <svg class="phase-ring-svg" viewBox="0 0 240 240" aria-hidden="true">
+    <svg class="phase-ring-svg" viewBox="0 0 200 200" aria-hidden="true">
         <!-- Tracks (always full) -->
-        <circle class="phase-track" cx="120" cy="120" r="92" />
-        <circle class="phase-track" cx="120" cy="120" r="72" />
-        <circle class="phase-track" cx="120" cy="120" r="52" />
+        <circle class="phase-track" cx="100" cy="100" r="92" />
+        <circle class="phase-track" cx="100" cy="100" r="72" />
+        <circle class="phase-track" cx="100" cy="100" r="52" />
 
         @RenderPhaseArc(transcription, "transcription", 92, Circumference92)
         @RenderPhaseArc(diarization, "diarization", 72, Circumference72)
@@ -44,8 +44,9 @@
 
     <div class="phase-center" aria-hidden="true">
         <div class="phase-center-pad">
-            <span class="phase-center-percent">@percentText</span>
-            <span class="phase-center-unit">%</span>
+            <div class="phase-center-pct-row">
+                <span class="phase-center-percent">@percentText</span><span class="phase-center-unit">%</span>
+            </div>
             <span class="phase-center-label">@labelText</span>
         </div>
     </div>
@@ -94,8 +95,8 @@
             builder.OpenElement(0, "circle");
             builder.AddAttribute(1, "class", cssClass);
             builder.AddAttribute(2, "data-phase", slug);
-            builder.AddAttribute(3, "cx", "120");
-            builder.AddAttribute(4, "cy", "120");
+            builder.AddAttribute(3, "cx", "100");
+            builder.AddAttribute(4, "cy", "100");
             builder.AddAttribute(5, "r", radius.ToString(CultureInfo.InvariantCulture));
             builder.AddAttribute(6, "stroke-dasharray", circumferenceStr);
             builder.AddAttribute(7, "stroke-dashoffset", offsetStr);

--- a/src/VoxFlow.Desktop/Components/Pages/PhaseRingStack.razor
+++ b/src/VoxFlow.Desktop/Components/Pages/PhaseRingStack.razor
@@ -11,50 +11,42 @@
     var merge = phases[(int)ProgressPhase.Merge];
 
     var focus = FocusPhase(phases);
-    var percentText = FocusPercent(focus);
-    var labelText = FocusLabel(focus);
     var ariaLabel = $"{FocusLabelTitleCase(focus)} progress";
     var ariaValueNow = ((int)Math.Round(focus.LocalPercent)).ToString(CultureInfo.InvariantCulture);
-    var stageCssClass = focus.Status switch
-    {
-        PhaseStatus.Done => "is-done",
-        PhaseStatus.Failed => "is-failed",
-        PhaseStatus.Skipped => "is-skipped",
-        PhaseStatus.Running => "is-running",
-        _ => "is-idle"
-    };
 }
 
-<div class="phase-ring-stack @stageCssClass"
+<div class="phase-ring-stack"
      role="progressbar"
      aria-label="@ariaLabel"
      aria-valuemin="0"
      aria-valuemax="100"
      aria-valuenow="@ariaValueNow">
-    <svg class="phase-ring-svg" viewBox="0 0 240 240" aria-hidden="true">
-        <!-- Tracks (always full) -->
-        <circle class="phase-track" cx="120" cy="120" r="92" />
-        <circle class="phase-track" cx="120" cy="120" r="72" />
-        <circle class="phase-track" cx="120" cy="120" r="52" />
 
-        @RenderPhaseArc(transcription, "transcription", 92, Circumference92)
-        @RenderPhaseArc(diarization, "diarization", 72, Circumference72)
-        @RenderPhaseArc(merge, "merge", 52, Circumference52)
-    </svg>
+    <div class="phase-cell"
+         data-phase="transcription"
+         data-status="@StatusSlug(transcription.Status)">
+        <PhaseRing State="@transcription" PhaseToken="--phase-transcription" />
+    </div>
 
-    <div class="phase-center" aria-hidden="true">
-        <div class="phase-center-pad">
-            <span class="phase-center-percent">@percentText</span>
-            <span class="phase-center-unit">%</span>
-            <span class="phase-center-label">@labelText</span>
-        </div>
+    <span class="@DividerClass" aria-hidden="true">›</span>
+
+    <div class="phase-cell"
+         data-phase="diarization"
+         data-status="@StatusSlug(diarization.Status)">
+        <PhaseRing State="@diarization" PhaseToken="--phase-diarization" />
+    </div>
+
+    <span class="@DividerClass" aria-hidden="true">›</span>
+
+    <div class="phase-cell"
+         data-phase="merge"
+         data-status="@StatusSlug(merge.Status)">
+        <PhaseRing State="@merge" PhaseToken="--phase-merge" />
     </div>
 </div>
 
 @code {
-    private const double Circumference92 = 2 * Math.PI * 92;
-    private const double Circumference72 = 2 * Math.PI * 72;
-    private const double Circumference52 = 2 * Math.PI * 52;
+    private const string DividerClass = "phase-divider";
 
     [Parameter, EditorRequired] public PhaseProgressTracker Tracker { get; set; } = default!;
 
@@ -68,40 +60,14 @@
         _ = InvokeAsync(StateHasChanged);
     }
 
-    private RenderFragment RenderPhaseArc(PhaseState state, string slug, int radius, double circumference)
-        => builder =>
-        {
-            var token = state.Status == PhaseStatus.Skipped
-                ? "--phase-skipped"
-                : state.Status == PhaseStatus.Failed
-                    ? "--phase-failed"
-                    : $"--phase-{slug}";
-
-            var fillPct = state.Status switch
-            {
-                PhaseStatus.Done => 100.0,
-                PhaseStatus.Skipped => 100.0,
-                PhaseStatus.Failed => state.LocalPercent <= 0 ? 100.0 : state.LocalPercent,
-                _ => Math.Clamp(state.LocalPercent, 0.0, 100.0)
-            };
-            var offset = circumference * (1.0 - fillPct / 100.0);
-            var offsetStr = offset.ToString("0.###", CultureInfo.InvariantCulture);
-            var circumferenceStr = circumference.ToString("0.###", CultureInfo.InvariantCulture);
-
-            var cssClass = $"phase-arc phase-arc-{slug} phase-arc-{state.Status.ToString().ToLowerInvariant()}";
-            var style = $"stroke: var({token});";
-
-            builder.OpenElement(0, "circle");
-            builder.AddAttribute(1, "class", cssClass);
-            builder.AddAttribute(2, "data-phase", slug);
-            builder.AddAttribute(3, "cx", "120");
-            builder.AddAttribute(4, "cy", "120");
-            builder.AddAttribute(5, "r", radius.ToString(CultureInfo.InvariantCulture));
-            builder.AddAttribute(6, "stroke-dasharray", circumferenceStr);
-            builder.AddAttribute(7, "stroke-dashoffset", offsetStr);
-            builder.AddAttribute(8, "style", style);
-            builder.CloseElement();
-        };
+    private static string StatusSlug(PhaseStatus status) => status switch
+    {
+        PhaseStatus.Running => "running",
+        PhaseStatus.Done => "done",
+        PhaseStatus.Skipped => "skipped",
+        PhaseStatus.Failed => "failed",
+        _ => "idle"
+    };
 
     private static PhaseState FocusPhase(IReadOnlyList<PhaseState> phases)
     {
@@ -119,22 +85,6 @@
         }
         return phases[0];
     }
-
-    private static string FocusPercent(PhaseState focus) => focus.Status switch
-    {
-        PhaseStatus.Done => "100",
-        PhaseStatus.Skipped => "—",
-        PhaseStatus.Failed => "!",
-        _ => ((int)Math.Round(focus.LocalPercent)).ToString(CultureInfo.InvariantCulture)
-    };
-
-    private static string FocusLabel(PhaseState focus) => focus.Phase switch
-    {
-        ProgressPhase.Transcription => "TRANSCRIPTION",
-        ProgressPhase.Diarization => "DIARIZATION",
-        ProgressPhase.Merge => "MERGE",
-        _ => string.Empty
-    };
 
     private static string FocusLabelTitleCase(PhaseState focus) => focus.Phase switch
     {

--- a/src/VoxFlow.Desktop/Components/Pages/PhaseRingStack.razor
+++ b/src/VoxFlow.Desktop/Components/Pages/PhaseRingStack.razor
@@ -1,27 +1,60 @@
 @using System.ComponentModel
+@using System.Globalization
+@using VoxFlow.Core.Models
 @using VoxFlow.Desktop.ViewModels
 @implements IDisposable
 
 @{
     var phases = Tracker.Phases;
+    var transcription = phases[(int)ProgressPhase.Transcription];
+    var diarization = phases[(int)ProgressPhase.Diarization];
+    var merge = phases[(int)ProgressPhase.Merge];
+
+    var focus = FocusPhase(phases);
+    var percentText = FocusPercent(focus);
+    var labelText = FocusLabel(focus);
+    var ariaLabel = $"{FocusLabelTitleCase(focus)} progress";
+    var ariaValueNow = ((int)Math.Round(focus.LocalPercent)).ToString(CultureInfo.InvariantCulture);
+    var stageCssClass = focus.Status switch
+    {
+        PhaseStatus.Done => "is-done",
+        PhaseStatus.Failed => "is-failed",
+        PhaseStatus.Skipped => "is-skipped",
+        PhaseStatus.Running => "is-running",
+        _ => "is-idle"
+    };
 }
 
-<div class="phase-ring-stack">
-    <div class="phase-ring-item">
-        <PhaseRing State="@phases[0]" PhaseToken="--phase-transcription" />
-    </div>
-    <div class="phase-ring-chevron" aria-hidden="true">@ChevronGlyph</div>
-    <div class="phase-ring-item">
-        <PhaseRing State="@phases[1]" PhaseToken="--phase-diarization" />
-    </div>
-    <div class="phase-ring-chevron" aria-hidden="true">@ChevronGlyph</div>
-    <div class="phase-ring-item">
-        <PhaseRing State="@phases[2]" PhaseToken="--phase-merge" />
+<div class="phase-ring-stack @stageCssClass"
+     role="progressbar"
+     aria-label="@ariaLabel"
+     aria-valuemin="0"
+     aria-valuemax="100"
+     aria-valuenow="@ariaValueNow">
+    <svg class="phase-ring-svg" viewBox="0 0 240 240" aria-hidden="true">
+        <!-- Tracks (always full) -->
+        <circle class="phase-track" cx="120" cy="120" r="92" />
+        <circle class="phase-track" cx="120" cy="120" r="72" />
+        <circle class="phase-track" cx="120" cy="120" r="52" />
+
+        @RenderPhaseArc(transcription, "transcription", 92, Circumference92)
+        @RenderPhaseArc(diarization, "diarization", 72, Circumference72)
+        @RenderPhaseArc(merge, "merge", 52, Circumference52)
+    </svg>
+
+    <div class="phase-center" aria-hidden="true">
+        <div class="phase-center-pad">
+            <span class="phase-center-percent">@percentText</span>
+            <span class="phase-center-unit">%</span>
+            <span class="phase-center-label">@labelText</span>
+        </div>
     </div>
 </div>
 
 @code {
-    private const string ChevronGlyph = "\u203A";
+    private const double Circumference92 = 2 * Math.PI * 92;
+    private const double Circumference72 = 2 * Math.PI * 72;
+    private const double Circumference52 = 2 * Math.PI * 52;
 
     [Parameter, EditorRequired] public PhaseProgressTracker Tracker { get; set; } = default!;
 
@@ -34,6 +67,82 @@
     {
         _ = InvokeAsync(StateHasChanged);
     }
+
+    private RenderFragment RenderPhaseArc(PhaseState state, string slug, int radius, double circumference)
+        => builder =>
+        {
+            var token = state.Status == PhaseStatus.Skipped
+                ? "--phase-skipped"
+                : state.Status == PhaseStatus.Failed
+                    ? "--phase-failed"
+                    : $"--phase-{slug}";
+
+            var fillPct = state.Status switch
+            {
+                PhaseStatus.Done => 100.0,
+                PhaseStatus.Skipped => 100.0,
+                PhaseStatus.Failed => state.LocalPercent <= 0 ? 100.0 : state.LocalPercent,
+                _ => Math.Clamp(state.LocalPercent, 0.0, 100.0)
+            };
+            var offset = circumference * (1.0 - fillPct / 100.0);
+            var offsetStr = offset.ToString("0.###", CultureInfo.InvariantCulture);
+            var circumferenceStr = circumference.ToString("0.###", CultureInfo.InvariantCulture);
+
+            var cssClass = $"phase-arc phase-arc-{slug} phase-arc-{state.Status.ToString().ToLowerInvariant()}";
+            var style = $"stroke: var({token});";
+
+            builder.OpenElement(0, "circle");
+            builder.AddAttribute(1, "class", cssClass);
+            builder.AddAttribute(2, "data-phase", slug);
+            builder.AddAttribute(3, "cx", "120");
+            builder.AddAttribute(4, "cy", "120");
+            builder.AddAttribute(5, "r", radius.ToString(CultureInfo.InvariantCulture));
+            builder.AddAttribute(6, "stroke-dasharray", circumferenceStr);
+            builder.AddAttribute(7, "stroke-dashoffset", offsetStr);
+            builder.AddAttribute(8, "style", style);
+            builder.CloseElement();
+        };
+
+    private static PhaseState FocusPhase(IReadOnlyList<PhaseState> phases)
+    {
+        for (var i = 0; i < phases.Count; i++)
+        {
+            if (phases[i].Status == PhaseStatus.Failed) return phases[i];
+        }
+        for (var i = 0; i < phases.Count; i++)
+        {
+            if (phases[i].Status == PhaseStatus.Running) return phases[i];
+        }
+        for (var i = phases.Count - 1; i >= 0; i--)
+        {
+            if (phases[i].Status == PhaseStatus.Done) return phases[i];
+        }
+        return phases[0];
+    }
+
+    private static string FocusPercent(PhaseState focus) => focus.Status switch
+    {
+        PhaseStatus.Done => "100",
+        PhaseStatus.Skipped => "—",
+        PhaseStatus.Failed => "!",
+        _ => ((int)Math.Round(focus.LocalPercent)).ToString(CultureInfo.InvariantCulture)
+    };
+
+    private static string FocusLabel(PhaseState focus) => focus.Phase switch
+    {
+        ProgressPhase.Transcription => "TRANSCRIPTION",
+        ProgressPhase.Diarization => "DIARIZATION",
+        ProgressPhase.Merge => "MERGE",
+        _ => string.Empty
+    };
+
+    private static string FocusLabelTitleCase(PhaseState focus) => focus.Phase switch
+    {
+        ProgressPhase.Transcription => "Transcription",
+        ProgressPhase.Diarization => "Diarization",
+        ProgressPhase.Merge => "Merge",
+        _ => string.Empty
+    };
 
     public void Dispose()
     {

--- a/src/VoxFlow.Desktop/Components/Pages/PhaseRingStack.razor
+++ b/src/VoxFlow.Desktop/Components/Pages/PhaseRingStack.razor
@@ -11,42 +11,50 @@
     var merge = phases[(int)ProgressPhase.Merge];
 
     var focus = FocusPhase(phases);
+    var percentText = FocusPercent(focus);
+    var labelText = FocusLabel(focus);
     var ariaLabel = $"{FocusLabelTitleCase(focus)} progress";
     var ariaValueNow = ((int)Math.Round(focus.LocalPercent)).ToString(CultureInfo.InvariantCulture);
+    var stageCssClass = focus.Status switch
+    {
+        PhaseStatus.Done => "is-done",
+        PhaseStatus.Failed => "is-failed",
+        PhaseStatus.Skipped => "is-skipped",
+        PhaseStatus.Running => "is-running",
+        _ => "is-idle"
+    };
 }
 
-<div class="phase-ring-stack"
+<div class="phase-ring-stack @stageCssClass"
      role="progressbar"
      aria-label="@ariaLabel"
      aria-valuemin="0"
      aria-valuemax="100"
      aria-valuenow="@ariaValueNow">
+    <svg class="phase-ring-svg" viewBox="0 0 240 240" aria-hidden="true">
+        <!-- Tracks (always full) -->
+        <circle class="phase-track" cx="120" cy="120" r="92" />
+        <circle class="phase-track" cx="120" cy="120" r="72" />
+        <circle class="phase-track" cx="120" cy="120" r="52" />
 
-    <div class="phase-cell"
-         data-phase="transcription"
-         data-status="@StatusSlug(transcription.Status)">
-        <PhaseRing State="@transcription" PhaseToken="--phase-transcription" />
-    </div>
+        @RenderPhaseArc(transcription, "transcription", 92, Circumference92)
+        @RenderPhaseArc(diarization, "diarization", 72, Circumference72)
+        @RenderPhaseArc(merge, "merge", 52, Circumference52)
+    </svg>
 
-    <span class="@DividerClass" aria-hidden="true">›</span>
-
-    <div class="phase-cell"
-         data-phase="diarization"
-         data-status="@StatusSlug(diarization.Status)">
-        <PhaseRing State="@diarization" PhaseToken="--phase-diarization" />
-    </div>
-
-    <span class="@DividerClass" aria-hidden="true">›</span>
-
-    <div class="phase-cell"
-         data-phase="merge"
-         data-status="@StatusSlug(merge.Status)">
-        <PhaseRing State="@merge" PhaseToken="--phase-merge" />
+    <div class="phase-center" aria-hidden="true">
+        <div class="phase-center-pad">
+            <span class="phase-center-percent">@percentText</span>
+            <span class="phase-center-unit">%</span>
+            <span class="phase-center-label">@labelText</span>
+        </div>
     </div>
 </div>
 
 @code {
-    private const string DividerClass = "phase-divider";
+    private const double Circumference92 = 2 * Math.PI * 92;
+    private const double Circumference72 = 2 * Math.PI * 72;
+    private const double Circumference52 = 2 * Math.PI * 52;
 
     [Parameter, EditorRequired] public PhaseProgressTracker Tracker { get; set; } = default!;
 
@@ -60,14 +68,40 @@
         _ = InvokeAsync(StateHasChanged);
     }
 
-    private static string StatusSlug(PhaseStatus status) => status switch
-    {
-        PhaseStatus.Running => "running",
-        PhaseStatus.Done => "done",
-        PhaseStatus.Skipped => "skipped",
-        PhaseStatus.Failed => "failed",
-        _ => "idle"
-    };
+    private RenderFragment RenderPhaseArc(PhaseState state, string slug, int radius, double circumference)
+        => builder =>
+        {
+            var token = state.Status == PhaseStatus.Skipped
+                ? "--phase-skipped"
+                : state.Status == PhaseStatus.Failed
+                    ? "--phase-failed"
+                    : $"--phase-{slug}";
+
+            var fillPct = state.Status switch
+            {
+                PhaseStatus.Done => 100.0,
+                PhaseStatus.Skipped => 100.0,
+                PhaseStatus.Failed => state.LocalPercent <= 0 ? 100.0 : state.LocalPercent,
+                _ => Math.Clamp(state.LocalPercent, 0.0, 100.0)
+            };
+            var offset = circumference * (1.0 - fillPct / 100.0);
+            var offsetStr = offset.ToString("0.###", CultureInfo.InvariantCulture);
+            var circumferenceStr = circumference.ToString("0.###", CultureInfo.InvariantCulture);
+
+            var cssClass = $"phase-arc phase-arc-{slug} phase-arc-{state.Status.ToString().ToLowerInvariant()}";
+            var style = $"stroke: var({token});";
+
+            builder.OpenElement(0, "circle");
+            builder.AddAttribute(1, "class", cssClass);
+            builder.AddAttribute(2, "data-phase", slug);
+            builder.AddAttribute(3, "cx", "120");
+            builder.AddAttribute(4, "cy", "120");
+            builder.AddAttribute(5, "r", radius.ToString(CultureInfo.InvariantCulture));
+            builder.AddAttribute(6, "stroke-dasharray", circumferenceStr);
+            builder.AddAttribute(7, "stroke-dashoffset", offsetStr);
+            builder.AddAttribute(8, "style", style);
+            builder.CloseElement();
+        };
 
     private static PhaseState FocusPhase(IReadOnlyList<PhaseState> phases)
     {
@@ -85,6 +119,22 @@
         }
         return phases[0];
     }
+
+    private static string FocusPercent(PhaseState focus) => focus.Status switch
+    {
+        PhaseStatus.Done => "100",
+        PhaseStatus.Skipped => "—",
+        PhaseStatus.Failed => "!",
+        _ => ((int)Math.Round(focus.LocalPercent)).ToString(CultureInfo.InvariantCulture)
+    };
+
+    private static string FocusLabel(PhaseState focus) => focus.Phase switch
+    {
+        ProgressPhase.Transcription => "TRANSCRIPTION",
+        ProgressPhase.Diarization => "DIARIZATION",
+        ProgressPhase.Merge => "MERGE",
+        _ => string.Empty
+    };
 
     private static string FocusLabelTitleCase(PhaseState focus) => focus.Phase switch
     {

--- a/src/VoxFlow.Desktop/Components/Pages/ReadyView.razor
+++ b/src/VoxFlow.Desktop/Components/Pages/ReadyView.razor
@@ -1,38 +1,77 @@
 @inject AppViewModel ViewModel
 
-<div class="text-center" id="ready-screen" aria-label="Ready Screen">
-    <h1 class="app-main-title" id="ready-screen-title">Audio Transcription</h1>
-</div>
+<div id="ready-screen" class="page-column" aria-label="Ready Screen">
 
-@if (ViewModel.HasBlockingValidationErrors && !string.IsNullOrWhiteSpace(ViewModel.BlockingValidationMessage))
-{
-    <div class="message message-warning mt-4" id="startup-validation-message" aria-label="Startup Validation Message">
-        <span class="message-icon">&#9888;</span>
-        <span>@ViewModel.BlockingValidationMessage</span>
+    <TopBar>
+        <RightSlot>
+            <button type="button"
+                    id="settings-toggle-button"
+                    class="icon-btn"
+                    aria-label="Open settings"
+                    aria-expanded="@_showSettings.ToString().ToLowerInvariant()"
+                    title="Settings"
+                    disabled="@ViewModel.HasBlockingValidationErrors"
+                    @onclick="ToggleSettings">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none"
+                     stroke="currentColor" stroke-width="2"
+                     stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z" />
+                    <circle cx="12" cy="12" r="3" />
+                </svg>
+            </button>
+        </RightSlot>
+    </TopBar>
+
+    <div class="ready-main text-center">
+        <h1 class="app-main-title" id="ready-screen-title">Audio Transcription</h1>
+        <p class="app-main-subtitle">Drop an audio file to get started</p>
     </div>
-}
 
-@if (!ViewModel.HasBlockingValidationErrors && ViewModel.HasWarnings)
-{
-    <div class="message message-info mt-4" id="startup-warning-message" aria-label="Startup Warning Message">
-        <span class="message-icon">&#9888;</span>
-        <span>@ViewModel.WarningMessage</span>
+    @if (ViewModel.HasBlockingValidationErrors && !string.IsNullOrWhiteSpace(ViewModel.BlockingValidationMessage))
+    {
+        <div class="message message-warning mt-4" id="startup-validation-message" aria-label="Startup Validation Message">
+            <span class="message-icon">&#9888;</span>
+            <span>@ViewModel.BlockingValidationMessage</span>
+        </div>
+    }
+
+    @if (!ViewModel.HasBlockingValidationErrors && ViewModel.HasWarnings)
+    {
+        <div class="message message-info mt-4" id="startup-warning-message" aria-label="Startup Warning Message">
+            <span class="message-icon">&#9888;</span>
+            <span>@ViewModel.WarningMessage</span>
+        </div>
+    }
+
+    <div class="ready-dropzone">
+        <DropZone OnFileSelected="HandleFileSelected" IsDisabled="ViewModel.HasBlockingValidationErrors" />
     </div>
-}
 
-<div class="mt-6">
-    <DropZone OnFileSelected="HandleFileSelected" IsDisabled="ViewModel.HasBlockingValidationErrors" />
+    <p class="supported-formats">
+        M4A · WAV · MP3 · AAC · FLAC · OGG · AIFF · MP4
+    </p>
+
+    <SettingsPanel IsDisabled="ViewModel.HasBlockingValidationErrors"
+                   ShowSheet="_showSettings"
+                   OnSheetClose="CloseSettings" />
 </div>
-
-<p class="text-muted mt-4 text-center supported-formats">
-    M4A, WAV, MP3, AAC, FLAC, OGG, AIFF, MP4
-</p>
-
-<SettingsPanel IsDisabled="ViewModel.HasBlockingValidationErrors" />
 
 @code {
+    private bool _showSettings;
+
     private async Task HandleFileSelected(string filePath)
     {
         await ViewModel.TranscribeFileAsync(filePath);
+    }
+
+    private void ToggleSettings()
+    {
+        if (ViewModel.HasBlockingValidationErrors) return;
+        _showSettings = !_showSettings;
+    }
+
+    private void CloseSettings()
+    {
+        _showSettings = false;
     }
 }

--- a/src/VoxFlow.Desktop/Components/Pages/RunningView.razor
+++ b/src/VoxFlow.Desktop/Components/Pages/RunningView.razor
@@ -20,30 +20,32 @@
 
     <TopBar />
 
-    <div class="progress-info">
-        <p class="progress-caption" id="running-caption" aria-live="polite">
-            <span id="running-file-name">@fileName</span>
-            <span class="progress-dot" aria-hidden="true">·</span>
-            <span id="running-stage">@captionState</span>
-        </p>
+    <div class="running-body">
+        <div class="progress-info">
+            <p class="progress-caption" id="running-caption" aria-live="polite">
+                <span id="running-file-name">@fileName</span>
+                <span class="progress-dot" aria-hidden="true">·</span>
+                <span id="running-stage">@captionState</span>
+            </p>
+        </div>
+
+        <PhaseRingStack Tracker="@ViewModel.PhaseTracker" />
+
+        <div class="activity-panel" id="activity-panel" aria-live="polite">
+            <span class="@pulseClass" aria-hidden="true"></span>
+            <span class="activity-message">@activityMessage</span>
+        </div>
     </div>
 
-    <PhaseRingStack Tracker="@ViewModel.PhaseTracker" />
-
-    <div class="activity-panel" id="activity-panel" aria-live="polite">
-        <span class="@pulseClass" aria-hidden="true"></span>
-        <span class="activity-message">@activityMessage</span>
+    <div class="btn-group running-actions" style="@(isComplete ? "opacity:0;pointer-events:none" : "")">
+        <button id="cancel-transcription-button"
+                class="btn btn-secondary"
+                aria-label="Cancel Transcription"
+                title="Cancel Transcription"
+                @onclick="ViewModel.CancelTranscription">
+            Cancel
+        </button>
     </div>
-</div>
-
-<div class="btn-group mt-4" style="@(isComplete ? "opacity:0;pointer-events:none" : "")">
-    <button id="cancel-transcription-button"
-            class="btn btn-secondary"
-            aria-label="Cancel Transcription"
-            title="Cancel Transcription"
-            @onclick="ViewModel.CancelTranscription">
-        Cancel
-    </button>
 </div>
 
 @code {

--- a/src/VoxFlow.Desktop/Components/Pages/RunningView.razor
+++ b/src/VoxFlow.Desktop/Components/Pages/RunningView.razor
@@ -1,42 +1,39 @@
 @using System.ComponentModel
 @using System.Globalization
+@using VoxFlow.Core.Models
+@using VoxFlow.Desktop.ViewModels
 @implements IDisposable
 @inject AppViewModel ViewModel
 
 @{
     var hasProgress = ViewModel.CurrentProgress is not null;
-    var isComplete = hasProgress && ViewModel.CurrentProgress!.Stage == VoxFlow.Core.Models.ProgressStage.Complete;
+    var isComplete = hasProgress && ViewModel.CurrentProgress!.Stage == ProgressStage.Complete;
+    var isFailed = hasProgress && ViewModel.CurrentProgress!.Stage == ProgressStage.Failed;
+    var focus = FocusPhase(ViewModel.PhaseTracker.Phases);
+    var activityMessage = BuildActivityMessage(ViewModel.CurrentProgress, focus, isComplete);
+    var captionState = BuildCaptionState(ViewModel.CurrentProgress, focus, isComplete, isFailed);
+    var fileName = ViewModel.CurrentFileName ?? "audio file";
+    var pulseClass = $"activity-pulse-dot activity-pulse-{focus.Phase.ToString().ToLowerInvariant()}";
 }
 
-<div id="running-screen" aria-label="Running Screen">
+<div id="running-screen" class="page-column" aria-label="Running Screen">
+
+    <TopBar />
+
     <div class="progress-info">
-        @if (isComplete)
-        {
-            <p class="progress-message progress-message-done" id="running-stage">Transcription complete</p>
-        }
-        else if (hasProgress)
-        {
-            <p class="progress-message" id="running-stage" aria-live="polite">
-                @(!string.IsNullOrEmpty(ViewModel.CurrentProgress!.Message)
-                    ? ViewModel.CurrentProgress.Message
-                    : FormatStage(ViewModel.CurrentProgress.Stage))
-            </p>
-            <p class="progress-meta">
-                <span id="running-file-name">@(ViewModel.CurrentFileName ?? "audio file")</span>
-                <span class="progress-dot" aria-hidden="true">&middot;</span>
-                <span>@FormatElapsed(ViewModel.CurrentProgress.Elapsed)</span>
-            </p>
-        }
-        else
-        {
-            <p class="progress-message" id="running-starting-label">Starting transcription...</p>
-            <p class="progress-meta">
-                <span id="running-file-name">@(ViewModel.CurrentFileName ?? "audio file")</span>
-            </p>
-        }
+        <p class="progress-caption" id="running-caption" aria-live="polite">
+            <span id="running-file-name">@fileName</span>
+            <span class="progress-dot" aria-hidden="true">·</span>
+            <span id="running-stage">@captionState</span>
+        </p>
     </div>
 
     <PhaseRingStack Tracker="@ViewModel.PhaseTracker" />
+
+    <div class="activity-panel" id="activity-panel" aria-live="polite">
+        <span class="@pulseClass" aria-hidden="true"></span>
+        <span class="activity-message">@activityMessage</span>
+    </div>
 </div>
 
 <div class="btn-group mt-4" style="@(isComplete ? "opacity:0;pointer-events:none" : "")">
@@ -60,23 +57,51 @@
         _ = InvokeAsync(StateHasChanged);
     }
 
-    private static string FormatElapsed(TimeSpan elapsed)
+    private static PhaseState FocusPhase(IReadOnlyList<PhaseState> phases)
     {
-        if (elapsed.TotalHours >= 1)
-            return elapsed.ToString(@"h\:mm\:ss");
-        return elapsed.ToString(@"m\:ss");
+        for (var i = 0; i < phases.Count; i++)
+            if (phases[i].Status == PhaseStatus.Failed) return phases[i];
+        for (var i = 0; i < phases.Count; i++)
+            if (phases[i].Status == PhaseStatus.Running) return phases[i];
+        for (var i = phases.Count - 1; i >= 0; i--)
+            if (phases[i].Status == PhaseStatus.Done) return phases[i];
+        return phases[0];
     }
 
-    private static string FormatStage(VoxFlow.Core.Models.ProgressStage stage) => stage switch
+    private static string BuildActivityMessage(ProgressUpdate? update, PhaseState focus, bool isComplete)
     {
-        VoxFlow.Core.Models.ProgressStage.Validating => "Validating",
-        VoxFlow.Core.Models.ProgressStage.Converting => "Converting",
-        VoxFlow.Core.Models.ProgressStage.LoadingModel => "Loading model",
-        VoxFlow.Core.Models.ProgressStage.Transcribing => "Transcribing",
-        VoxFlow.Core.Models.ProgressStage.Filtering => "Filtering",
-        VoxFlow.Core.Models.ProgressStage.Writing => "Writing",
-        VoxFlow.Core.Models.ProgressStage.Complete => "Complete",
-        VoxFlow.Core.Models.ProgressStage.Failed => "Failed",
+        if (update is null) return "starting";
+        if (isComplete) return "done";
+        if (!string.IsNullOrWhiteSpace(update.Message)) return update.Message!;
+        if (!string.IsNullOrWhiteSpace(focus.SubStatus)) return focus.SubStatus!;
+        return FormatStage(update.Stage).ToLowerInvariant();
+    }
+
+    private static string BuildCaptionState(ProgressUpdate? update, PhaseState focus, bool isComplete, bool isFailed)
+    {
+        if (update is null) return "Starting transcription...";
+        if (isComplete) return "Transcription complete";
+        if (isFailed) return "Transcription failed";
+        return focus.Phase switch
+        {
+            ProgressPhase.Transcription => "Transcribing...",
+            ProgressPhase.Diarization => "Identifying speakers...",
+            ProgressPhase.Merge => "Writing output...",
+            _ => FormatStage(update.Stage)
+        };
+    }
+
+    private static string FormatStage(ProgressStage stage) => stage switch
+    {
+        ProgressStage.Validating => "Validating",
+        ProgressStage.Converting => "Converting",
+        ProgressStage.LoadingModel => "Loading model",
+        ProgressStage.Transcribing => "Transcribing",
+        ProgressStage.Filtering => "Filtering",
+        ProgressStage.Diarizing => "Diarizing",
+        ProgressStage.Writing => "Writing",
+        ProgressStage.Complete => "Complete",
+        ProgressStage.Failed => "Failed",
         _ => stage.ToString()
     };
 

--- a/src/VoxFlow.Desktop/Components/Shared/SettingsPanel.razor
+++ b/src/VoxFlow.Desktop/Components/Shared/SettingsPanel.razor
@@ -22,11 +22,35 @@
     </div>
 </div>
 
-<SpeakerLabelingToggle IsDisabled="IsDisabled" />
+<div class="settings-sheet-backdrop @(ShowSheet ? "show" : string.Empty)"
+     id="settings-sheet-backdrop"
+     aria-hidden="@((!ShowSheet).ToString().ToLowerInvariant())"
+     @onclick="HandleBackdropClick"></div>
+
+<div class="settings-sheet @(ShowSheet ? "show" : string.Empty)"
+     id="settings-sheet"
+     role="dialog"
+     aria-modal="true"
+     aria-hidden="@((!ShowSheet).ToString().ToLowerInvariant())"
+     aria-label="Settings">
+    <div class="settings-sheet-handle" aria-hidden="true"></div>
+    <SpeakerLabelingToggle IsDisabled="IsDisabled" />
+</div>
 
 @code {
     [Parameter]
     public bool IsDisabled { get; set; }
+
+    [Parameter]
+    public bool ShowSheet { get; set; }
+
+    [Parameter]
+    public EventCallback OnSheetClose { get; set; }
+
+    private Task HandleBackdropClick()
+    {
+        return OnSheetClose.HasDelegate ? OnSheetClose.InvokeAsync() : Task.CompletedTask;
+    }
 
     private static readonly FormatOption[] _options =
     [

--- a/src/VoxFlow.Desktop/Components/Shared/TopBar.razor
+++ b/src/VoxFlow.Desktop/Components/Shared/TopBar.razor
@@ -1,0 +1,18 @@
+@*
+    Shared topbar: gradient-dot wordmark on the left, optional right-slot
+    for a page-scoped action (settings gear on Ready, X close on Running, …).
+*@
+
+<header class="topbar" id="top-bar" aria-label="VoxFlow header">
+    <div class="wordmark" aria-label="VoxFlow">
+        <span class="wordmark-dot" aria-hidden="true"></span>
+        <span class="wordmark-name">VoxFlow</span>
+    </div>
+    <div class="topbar-actions">
+        @RightSlot
+    </div>
+</header>
+
+@code {
+    [Parameter] public RenderFragment? RightSlot { get; set; }
+}

--- a/src/VoxFlow.Desktop/VoxFlow.Desktop.csproj
+++ b/src/VoxFlow.Desktop/VoxFlow.Desktop.csproj
@@ -209,12 +209,19 @@
         Condition="Exists('$(MSBuildProjectDirectory)/../VoxFlow.Cli/bin/$(Configuration)/net9.0/ggml-metal.metal')" />
       <BundledCliFiles Include="$(MSBuildProjectDirectory)/../VoxFlow.Cli/bin/$(Configuration)/net9.0/runtimes/macos-x64/**/*" />
       <BundledCliFiles Include="$(MSBuildProjectDirectory)/../VoxFlow.Cli/bin/$(Configuration)/net9.0/runtimes/macos-arm64/**/*" />
+      <BundledCliSidecarFiles Include="$(MSBuildProjectDirectory)/../VoxFlow.Cli/bin/$(Configuration)/net9.0/python/**/*" />
     </ItemGroup>
 
     <MakeDir Directories="$(MSBuildProjectDirectory)/$(_AppBundlePath)/Contents/MonoBundle/cli" />
     <Copy
       SourceFiles="@(BundledCliFiles)"
       DestinationFiles="@(BundledCliFiles->'$(MSBuildProjectDirectory)/$(_AppBundlePath)/Contents/MonoBundle/cli/%(RecursiveDir)%(Filename)%(Extension)')"
+      SkipUnchangedFiles="true" />
+
+    <MakeDir Directories="$(MSBuildProjectDirectory)/$(_AppBundlePath)/Contents/MonoBundle/cli/python" />
+    <Copy
+      SourceFiles="@(BundledCliSidecarFiles)"
+      DestinationFiles="@(BundledCliSidecarFiles->'$(MSBuildProjectDirectory)/$(_AppBundlePath)/Contents/MonoBundle/cli/python/%(RecursiveDir)%(Filename)%(Extension)')"
       SkipUnchangedFiles="true" />
   </Target>
 

--- a/src/VoxFlow.Desktop/wwwroot/css/app.css
+++ b/src/VoxFlow.Desktop/wwwroot/css/app.css
@@ -397,36 +397,123 @@ html, body {
     pointer-events: none;
 }
 
-/* ---------- Phase Ring Tracker (ADR-024) ---------- */
+/* ---------- Phase Ring Tracker (ADR-024 P2.3 redesign) ----------
+   Nested concentric arcs: outer r=92 (Transcription, purple),
+   middle r=72 (Diarization, cyan), inner r=52 (Merge, green).
+   A 3D center pad displays the currently-focused phase's percent
+   and an uppercase stage label. */
 .phase-ring-stack {
-    display: flex;
-    align-items: flex-start;
-    justify-content: center;
-    gap: 4px;
+    position: relative;
+    width: 240px;
+    height: 240px;
+    margin: 0 auto 32px;
+}
+
+.phase-ring-stack .phase-ring-svg {
+    position: absolute;
+    inset: 0;
     width: 100%;
-    margin: 0 auto 24px;
+    height: 100%;
+    transform: rotate(-90deg);
 }
 
-.phase-ring-item {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    flex: 0 0 auto;
-    min-width: 160px;
+.phase-ring-stack .phase-track {
+    fill: none;
+    stroke: var(--phase-track);
+    stroke-width: 10;
 }
 
-.phase-ring-chevron {
+.phase-arc {
+    fill: none;
+    stroke-width: 10;
+    stroke-linecap: round;
+    transition:
+        stroke-dashoffset 400ms cubic-bezier(0.2, 0.8, 0.2, 1),
+        stroke 250ms ease,
+        filter 250ms ease;
+}
+
+.phase-arc.phase-arc-running {
+    filter: drop-shadow(0 0 6px currentColor)
+            drop-shadow(0 0 2px currentColor);
+    animation: phase-arc-breathe 2.4s ease-in-out infinite;
+}
+
+.phase-arc.phase-arc-failed {
+    filter: drop-shadow(0 0 4px var(--phase-failed));
+}
+
+@keyframes phase-arc-breathe {
+    0%, 100% {
+        filter: drop-shadow(0 0 5px currentColor)
+                drop-shadow(0 0 1px currentColor);
+    }
+    50% {
+        filter: drop-shadow(0 0 14px currentColor)
+                drop-shadow(0 0 3px currentColor);
+    }
+}
+
+.phase-center {
+    position: absolute;
+    inset: 0;
     display: flex;
     align-items: center;
     justify-content: center;
-    align-self: stretch;
-    width: 24px;
-    min-height: 140px;
+    pointer-events: none;
+}
+
+.phase-center-pad {
+    width: 80px;
+    height: 80px;
+    border-radius: 50%;
+    background:
+        radial-gradient(circle at 30% 28%, rgba(255, 255, 255, 0.12), transparent 60%),
+        linear-gradient(135deg, var(--bg-raised) 0%, var(--bg-secondary) 100%);
+    border: 1px solid var(--line-strong);
+    box-shadow:
+        0 10px 24px rgba(0, 0, 0, 0.45),
+        inset 0 1px 2px rgba(255, 255, 255, 0.12),
+        inset 0 -4px 10px rgba(0, 0, 0, 0.25);
+    display: grid;
+    grid-template-rows: auto auto;
+    align-items: center;
+    justify-items: center;
+    text-align: center;
+    padding: 10px 4px 6px;
+}
+
+.phase-center-percent {
+    grid-row: 1;
+    grid-column: 1;
+    font-size: 30px;
+    font-weight: 600;
+    color: var(--text-primary);
+    letter-spacing: -0.02em;
+    line-height: 1;
+    font-variant-numeric: tabular-nums;
+}
+
+.phase-center-unit {
+    grid-row: 1;
+    grid-column: 1;
+    align-self: start;
+    justify-self: end;
+    margin-top: 2px;
+    margin-right: -10px;
+    font-size: 11px;
     color: var(--text-muted);
-    font-size: 22px;
-    font-weight: 300;
-    opacity: 0.55;
-    user-select: none;
+}
+
+.phase-center-label {
+    grid-row: 2;
+    grid-column: 1;
+    margin-top: 4px;
+    font-size: 9px;
+    font-weight: 600;
+    color: var(--text-muted);
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
 }
 
 .phase-ring {
@@ -547,19 +634,6 @@ html, body {
     font-variant-numeric: tabular-nums;
     letter-spacing: 0.03em;
     margin: 0;
-}
-
-@media (max-width: 720px) {
-    .phase-ring-stack {
-        flex-direction: column;
-        align-items: center;
-        gap: 12px;
-    }
-    .phase-ring-chevron {
-        min-height: 0;
-        height: 16px;
-        transform: rotate(90deg);
-    }
 }
 
 /* ---------- Organic Circular Progress ---------- */

--- a/src/VoxFlow.Desktop/wwwroot/css/app.css
+++ b/src/VoxFlow.Desktop/wwwroot/css/app.css
@@ -27,11 +27,11 @@
     --line: rgba(255, 255, 255, 0.06);
     --line-strong: rgba(255, 255, 255, 0.10);
 
-    /* Phase tracker (ADR-024 P2.3 redesign). Nested concentric rings:
-       outer=Transcription (purple), middle=Diarization (cyan/blue),
-       inner=Merge (green). Matches the desktop redesign mockup. */
-    --phase-transcription: #a78bfa;
-    --phase-diarization: #4db8ff;
+    /* Phase tracker (ADR-024 P2.3). Three separate rings in a strip.
+       Colors match the CLI ANSI semantics: Transcription=cyan (96),
+       Diarization=magenta (95), Merge=green (92). */
+    --phase-transcription: #4aa8ff;
+    --phase-diarization: #b06cff;
     --phase-merge: var(--success);
     --phase-track: rgba(255, 255, 255, 0.06);
     --phase-skipped: var(--drop-zone-border);
@@ -422,123 +422,67 @@ html, body {
     pointer-events: none;
 }
 
-/* ---------- Phase Ring Tracker (ADR-024 P2.3 redesign) ----------
-   Nested concentric arcs: outer r=92 (Transcription, purple),
-   middle r=72 (Diarization, cyan), inner r=52 (Merge, green).
-   A 3D center pad displays the currently-focused phase's percent
-   and an uppercase stage label. */
+/* ---------- Phase Ring Tracker (ADR-024 P2.3) ----------
+   Three separate rings (Transcription → Diarization → Merge) arranged
+   in a horizontal strip on wide viewports and stacked vertically on
+   narrow ones. Individual ring geometry lives in .phase-ring below. */
 .phase-ring-stack {
-    position: relative;
-    width: 240px;
-    height: 240px;
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+    gap: 0;
+    flex-wrap: nowrap;
+    width: 100%;
+    max-width: 780px;
     margin: 0 auto;
 }
 
-.phase-ring-stack .phase-ring-svg {
-    position: absolute;
-    inset: 0;
-    width: 100%;
-    height: 100%;
-    transform: rotate(-90deg);
-}
-
-.phase-ring-stack .phase-track {
-    fill: none;
-    stroke: var(--phase-track);
-    stroke-width: 10;
-}
-
-.phase-arc {
-    fill: none;
-    stroke-width: 10;
-    stroke-linecap: round;
-    transition:
-        stroke-dashoffset 400ms cubic-bezier(0.2, 0.8, 0.2, 1),
-        stroke 250ms ease,
-        filter 250ms ease;
-}
-
-.phase-arc.phase-arc-running {
-    filter: drop-shadow(0 0 6px currentColor)
-            drop-shadow(0 0 2px currentColor);
-    animation: phase-arc-breathe 2.4s ease-in-out infinite;
-}
-
-.phase-arc.phase-arc-failed {
-    filter: drop-shadow(0 0 4px var(--phase-failed));
-}
-
-@keyframes phase-arc-breathe {
-    0%, 100% {
-        filter: drop-shadow(0 0 5px currentColor)
-                drop-shadow(0 0 1px currentColor);
-    }
-    50% {
-        filter: drop-shadow(0 0 14px currentColor)
-                drop-shadow(0 0 3px currentColor);
-    }
-}
-
-.phase-center {
-    position: absolute;
-    inset: 0;
+.phase-cell {
     display: flex;
+    flex-direction: column;
     align-items: center;
-    justify-content: center;
-    pointer-events: none;
+    flex: 0 0 auto;
+    min-width: 180px;
+    padding: 8px 4px;
 }
 
-.phase-center-pad {
-    width: 80px;
-    height: 80px;
-    border-radius: 50%;
-    background:
-        radial-gradient(circle at 30% 28%, rgba(255, 255, 255, 0.12), transparent 60%),
-        linear-gradient(135deg, var(--bg-raised) 0%, var(--bg-secondary) 100%);
-    border: 1px solid var(--line-strong);
-    box-shadow:
-        0 10px 24px rgba(0, 0, 0, 0.45),
-        inset 0 1px 2px rgba(255, 255, 255, 0.12),
-        inset 0 -4px 10px rgba(0, 0, 0, 0.25);
-    display: grid;
-    grid-template-rows: auto auto;
-    align-items: center;
-    justify-items: center;
-    text-align: center;
-    padding: 10px 4px 6px;
-}
-
-.phase-center-percent {
-    grid-row: 1;
-    grid-column: 1;
-    font-size: 30px;
-    font-weight: 600;
-    color: var(--text-primary);
-    letter-spacing: -0.02em;
-    line-height: 1;
-    font-variant-numeric: tabular-nums;
-}
-
-.phase-center-unit {
-    grid-row: 1;
-    grid-column: 1;
-    align-self: start;
-    justify-self: end;
-    margin-top: 2px;
-    margin-right: -10px;
-    font-size: 11px;
+.phase-divider {
+    flex: 0 0 auto;
+    align-self: center;
     color: var(--text-muted);
+    font-size: 20px;
+    padding: 0 8px;
+    opacity: 0.7;
+    user-select: none;
+    position: relative;
+    /* Raise the chevron to align with each ring's vertical center
+       (rings are 140px tall but phase-meta extends the cell below). */
+    top: -14px;
 }
 
-.phase-center-label {
-    grid-row: 2;
-    grid-column: 1;
-    margin-top: 4px;
-    font-size: 9px;
-    font-weight: 600;
-    color: var(--text-muted);
-    letter-spacing: 0.14em;
-    text-transform: uppercase;
+/* Narrow viewport: stack rings vertically and rotate chevrons. */
+@media (max-width: 719px) {
+    .phase-ring-stack {
+        flex-direction: column;
+        align-items: center;
+        max-width: 260px;
+    }
+    .phase-divider {
+        top: 0;
+        padding: 4px 0;
+        transform: rotate(90deg);
+    }
+}
+
+/* Done-state: dim the check glyph slightly so running rings pop more. */
+.phase-cell[data-status="done"] .phase-ring-glyph-done {
+    color: var(--phase-merge);
+}
+
+/* Skipped state: muted ring with dashed track look handled inside
+   PhaseRing via its status-specific classes. */
+.phase-cell[data-status="skipped"] .phase-ring {
+    opacity: 0.6;
 }
 
 /* ---------- Activity panel (live stage-threshold message) ---------- */

--- a/src/VoxFlow.Desktop/wwwroot/css/app.css
+++ b/src/VoxFlow.Desktop/wwwroot/css/app.css
@@ -5,34 +5,41 @@
 
 /* ---------- Design Tokens ---------- */
 :root {
-    --bg-primary: #1a1a2e;
-    --bg-secondary: #16213e;
-    --bg-surface: #0f3460;
-    --text-primary: #e0e0f0;
-    --text-secondary: #a0a0b8;
-    --text-muted: #6c6c8a;
-    --accent: #4a4aff;
-    --accent-hover: #5c5cff;
-    --accent-active: #3a3ae0;
-    --success: #28c840;
+    --bg-primary: #0f1220;
+    --bg-secondary: #161a2c;
+    --bg-surface: #1c2138;
+    --bg-raised: #222845;
+    --text-primary: #e7e9f3;
+    --text-secondary: #8a90a8;
+    --text-muted: #5a6080;
+    --accent: #5b5ef0;
+    --accent-hover: #7074ff;
+    --accent-active: #4a4ddb;
+    --accent-alt: #4db8ff;
+    --accent-alt-hover: #6fc6ff;
+    --success: #4ade80;
     --warning: #febc2e;
-    --error: #ff5f57;
-    --border: #2a2a4a;
-    --drop-zone-border: #4a4a6a;
-    --progress-bar: #4a4aff;
-    --progress-track: #2a2a4a;
+    --error: #ef4f5e;
+    --border: #22263c;
+    --drop-zone-border: #2d3353;
+    --progress-bar: #5b5ef0;
+    --progress-track: #22263c;
+    --line: rgba(255, 255, 255, 0.06);
+    --line-strong: rgba(255, 255, 255, 0.10);
 
-    /* Phase tracker (ADR-024 P2.3). Cyan/magenta/green mirror the CLI
-       ANSI 96/95/92 palette so the Desktop and CLI surfaces read as the
-       same product. Skipped reuses --drop-zone-border. */
-    --phase-transcription: #4aa8ff;
-    --phase-diarization: #b06cff;
+    /* Phase tracker (ADR-024 P2.3 redesign). Nested concentric rings:
+       outer=Transcription (purple), middle=Diarization (cyan/blue),
+       inner=Merge (green). Matches the desktop redesign mockup. */
+    --phase-transcription: #a78bfa;
+    --phase-diarization: #4db8ff;
     --phase-merge: var(--success);
-    --phase-track: rgba(42, 42, 74, 0.4);
+    --phase-track: rgba(255, 255, 255, 0.06);
     --phase-skipped: var(--drop-zone-border);
     --phase-failed: var(--error);
 
-    --font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+    --font-display: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+    --font-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    --font-family: var(--font-display);
     --border-radius: 8px;
     --transition-fast: 150ms ease;
     --transition-normal: 250ms ease;
@@ -60,6 +67,7 @@ html, body {
     background-color: var(--bg-primary);
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
+    text-rendering: optimizeLegibility;
     overflow: hidden;
     user-select: none;
 }
@@ -70,10 +78,13 @@ html, body {
     flex-direction: column;
     height: 100vh;
     width: 100vw;
-    background: var(--bg-primary);
     color: var(--text-primary);
     position: relative;
     overflow: hidden;
+    background:
+        radial-gradient(1200px 700px at 50% -10%, rgba(91, 94, 240, 0.12), transparent 60%),
+        radial-gradient(900px 600px at 80% 110%, rgba(77, 184, 255, 0.07), transparent 60%),
+        var(--bg-primary);
 }
 
 /* ---------- App Content ---------- */
@@ -119,7 +130,7 @@ html, body {
     position: absolute;
     inset: -12px;
     border-radius: 50%;
-    border: 1px solid rgba(74, 74, 255, 0.06);
+    border: 1px solid rgba(91, 94, 240, 0.06);
 }
 
 .drop-zone-circle {
@@ -127,7 +138,7 @@ html, body {
     inset: 0;
     border-radius: 50%;
     background: rgba(22, 33, 62, 0.7);
-    border: 1.5px solid rgba(74, 74, 255, 0.15);
+    border: 1.5px solid rgba(91, 94, 240, 0.15);
     display: flex;
     align-items: center;
     justify-content: center;
@@ -142,9 +153,9 @@ html, body {
 }
 
 .drop-zone:hover .drop-zone-circle {
-    border-color: rgba(74, 74, 255, 0.3);
+    border-color: rgba(91, 94, 240, 0.3);
     box-shadow:
-        0 4px 30px rgba(74, 74, 255, 0.12),
+        0 4px 30px rgba(91, 94, 240, 0.12),
         inset 0 1px 3px rgba(255, 255, 255, 0.03);
 }
 
@@ -153,7 +164,7 @@ html, body {
     position: absolute;
     inset: 0;
     border-radius: 50%;
-    border: 1.5px solid rgba(74, 74, 255, 0.12);
+    border: 1.5px solid rgba(91, 94, 240, 0.12);
     animation: ripple-wave 3s ease-out infinite;
 }
 
@@ -191,14 +202,14 @@ html, body {
 }
 
 .drop-zone.drag-over .drop-zone-circle {
-    border-color: rgba(74, 74, 255, 0.5);
-    box-shadow: 0 0 40px rgba(74, 74, 255, 0.2);
+    border-color: rgba(91, 94, 240, 0.5);
+    box-shadow: 0 0 40px rgba(91, 94, 240, 0.2);
     transform: scale(1.08);
 }
 
 .drop-zone.drag-over .ripple {
     animation-duration: 1.5s;
-    border-color: rgba(74, 74, 255, 0.25);
+    border-color: rgba(91, 94, 240, 0.25);
 }
 
 .drop-zone.drag-over .drop-label {
@@ -447,7 +458,7 @@ html, body {
 .organic-progress-spinner {
     width: 48px;
     height: 48px;
-    border: 3px solid rgba(74, 74, 255, 0.2);
+    border: 3px solid rgba(91, 94, 240, 0.2);
     border-top-color: var(--accent);
     border-radius: 50%;
     animation: spin 0.8s linear infinite;
@@ -695,7 +706,7 @@ button {
 .btn-primary:hover:not(:disabled) {
     background: var(--accent-hover);
     border-color: var(--accent-hover);
-    box-shadow: 0 2px 12px rgba(74, 74, 255, 0.3);
+    box-shadow: 0 2px 12px rgba(91, 94, 240, 0.3);
 }
 
 .btn-primary:active:not(:disabled) {
@@ -873,7 +884,7 @@ button {
     width: 64px;
     height: 64px;
     margin: 0 auto 16px;
-    background: rgba(74, 74, 255, 0.1);
+    background: rgba(91, 94, 240, 0.1);
     border-radius: 16px;
     display: flex;
     align-items: center;
@@ -920,7 +931,7 @@ button {
 .file-card-icon {
     width: 32px;
     height: 32px;
-    background: rgba(74, 74, 255, 0.15);
+    background: rgba(91, 94, 240, 0.15);
     border-radius: 8px;
     display: flex;
     align-items: center;
@@ -1030,8 +1041,8 @@ button {
     font-size: 11px;
     font-weight: 500;
     color: var(--accent);
-    background: rgba(74, 74, 255, 0.1);
-    border: 1px solid rgba(74, 74, 255, 0.2);
+    background: rgba(91, 94, 240, 0.1);
+    border: 1px solid rgba(91, 94, 240, 0.2);
     padding: 3px 10px;
     border-radius: 12px;
     letter-spacing: 0.3px;
@@ -1171,8 +1182,8 @@ button {
 
 .format-segment-active {
     color: var(--text-primary);
-    background: rgba(74, 74, 255, 0.12);
-    border-color: rgba(74, 74, 255, 0.25);
+    background: rgba(91, 94, 240, 0.12);
+    border-color: rgba(91, 94, 240, 0.25);
     box-shadow: 0 1px 4px rgba(0, 0, 0, 0.2);
 }
 
@@ -1239,14 +1250,14 @@ button {
 }
 
 .speaker-toggle-switch.on {
-    background: rgba(74, 74, 255, 0.55);
-    border-color: rgba(74, 74, 255, 0.8);
-    box-shadow: 0 0 0 1px rgba(74, 74, 255, 0.25),
+    background: rgba(91, 94, 240, 0.55);
+    border-color: rgba(91, 94, 240, 0.8);
+    box-shadow: 0 0 0 1px rgba(91, 94, 240, 0.25),
                 0 1px 4px rgba(0, 0, 0, 0.25);
 }
 
 .speaker-toggle-switch:focus-visible {
-    box-shadow: 0 0 0 2px rgba(74, 74, 255, 0.35);
+    box-shadow: 0 0 0 2px rgba(91, 94, 240, 0.35);
 }
 
 .speaker-toggle-switch:disabled {

--- a/src/VoxFlow.Desktop/wwwroot/css/app.css
+++ b/src/VoxFlow.Desktop/wwwroot/css/app.css
@@ -241,47 +241,65 @@ html, body {
     transform: scale(1.01);
 }
 
-/* Central circle and ripple container */
+/* Central pad (180x180) with two decorative rings framing it. The ripple
+   waves still anchor to this 180x180 box so the existing
+   @keyframes ripple-wave scale 1→2.5 reaches the outer ring and beyond. */
 .drop-zone-visual {
     position: relative;
-    width: 240px;
-    height: 240px;
-    margin-bottom: 32px;
+    width: 180px;
+    height: 180px;
+    margin: 32px 0 40px;
 }
 
-/* Subtle outer ring */
+/* Outer decorative ring (240x240) */
 .drop-zone-visual::before {
     content: '';
     position: absolute;
-    inset: -12px;
+    inset: -30px;
     border-radius: 50%;
-    border: 1px solid rgba(91, 94, 240, 0.06);
+    border: 1px solid rgba(91, 94, 240, 0.18);
+    pointer-events: none;
+}
+
+/* Outer-most decorative ring (300x300) */
+.drop-zone-visual::after {
+    content: '';
+    position: absolute;
+    inset: -60px;
+    border-radius: 50%;
+    border: 1px solid rgba(91, 94, 240, 0.08);
+    pointer-events: none;
 }
 
 .drop-zone-circle {
     position: absolute;
     inset: 0;
     border-radius: 50%;
-    background: rgba(22, 33, 62, 0.7);
-    border: 1.5px solid rgba(91, 94, 240, 0.15);
+    background:
+        radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.18), transparent 55%),
+        linear-gradient(135deg, var(--accent) 0%, var(--accent-active) 100%);
+    border: 1px solid rgba(255, 255, 255, 0.08);
     display: flex;
     align-items: center;
     justify-content: center;
-    color: var(--accent);
+    color: var(--text-primary);
     z-index: 1;
     box-shadow:
-        0 4px 20px rgba(0, 0, 0, 0.3),
-        inset 0 1px 3px rgba(255, 255, 255, 0.03);
-    transition: border-color var(--transition-normal),
-                box-shadow var(--transition-normal),
+        0 16px 40px rgba(91, 94, 240, 0.35),
+        0 4px 14px rgba(0, 0, 0, 0.45),
+        inset 0 1px 2px rgba(255, 255, 255, 0.25),
+        inset 0 -6px 14px rgba(0, 0, 0, 0.25);
+    transition: box-shadow var(--transition-normal),
                 transform var(--transition-normal);
 }
 
 .drop-zone:hover .drop-zone-circle {
-    border-color: rgba(91, 94, 240, 0.3);
     box-shadow:
-        0 4px 30px rgba(91, 94, 240, 0.12),
-        inset 0 1px 3px rgba(255, 255, 255, 0.03);
+        0 20px 48px rgba(91, 94, 240, 0.45),
+        0 4px 14px rgba(0, 0, 0, 0.45),
+        inset 0 1px 2px rgba(255, 255, 255, 0.3),
+        inset 0 -6px 14px rgba(0, 0, 0, 0.25);
+    transform: scale(1.02);
 }
 
 /* Ripple waves */
@@ -327,9 +345,12 @@ html, body {
 }
 
 .drop-zone.drag-over .drop-zone-circle {
-    border-color: rgba(91, 94, 240, 0.5);
-    box-shadow: 0 0 40px rgba(91, 94, 240, 0.2);
-    transform: scale(1.08);
+    box-shadow:
+        0 24px 56px rgba(91, 94, 240, 0.55),
+        0 4px 14px rgba(0, 0, 0, 0.45),
+        inset 0 1px 2px rgba(255, 255, 255, 0.35),
+        inset 0 -6px 14px rgba(0, 0, 0, 0.2);
+    transform: scale(1.06);
 }
 
 .drop-zone.drag-over .ripple {
@@ -350,7 +371,8 @@ html, body {
 
 .drop-zone-disabled .drop-zone-circle {
     opacity: 0.35;
-    border-color: var(--border);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.35);
+    transform: none;
 }
 
 .drop-zone-disabled .ripple {

--- a/src/VoxFlow.Desktop/wwwroot/css/app.css
+++ b/src/VoxFlow.Desktop/wwwroot/css/app.css
@@ -1295,30 +1295,33 @@ button {
 }
 
 .format-picker-segments {
-    display: flex;
-    background: rgba(22, 33, 62, 0.6);
+    display: grid;
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+    width: 100%;
+    background: var(--bg-secondary);
     border: 1px solid var(--border);
-    border-radius: 8px;
+    border-radius: 10px;
     padding: 3px;
     gap: 2px;
 }
 
 .format-segment {
     position: relative;
-    padding: 6px 16px;
+    padding: 7px 0;
     font-size: 12px;
-    font-weight: 500;
+    font-weight: 600;
     font-family: var(--font-family);
-    letter-spacing: 0.3px;
+    letter-spacing: 0.4px;
+    text-transform: uppercase;
     color: var(--text-muted);
     background: transparent;
-    border: 1px solid transparent;
-    border-radius: 6px;
+    border: 0;
+    border-radius: 7px;
     cursor: pointer;
     outline: none;
+    text-align: center;
     transition: color var(--transition-fast),
                 background var(--transition-fast),
-                border-color var(--transition-fast),
                 box-shadow var(--transition-fast);
 }
 
@@ -1328,10 +1331,9 @@ button {
 }
 
 .format-segment-active {
-    color: var(--text-primary);
-    background: rgba(91, 94, 240, 0.12);
-    border-color: rgba(91, 94, 240, 0.25);
-    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.2);
+    color: #ffffff;
+    background: var(--accent);
+    box-shadow: 0 2px 8px rgba(91, 94, 240, 0.35);
 }
 
 .format-segment:disabled {
@@ -1383,28 +1385,25 @@ button {
 .speaker-toggle-switch {
     position: relative;
     flex: 0 0 auto;
-    width: 36px;
-    height: 20px;
+    width: 40px;
+    height: 24px;
     padding: 0;
-    border: 1px solid var(--border);
+    border: 0;
     border-radius: 999px;
-    background: rgba(42, 42, 74, 0.8);
+    background: rgba(42, 42, 74, 0.9);
     cursor: pointer;
     outline: none;
     transition: background var(--transition-fast),
-                border-color var(--transition-fast),
                 box-shadow var(--transition-fast);
 }
 
 .speaker-toggle-switch.on {
-    background: rgba(91, 94, 240, 0.55);
-    border-color: rgba(91, 94, 240, 0.8);
-    box-shadow: 0 0 0 1px rgba(91, 94, 240, 0.25),
-                0 1px 4px rgba(0, 0, 0, 0.25);
+    background: var(--accent);
+    box-shadow: 0 2px 8px rgba(91, 94, 240, 0.35);
 }
 
 .speaker-toggle-switch:focus-visible {
-    box-shadow: 0 0 0 2px rgba(91, 94, 240, 0.35);
+    box-shadow: 0 0 0 2px rgba(91, 94, 240, 0.45);
 }
 
 .speaker-toggle-switch:disabled {
@@ -1415,20 +1414,19 @@ button {
 .speaker-toggle-thumb {
     position: absolute;
     top: 50%;
-    left: 2px;
-    width: 14px;
-    height: 14px;
+    left: 3px;
+    width: 18px;
+    height: 18px;
     border-radius: 50%;
-    background: var(--text-primary);
-    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.35);
+    background: #ffffff;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.35);
     transform: translateY(-50%);
     transition: left var(--transition-fast),
                 background var(--transition-fast);
 }
 
 .speaker-toggle-switch.on .speaker-toggle-thumb {
-    left: 18px;
-    background: #ffffff;
+    left: 19px;
 }
 
 /* ---------- Blazor Error UI ---------- */

--- a/src/VoxFlow.Desktop/wwwroot/css/app.css
+++ b/src/VoxFlow.Desktop/wwwroot/css/app.css
@@ -27,11 +27,11 @@
     --line: rgba(255, 255, 255, 0.06);
     --line-strong: rgba(255, 255, 255, 0.10);
 
-    /* Phase tracker (ADR-024 P2.3). Three separate rings in a strip.
-       Colors match the CLI ANSI semantics: Transcription=cyan (96),
-       Diarization=magenta (95), Merge=green (92). */
-    --phase-transcription: #4aa8ff;
-    --phase-diarization: #b06cff;
+    /* Phase tracker (ADR-024 P2.3 redesign). Nested concentric rings:
+       outer=Transcription (purple), middle=Diarization (cyan/blue),
+       inner=Merge (green). Matches the desktop redesign mockup. */
+    --phase-transcription: #a78bfa;
+    --phase-diarization: #4db8ff;
     --phase-merge: var(--success);
     --phase-track: rgba(255, 255, 255, 0.06);
     --phase-skipped: var(--drop-zone-border);
@@ -422,67 +422,123 @@ html, body {
     pointer-events: none;
 }
 
-/* ---------- Phase Ring Tracker (ADR-024 P2.3) ----------
-   Three separate rings (Transcription → Diarization → Merge) arranged
-   in a horizontal strip on wide viewports and stacked vertically on
-   narrow ones. Individual ring geometry lives in .phase-ring below. */
+/* ---------- Phase Ring Tracker (ADR-024 P2.3 redesign) ----------
+   Nested concentric arcs: outer r=92 (Transcription, purple),
+   middle r=72 (Diarization, cyan), inner r=52 (Merge, green).
+   A 3D center pad displays the currently-focused phase's percent
+   and an uppercase stage label. */
 .phase-ring-stack {
-    display: flex;
-    align-items: flex-start;
-    justify-content: center;
-    gap: 0;
-    flex-wrap: nowrap;
-    width: 100%;
-    max-width: 780px;
+    position: relative;
+    width: 240px;
+    height: 240px;
     margin: 0 auto;
 }
 
-.phase-cell {
+.phase-ring-stack .phase-ring-svg {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    transform: rotate(-90deg);
+}
+
+.phase-ring-stack .phase-track {
+    fill: none;
+    stroke: var(--phase-track);
+    stroke-width: 10;
+}
+
+.phase-arc {
+    fill: none;
+    stroke-width: 10;
+    stroke-linecap: round;
+    transition:
+        stroke-dashoffset 400ms cubic-bezier(0.2, 0.8, 0.2, 1),
+        stroke 250ms ease,
+        filter 250ms ease;
+}
+
+.phase-arc.phase-arc-running {
+    filter: drop-shadow(0 0 6px currentColor)
+            drop-shadow(0 0 2px currentColor);
+    animation: phase-arc-breathe 2.4s ease-in-out infinite;
+}
+
+.phase-arc.phase-arc-failed {
+    filter: drop-shadow(0 0 4px var(--phase-failed));
+}
+
+@keyframes phase-arc-breathe {
+    0%, 100% {
+        filter: drop-shadow(0 0 5px currentColor)
+                drop-shadow(0 0 1px currentColor);
+    }
+    50% {
+        filter: drop-shadow(0 0 14px currentColor)
+                drop-shadow(0 0 3px currentColor);
+    }
+}
+
+.phase-center {
+    position: absolute;
+    inset: 0;
     display: flex;
-    flex-direction: column;
     align-items: center;
-    flex: 0 0 auto;
-    min-width: 180px;
-    padding: 8px 4px;
+    justify-content: center;
+    pointer-events: none;
 }
 
-.phase-divider {
-    flex: 0 0 auto;
-    align-self: center;
+.phase-center-pad {
+    width: 80px;
+    height: 80px;
+    border-radius: 50%;
+    background:
+        radial-gradient(circle at 30% 28%, rgba(255, 255, 255, 0.12), transparent 60%),
+        linear-gradient(135deg, var(--bg-raised) 0%, var(--bg-secondary) 100%);
+    border: 1px solid var(--line-strong);
+    box-shadow:
+        0 10px 24px rgba(0, 0, 0, 0.45),
+        inset 0 1px 2px rgba(255, 255, 255, 0.12),
+        inset 0 -4px 10px rgba(0, 0, 0, 0.25);
+    display: grid;
+    grid-template-rows: auto auto;
+    align-items: center;
+    justify-items: center;
+    text-align: center;
+    padding: 10px 4px 6px;
+}
+
+.phase-center-percent {
+    grid-row: 1;
+    grid-column: 1;
+    font-size: 30px;
+    font-weight: 600;
+    color: var(--text-primary);
+    letter-spacing: -0.02em;
+    line-height: 1;
+    font-variant-numeric: tabular-nums;
+}
+
+.phase-center-unit {
+    grid-row: 1;
+    grid-column: 1;
+    align-self: start;
+    justify-self: end;
+    margin-top: 2px;
+    margin-right: -10px;
+    font-size: 11px;
     color: var(--text-muted);
-    font-size: 20px;
-    padding: 0 8px;
-    opacity: 0.7;
-    user-select: none;
-    position: relative;
-    /* Raise the chevron to align with each ring's vertical center
-       (rings are 140px tall but phase-meta extends the cell below). */
-    top: -14px;
 }
 
-/* Narrow viewport: stack rings vertically and rotate chevrons. */
-@media (max-width: 719px) {
-    .phase-ring-stack {
-        flex-direction: column;
-        align-items: center;
-        max-width: 260px;
-    }
-    .phase-divider {
-        top: 0;
-        padding: 4px 0;
-        transform: rotate(90deg);
-    }
-}
-
-/* Done-state: dim the check glyph slightly so running rings pop more. */
-.phase-cell[data-status="done"] .phase-ring-glyph-done {
-    color: var(--phase-merge);
-}
-
-/* Skipped state: muted ring with dashed track look handled inside
-   PhaseRing via its status-specific classes. */
-.phase-cell[data-status="skipped"] .phase-ring {
-    opacity: 0.6;
+.phase-center-label {
+    grid-row: 2;
+    grid-column: 1;
+    margin-top: 4px;
+    font-size: 9px;
+    font-weight: 600;
+    color: var(--text-muted);
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
 }
 
 /* ---------- Activity panel (live stage-threshold message) ---------- */

--- a/src/VoxFlow.Desktop/wwwroot/css/app.css
+++ b/src/VoxFlow.Desktop/wwwroot/css/app.css
@@ -429,9 +429,22 @@ html, body {
    and an uppercase stage label. */
 .phase-ring-stack {
     position: relative;
-    width: 240px;
-    height: 240px;
-    margin: 0 auto;
+    width: 320px;
+    height: 320px;
+    margin: 8px auto 18px;
+}
+
+/* Soft ambient glow behind the rings (matches the mockup's `.rings::before`). */
+.phase-ring-stack::before {
+    content: '';
+    position: absolute;
+    inset: 14px;
+    border-radius: 50%;
+    background:
+        radial-gradient(circle at 35% 25%, rgba(91, 94, 240, 0.12), transparent 55%),
+        radial-gradient(circle at 65% 80%, rgba(77, 184, 255, 0.08), transparent 60%);
+    filter: blur(8px);
+    pointer-events: none;
 }
 
 .phase-ring-stack .phase-ring-svg {
@@ -440,79 +453,89 @@ html, body {
     width: 100%;
     height: 100%;
     transform: rotate(-90deg);
+    filter: drop-shadow(0 6px 16px rgba(0, 0, 0, 0.4));
 }
 
 .phase-ring-stack .phase-track {
     fill: none;
     stroke: var(--phase-track);
-    stroke-width: 10;
+    stroke-width: 6;
 }
 
 .phase-arc {
     fill: none;
-    stroke-width: 10;
+    stroke-width: 6;
     stroke-linecap: round;
+    filter: drop-shadow(0 0 6px currentColor);
     transition:
         stroke-dashoffset 400ms cubic-bezier(0.2, 0.8, 0.2, 1),
-        stroke 250ms ease,
-        filter 250ms ease;
+        stroke 300ms ease;
 }
 
 .phase-arc.phase-arc-running {
-    filter: drop-shadow(0 0 6px currentColor)
-            drop-shadow(0 0 2px currentColor);
     animation: phase-arc-breathe 2.4s ease-in-out infinite;
 }
 
 .phase-arc.phase-arc-failed {
-    filter: drop-shadow(0 0 4px var(--phase-failed));
+    filter: drop-shadow(0 0 6px var(--phase-failed));
 }
 
 @keyframes phase-arc-breathe {
     0%, 100% {
-        filter: drop-shadow(0 0 5px currentColor)
-                drop-shadow(0 0 1px currentColor);
+        filter: drop-shadow(0 0 5px currentColor);
     }
     50% {
-        filter: drop-shadow(0 0 14px currentColor)
-                drop-shadow(0 0 3px currentColor);
+        filter: drop-shadow(0 0 14px currentColor);
     }
 }
 
+/* Center — a grid that places one content block dead-center. The dark
+   sphere is drawn via ::before so the content stays clean HTML. */
 .phase-center {
     position: absolute;
     inset: 0;
-    display: flex;
-    align-items: center;
-    justify-content: center;
+    display: grid;
+    place-items: center;
+    text-align: center;
+    pointer-events: none;
+}
+
+.phase-center::before {
+    content: '';
+    position: absolute;
+    width: 96px;
+    height: 96px;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    border-radius: 50%;
+    background: radial-gradient(circle at 40% 30%, #272d4c 0%, #1b2040 55%, #141828 100%);
+    box-shadow:
+        inset 0 2px 3px rgba(255, 255, 255, 0.06),
+        inset 0 -8px 18px rgba(0, 0, 0, 0.35),
+        0 8px 20px -8px rgba(0, 0, 0, 0.6);
     pointer-events: none;
 }
 
 .phase-center-pad {
-    width: 80px;
-    height: 80px;
-    border-radius: 50%;
-    background:
-        radial-gradient(circle at 30% 28%, rgba(255, 255, 255, 0.12), transparent 60%),
-        linear-gradient(135deg, var(--bg-raised) 0%, var(--bg-secondary) 100%);
-    border: 1px solid var(--line-strong);
-    box-shadow:
-        0 10px 24px rgba(0, 0, 0, 0.45),
-        inset 0 1px 2px rgba(255, 255, 255, 0.12),
-        inset 0 -4px 10px rgba(0, 0, 0, 0.25);
-    display: grid;
-    grid-template-rows: auto auto;
+    position: relative;
+    z-index: 1;
+    display: flex;
+    flex-direction: column;
     align-items: center;
-    justify-items: center;
-    text-align: center;
-    padding: 10px 4px 6px;
+    gap: 4px;
+}
+
+.phase-center-pct-row {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 2px;
+    line-height: 1;
 }
 
 .phase-center-percent {
-    grid-row: 1;
-    grid-column: 1;
-    font-size: 30px;
-    font-weight: 600;
+    font-size: 38px;
+    font-weight: 700;
     color: var(--text-primary);
     letter-spacing: -0.02em;
     line-height: 1;
@@ -520,21 +543,13 @@ html, body {
 }
 
 .phase-center-unit {
-    grid-row: 1;
-    grid-column: 1;
-    align-self: start;
-    justify-self: end;
-    margin-top: 2px;
-    margin-right: -10px;
-    font-size: 11px;
+    font-size: 13px;
+    font-weight: 500;
     color: var(--text-muted);
 }
 
 .phase-center-label {
-    grid-row: 2;
-    grid-column: 1;
-    margin-top: 4px;
-    font-size: 9px;
+    font-size: 9.5px;
     font-weight: 600;
     color: var(--text-muted);
     letter-spacing: 0.14em;
@@ -543,14 +558,17 @@ html, body {
 
 /* ---------- Activity panel (live stage-threshold message) ---------- */
 .activity-panel {
-    display: inline-flex;
+    display: flex;
     align-items: center;
-    gap: 10px;
-    padding: 10px 14px;
-    margin: 0 auto;
-    border-radius: 10px;
-    background: rgba(255, 255, 255, 0.03);
-    border: 1px solid var(--border);
+    gap: 12px;
+    width: 100%;
+    padding: 14px 16px;
+    margin: 0;
+    min-height: 52px;
+    border-radius: 14px;
+    background: var(--bg-secondary);
+    border: 1px solid var(--line);
+    overflow: hidden;
 }
 
 .activity-pulse-dot {
@@ -560,6 +578,7 @@ html, body {
     background: var(--phase-transcription);
     box-shadow: 0 0 0 0 rgba(167, 139, 250, 0.55);
     animation: activity-pulse 1.6s ease-out infinite;
+    flex-shrink: 0;
 }
 
 .activity-pulse-dot.activity-pulse-diarization {

--- a/src/VoxFlow.Desktop/wwwroot/css/app.css
+++ b/src/VoxFlow.Desktop/wwwroot/css/app.css
@@ -516,6 +516,51 @@ html, body {
     text-transform: uppercase;
 }
 
+/* ---------- Activity panel (live stage-threshold message) ---------- */
+.activity-panel {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 14px;
+    margin: 0 auto;
+    border-radius: 10px;
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid var(--border);
+}
+
+.activity-pulse-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--phase-transcription);
+    box-shadow: 0 0 0 0 rgba(167, 139, 250, 0.55);
+    animation: activity-pulse 1.6s ease-out infinite;
+}
+
+.activity-pulse-dot.activity-pulse-diarization {
+    background: var(--phase-diarization);
+    box-shadow: 0 0 0 0 rgba(77, 184, 255, 0.55);
+}
+
+.activity-pulse-dot.activity-pulse-merge {
+    background: var(--phase-merge);
+    box-shadow: 0 0 0 0 rgba(40, 200, 64, 0.55);
+}
+
+@keyframes activity-pulse {
+    0%   { box-shadow: 0 0 0 0 var(--activity-pulse-halo, rgba(167, 139, 250, 0.55)); }
+    70%  { box-shadow: 0 0 0 10px rgba(0, 0, 0, 0); }
+    100% { box-shadow: 0 0 0 0 rgba(0, 0, 0, 0); }
+}
+
+.activity-message {
+    font-family: var(--font-mono);
+    font-size: 12px;
+    color: var(--text-secondary);
+    letter-spacing: 0.02em;
+    font-variant-numeric: tabular-nums;
+}
+
 .phase-ring {
     display: flex;
     flex-direction: column;

--- a/src/VoxFlow.Desktop/wwwroot/css/app.css
+++ b/src/VoxFlow.Desktop/wwwroot/css/app.css
@@ -93,7 +93,7 @@ html, body {
     display: flex;
     flex-direction: column;
     align-items: center;
-    justify-content: center;
+    justify-content: flex-start;
     padding: 8px 24px 32px;
     overflow-y: auto;
     overflow-x: hidden;
@@ -168,14 +168,39 @@ html, body {
 }
 
 /* A narrow "page column" wrapper used by Ready/Running/Complete so they
-   line up with the topbar's max-width. */
+   line up with the topbar's max-width. Grows to fill .app-content so
+   TopBar stays anchored at the top and trailing actions (Cancel, etc.)
+   can sit at the bottom via margin-top: auto. */
 .page-column {
     width: 100%;
     max-width: 480px;
     margin: 0 auto;
+    flex: 1 0 auto;
+    min-height: 100%;
     display: flex;
     flex-direction: column;
     align-items: center;
+}
+
+/* Running screen body: grows to absorb vertical slack so the phase rings
+   feel optically centered between the topbar and the Cancel footer. */
+.running-body {
+    flex: 1 1 auto;
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 20px;
+    padding: 24px 0;
+}
+
+.running-actions {
+    width: 100%;
+    margin-top: auto;
+    padding-top: 16px;
+    display: flex;
+    justify-content: center;
 }
 
 /* ---------- Settings bottom sheet ---------- */
@@ -406,7 +431,7 @@ html, body {
     position: relative;
     width: 240px;
     height: 240px;
-    margin: 0 auto 32px;
+    margin: 0 auto;
 }
 
 .phase-ring-stack .phase-ring-svg {

--- a/src/VoxFlow.Desktop/wwwroot/css/app.css
+++ b/src/VoxFlow.Desktop/wwwroot/css/app.css
@@ -94,9 +94,134 @@ html, body {
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    padding: 32px 24px;
+    padding: 8px 24px 32px;
     overflow-y: auto;
     overflow-x: hidden;
+}
+
+/* ---------- Top Bar ---------- */
+.topbar {
+    width: 100%;
+    max-width: 480px;
+    margin: 0 auto;
+    padding: 12px 4px 18px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    user-select: none;
+}
+
+.wordmark {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-weight: 700;
+    font-size: 15px;
+    letter-spacing: -0.01em;
+    color: var(--text-primary);
+}
+
+.wordmark-dot {
+    width: 22px;
+    height: 22px;
+    border-radius: 7px;
+    background: linear-gradient(135deg, var(--accent), var(--accent-alt));
+    box-shadow: 0 6px 16px -6px rgba(91, 94, 240, 0.7);
+    flex-shrink: 0;
+}
+
+.topbar-actions {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+}
+
+.icon-btn {
+    width: 36px;
+    height: 36px;
+    padding: 0;
+    border: 0;
+    border-radius: 10px;
+    background: transparent;
+    color: var(--text-secondary);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+.icon-btn:hover:not(:disabled) {
+    background: var(--bg-surface);
+    color: var(--text-primary);
+}
+
+.icon-btn.is-active,
+.icon-btn[aria-expanded="true"] {
+    background: var(--bg-surface);
+    color: var(--text-primary);
+}
+
+.icon-btn:disabled {
+    opacity: 0.35;
+    cursor: not-allowed;
+}
+
+/* A narrow "page column" wrapper used by Ready/Running/Complete so they
+   line up with the topbar's max-width. */
+.page-column {
+    width: 100%;
+    max-width: 480px;
+    margin: 0 auto;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+/* ---------- Settings bottom sheet ---------- */
+.settings-sheet-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.5);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity var(--transition-medium);
+    z-index: 40;
+}
+
+.settings-sheet-backdrop.show {
+    opacity: 1;
+    pointer-events: auto;
+}
+
+.settings-sheet {
+    position: fixed;
+    left: 50%;
+    bottom: 0;
+    transform: translate(-50%, 100%);
+    width: 100%;
+    max-width: 480px;
+    background: var(--bg-secondary);
+    border-top-left-radius: 16px;
+    border-top-right-radius: 16px;
+    border-top: 1px solid var(--border);
+    padding: 12px 20px 24px;
+    box-shadow: 0 -12px 40px rgba(0, 0, 0, 0.45);
+    transition: transform var(--transition-medium);
+    z-index: 50;
+}
+
+.settings-sheet.show {
+    transform: translate(-50%, 0);
+}
+
+.settings-sheet-handle {
+    width: 40px;
+    height: 4px;
+    margin: 0 auto 12px;
+    border-radius: 2px;
+    background: var(--text-muted);
+    opacity: 0.5;
 }
 
 /* ---------- Drop Zone ---------- */

--- a/src/VoxFlow.Desktop/wwwroot/index.html
+++ b/src/VoxFlow.Desktop/wwwroot/index.html
@@ -5,6 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>VoxFlow</title>
     <base href="/" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
     <link href="css/app.css" rel="stylesheet" />
 </head>
 <body>

--- a/tests/VoxFlow.Desktop.Tests/Components/PhaseRingStackTests.cs
+++ b/tests/VoxFlow.Desktop.Tests/Components/PhaseRingStackTests.cs
@@ -19,8 +19,13 @@ public sealed class PhaseRingStackTests
     private static ProgressUpdate Frame(ProgressStage stage, double pct, string? msg = null)
         => new(stage, pct, TimeSpan.Zero, Message: msg);
 
+    private static bool IsPhaseArc(RenderedElement e, string phaseSlug)
+        => e.Name == "circle"
+            && e.Attributes.TryGetValue("data-phase", out var p)
+            && (p?.ToString() ?? string.Empty) == phaseSlug;
+
     [Fact]
-    public async Task RendersThreePhaseRings_InPhaseOrder()
+    public async Task RendersThreeNestedArcs_InPhaseOrder()
     {
         await using var context = DesktopUiTestContext.Create();
         var clock = new ControllableTimeProvider(T0);
@@ -28,17 +33,17 @@ public sealed class PhaseRingStackTests
 
         var rendered = await context.RenderAsync<PhaseRingStack>(Params(tracker));
 
-        var cells = rendered
-            .FindElements(e => e.HasClass("phase-cell"))
+        var arcs = rendered
+            .FindElements(e => e.Name == "circle" && e.Attributes.ContainsKey("data-phase"))
             .ToArray();
-        Assert.Equal(3, cells.Length);
-        Assert.Equal("transcription", cells[0].Attributes["data-phase"]?.ToString());
-        Assert.Equal("diarization", cells[1].Attributes["data-phase"]?.ToString());
-        Assert.Equal("merge", cells[2].Attributes["data-phase"]?.ToString());
+        Assert.Equal(3, arcs.Length);
+        Assert.Equal("transcription", arcs[0].Attributes["data-phase"]?.ToString());
+        Assert.Equal("diarization", arcs[1].Attributes["data-phase"]?.ToString());
+        Assert.Equal("merge", arcs[2].Attributes["data-phase"]?.ToString());
     }
 
     [Fact]
-    public async Task EachPhaseCell_PassesCorrectPhaseToken_ToItsRing()
+    public async Task ArcsUseCorrectPhaseColorTokens()
     {
         await using var context = DesktopUiTestContext.Create();
         var clock = new ControllableTimeProvider(T0);
@@ -46,17 +51,17 @@ public sealed class PhaseRingStackTests
 
         var rendered = await context.RenderAsync<PhaseRingStack>(Params(tracker));
 
-        var rings = rendered
-            .FindElements(e => e.HasClass("phase-ring") && !e.HasClass("phase-ring-stack"))
-            .ToArray();
-        Assert.Equal(3, rings.Length);
-        Assert.Contains("--phase-transcription", rings[0].Attributes["style"]?.ToString() ?? "");
-        Assert.Contains("--phase-diarization", rings[1].Attributes["style"]?.ToString() ?? "");
-        Assert.Contains("--phase-merge", rings[2].Attributes["style"]?.ToString() ?? "");
+        var transcription = rendered.FindElement(e => IsPhaseArc(e, "transcription"), "transcription arc");
+        var diarization = rendered.FindElement(e => IsPhaseArc(e, "diarization"), "diarization arc");
+        var merge = rendered.FindElement(e => IsPhaseArc(e, "merge"), "merge arc");
+
+        Assert.Contains("--phase-transcription", transcription.Attributes["style"]?.ToString() ?? "");
+        Assert.Contains("--phase-diarization", diarization.Attributes["style"]?.ToString() ?? "");
+        Assert.Contains("--phase-merge", merge.Attributes["style"]?.ToString() ?? "");
     }
 
     [Fact]
-    public async Task ChevronDividers_SeparateRings()
+    public async Task ArcRadiiMatchConcentricContract()
     {
         await using var context = DesktopUiTestContext.Create();
         var clock = new ControllableTimeProvider(T0);
@@ -64,12 +69,17 @@ public sealed class PhaseRingStackTests
 
         var rendered = await context.RenderAsync<PhaseRingStack>(Params(tracker));
 
-        var dividers = rendered.FindElements(e => e.HasClass("phase-divider")).ToArray();
-        Assert.Equal(2, dividers.Length);
+        var transcription = rendered.FindElement(e => IsPhaseArc(e, "transcription"), "transcription arc");
+        var diarization = rendered.FindElement(e => IsPhaseArc(e, "diarization"), "diarization arc");
+        var merge = rendered.FindElement(e => IsPhaseArc(e, "merge"), "merge arc");
+
+        Assert.Equal("92", transcription.Attributes["r"]?.ToString());
+        Assert.Equal("72", diarization.Attributes["r"]?.ToString());
+        Assert.Equal("52", merge.Attributes["r"]?.ToString());
     }
 
     [Fact]
-    public async Task TranscriptionRunning_TranscriptionCellHasRunningStatus()
+    public async Task ArcDashOffset_ReflectsLocalPercent()
     {
         await using var context = DesktopUiTestContext.Create();
         var clock = new ControllableTimeProvider(T0);
@@ -79,19 +89,16 @@ public sealed class PhaseRingStackTests
         tracker.OnProgress(Frame(ProgressStage.Transcribing, 45.0));
         await rendered.SynchronizeAsync();
 
-        var transcriptionCell = rendered.FindElement(
-            e => e.HasClass("phase-cell")
-                 && e.Attributes.TryGetValue("data-phase", out var p)
-                 && (p?.ToString() ?? "") == "transcription",
-            "transcription phase-cell");
-        Assert.Equal("running", transcriptionCell.Attributes["data-status"]?.ToString());
-
-        // Transcription local at ProgressStage.Transcribing 45% overall = 50%
-        Assert.Contains("50", transcriptionCell.TextContent);
+        var transcription = rendered.FindElement(e => IsPhaseArc(e, "transcription"), "transcription arc");
+        var dashOffset = transcription.Attributes["stroke-dashoffset"]?.ToString() ?? "";
+        var parsed = double.Parse(dashOffset, System.Globalization.CultureInfo.InvariantCulture);
+        // Local percent for Transcribing @ 45% overall = 50%. Circumference 2π*92 ≈ 578.053.
+        // Expected dashoffset at 50% = ~289.027.
+        Assert.InRange(parsed, 288.5, 289.6);
     }
 
     [Fact]
-    public async Task SkippedDiarization_DiarizationCellHasSkippedStatus()
+    public async Task SkippedDiarization_MiddleArcUsesSkippedToken()
     {
         await using var context = DesktopUiTestContext.Create();
         var clock = new ControllableTimeProvider(T0);
@@ -99,17 +106,12 @@ public sealed class PhaseRingStackTests
 
         var rendered = await context.RenderAsync<PhaseRingStack>(Params(tracker));
 
-        var diarizationCell = rendered.FindElement(
-            e => e.HasClass("phase-cell")
-                 && e.Attributes.TryGetValue("data-phase", out var p)
-                 && (p?.ToString() ?? "") == "diarization",
-            "diarization phase-cell");
-        Assert.Equal("skipped", diarizationCell.Attributes["data-status"]?.ToString());
-        Assert.Contains("skipped", diarizationCell.TextContent, StringComparison.OrdinalIgnoreCase);
+        var diarization = rendered.FindElement(e => IsPhaseArc(e, "diarization"), "diarization arc");
+        Assert.Contains("--phase-skipped", diarization.Attributes["style"]?.ToString() ?? "");
     }
 
     [Fact]
-    public async Task OuterStack_HasProgressbarRole_ReflectingFocusPhase()
+    public async Task Center_ShowsPercentAndStageLabel_DuringRunning()
     {
         await using var context = DesktopUiTestContext.Create();
         var clock = new ControllableTimeProvider(T0);
@@ -119,11 +121,14 @@ public sealed class PhaseRingStackTests
         tracker.OnProgress(Frame(ProgressStage.Transcribing, 45.0));
         await rendered.SynchronizeAsync();
 
-        var stack = rendered.FindElement(
-            e => e.Name == "div" && e.HasClass("phase-ring-stack"),
-            "phase-ring-stack");
-        Assert.Equal("progressbar", stack.Attributes["role"]?.ToString());
-        Assert.Equal("Transcription progress", stack.Attributes["aria-label"]?.ToString());
-        Assert.Equal("50", stack.Attributes["aria-valuenow"]?.ToString());
+        var percent = rendered.FindElement(
+            e => e.HasClass("phase-center-percent"),
+            ".phase-center-percent");
+        Assert.Contains("50", percent.TextContent);
+
+        var label = rendered.FindElement(
+            e => e.HasClass("phase-center-label"),
+            ".phase-center-label");
+        Assert.Contains("TRANSCRIPTION", label.TextContent, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/tests/VoxFlow.Desktop.Tests/Components/PhaseRingStackTests.cs
+++ b/tests/VoxFlow.Desktop.Tests/Components/PhaseRingStackTests.cs
@@ -19,13 +19,8 @@ public sealed class PhaseRingStackTests
     private static ProgressUpdate Frame(ProgressStage stage, double pct, string? msg = null)
         => new(stage, pct, TimeSpan.Zero, Message: msg);
 
-    private static bool IsPhaseArc(RenderedElement e, string phaseSlug)
-        => e.Name == "circle"
-            && e.Attributes.TryGetValue("data-phase", out var p)
-            && (p?.ToString() ?? string.Empty) == phaseSlug;
-
     [Fact]
-    public async Task RendersThreeNestedArcs_InPhaseOrder()
+    public async Task RendersThreePhaseRings_InPhaseOrder()
     {
         await using var context = DesktopUiTestContext.Create();
         var clock = new ControllableTimeProvider(T0);
@@ -33,17 +28,17 @@ public sealed class PhaseRingStackTests
 
         var rendered = await context.RenderAsync<PhaseRingStack>(Params(tracker));
 
-        var arcs = rendered
-            .FindElements(e => e.Name == "circle" && e.Attributes.ContainsKey("data-phase"))
+        var cells = rendered
+            .FindElements(e => e.HasClass("phase-cell"))
             .ToArray();
-        Assert.Equal(3, arcs.Length);
-        Assert.Equal("transcription", arcs[0].Attributes["data-phase"]?.ToString());
-        Assert.Equal("diarization", arcs[1].Attributes["data-phase"]?.ToString());
-        Assert.Equal("merge", arcs[2].Attributes["data-phase"]?.ToString());
+        Assert.Equal(3, cells.Length);
+        Assert.Equal("transcription", cells[0].Attributes["data-phase"]?.ToString());
+        Assert.Equal("diarization", cells[1].Attributes["data-phase"]?.ToString());
+        Assert.Equal("merge", cells[2].Attributes["data-phase"]?.ToString());
     }
 
     [Fact]
-    public async Task ArcsUseCorrectPhaseColorTokens()
+    public async Task EachPhaseCell_PassesCorrectPhaseToken_ToItsRing()
     {
         await using var context = DesktopUiTestContext.Create();
         var clock = new ControllableTimeProvider(T0);
@@ -51,17 +46,17 @@ public sealed class PhaseRingStackTests
 
         var rendered = await context.RenderAsync<PhaseRingStack>(Params(tracker));
 
-        var transcription = rendered.FindElement(e => IsPhaseArc(e, "transcription"), "transcription arc");
-        var diarization = rendered.FindElement(e => IsPhaseArc(e, "diarization"), "diarization arc");
-        var merge = rendered.FindElement(e => IsPhaseArc(e, "merge"), "merge arc");
-
-        Assert.Contains("--phase-transcription", transcription.Attributes["style"]?.ToString() ?? "");
-        Assert.Contains("--phase-diarization", diarization.Attributes["style"]?.ToString() ?? "");
-        Assert.Contains("--phase-merge", merge.Attributes["style"]?.ToString() ?? "");
+        var rings = rendered
+            .FindElements(e => e.HasClass("phase-ring") && !e.HasClass("phase-ring-stack"))
+            .ToArray();
+        Assert.Equal(3, rings.Length);
+        Assert.Contains("--phase-transcription", rings[0].Attributes["style"]?.ToString() ?? "");
+        Assert.Contains("--phase-diarization", rings[1].Attributes["style"]?.ToString() ?? "");
+        Assert.Contains("--phase-merge", rings[2].Attributes["style"]?.ToString() ?? "");
     }
 
     [Fact]
-    public async Task ArcRadiiMatchConcentricContract()
+    public async Task ChevronDividers_SeparateRings()
     {
         await using var context = DesktopUiTestContext.Create();
         var clock = new ControllableTimeProvider(T0);
@@ -69,17 +64,12 @@ public sealed class PhaseRingStackTests
 
         var rendered = await context.RenderAsync<PhaseRingStack>(Params(tracker));
 
-        var transcription = rendered.FindElement(e => IsPhaseArc(e, "transcription"), "transcription arc");
-        var diarization = rendered.FindElement(e => IsPhaseArc(e, "diarization"), "diarization arc");
-        var merge = rendered.FindElement(e => IsPhaseArc(e, "merge"), "merge arc");
-
-        Assert.Equal("92", transcription.Attributes["r"]?.ToString());
-        Assert.Equal("72", diarization.Attributes["r"]?.ToString());
-        Assert.Equal("52", merge.Attributes["r"]?.ToString());
+        var dividers = rendered.FindElements(e => e.HasClass("phase-divider")).ToArray();
+        Assert.Equal(2, dividers.Length);
     }
 
     [Fact]
-    public async Task ArcDashOffset_ReflectsLocalPercent()
+    public async Task TranscriptionRunning_TranscriptionCellHasRunningStatus()
     {
         await using var context = DesktopUiTestContext.Create();
         var clock = new ControllableTimeProvider(T0);
@@ -89,16 +79,19 @@ public sealed class PhaseRingStackTests
         tracker.OnProgress(Frame(ProgressStage.Transcribing, 45.0));
         await rendered.SynchronizeAsync();
 
-        var transcription = rendered.FindElement(e => IsPhaseArc(e, "transcription"), "transcription arc");
-        var dashOffset = transcription.Attributes["stroke-dashoffset"]?.ToString() ?? "";
-        var parsed = double.Parse(dashOffset, System.Globalization.CultureInfo.InvariantCulture);
-        // Local percent for Transcribing @ 45% overall = 50%. Circumference 2π*92 ≈ 578.053.
-        // Expected dashoffset at 50% = ~289.027.
-        Assert.InRange(parsed, 288.5, 289.6);
+        var transcriptionCell = rendered.FindElement(
+            e => e.HasClass("phase-cell")
+                 && e.Attributes.TryGetValue("data-phase", out var p)
+                 && (p?.ToString() ?? "") == "transcription",
+            "transcription phase-cell");
+        Assert.Equal("running", transcriptionCell.Attributes["data-status"]?.ToString());
+
+        // Transcription local at ProgressStage.Transcribing 45% overall = 50%
+        Assert.Contains("50", transcriptionCell.TextContent);
     }
 
     [Fact]
-    public async Task SkippedDiarization_MiddleArcUsesSkippedToken()
+    public async Task SkippedDiarization_DiarizationCellHasSkippedStatus()
     {
         await using var context = DesktopUiTestContext.Create();
         var clock = new ControllableTimeProvider(T0);
@@ -106,12 +99,17 @@ public sealed class PhaseRingStackTests
 
         var rendered = await context.RenderAsync<PhaseRingStack>(Params(tracker));
 
-        var diarization = rendered.FindElement(e => IsPhaseArc(e, "diarization"), "diarization arc");
-        Assert.Contains("--phase-skipped", diarization.Attributes["style"]?.ToString() ?? "");
+        var diarizationCell = rendered.FindElement(
+            e => e.HasClass("phase-cell")
+                 && e.Attributes.TryGetValue("data-phase", out var p)
+                 && (p?.ToString() ?? "") == "diarization",
+            "diarization phase-cell");
+        Assert.Equal("skipped", diarizationCell.Attributes["data-status"]?.ToString());
+        Assert.Contains("skipped", diarizationCell.TextContent, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
-    public async Task Center_ShowsPercentAndStageLabel_DuringRunning()
+    public async Task OuterStack_HasProgressbarRole_ReflectingFocusPhase()
     {
         await using var context = DesktopUiTestContext.Create();
         var clock = new ControllableTimeProvider(T0);
@@ -121,14 +119,11 @@ public sealed class PhaseRingStackTests
         tracker.OnProgress(Frame(ProgressStage.Transcribing, 45.0));
         await rendered.SynchronizeAsync();
 
-        var percent = rendered.FindElement(
-            e => e.HasClass("phase-center-percent"),
-            ".phase-center-percent");
-        Assert.Contains("50", percent.TextContent);
-
-        var label = rendered.FindElement(
-            e => e.HasClass("phase-center-label"),
-            ".phase-center-label");
-        Assert.Contains("TRANSCRIPTION", label.TextContent, StringComparison.OrdinalIgnoreCase);
+        var stack = rendered.FindElement(
+            e => e.Name == "div" && e.HasClass("phase-ring-stack"),
+            "phase-ring-stack");
+        Assert.Equal("progressbar", stack.Attributes["role"]?.ToString());
+        Assert.Equal("Transcription progress", stack.Attributes["aria-label"]?.ToString());
+        Assert.Equal("50", stack.Attributes["aria-valuenow"]?.ToString());
     }
 }

--- a/tests/VoxFlow.Desktop.Tests/Components/PhaseRingStackTests.cs
+++ b/tests/VoxFlow.Desktop.Tests/Components/PhaseRingStackTests.cs
@@ -19,8 +19,13 @@ public sealed class PhaseRingStackTests
     private static ProgressUpdate Frame(ProgressStage stage, double pct, string? msg = null)
         => new(stage, pct, TimeSpan.Zero, Message: msg);
 
+    private static bool IsPhaseArc(RenderedElement e, string phaseSlug)
+        => e.Name == "circle"
+            && e.Attributes.TryGetValue("data-phase", out var p)
+            && (p?.ToString() ?? string.Empty) == phaseSlug;
+
     [Fact]
-    public async Task Renders_ThreeRings_InPhaseOrder()
+    public async Task RendersThreeNestedArcs_InPhaseOrder()
     {
         await using var context = DesktopUiTestContext.Create();
         var clock = new ControllableTimeProvider(T0);
@@ -28,37 +33,17 @@ public sealed class PhaseRingStackTests
 
         var rendered = await context.RenderAsync<PhaseRingStack>(Params(tracker));
 
-        var ringRoots = rendered.FindElements(
-            e => e.Name == "div"
-                && e.Attributes.TryGetValue("class", out var c)
-                && (c?.ToString() ?? "") == "phase-ring");
-        Assert.Equal(3, ringRoots.Count);
-    }
-
-    [Fact]
-    public async Task AssignsPhaseColorTokens_CyanMagentaGreen()
-    {
-        await using var context = DesktopUiTestContext.Create();
-        var clock = new ControllableTimeProvider(T0);
-        using var tracker = new PhaseProgressTracker(speakerLabelingEnabled: true, timeProvider: clock);
-
-        var rendered = await context.RenderAsync<PhaseRingStack>(Params(tracker));
-
-        var ringRoots = rendered
-            .FindElements(
-                e => e.Name == "div"
-                    && e.Attributes.TryGetValue("class", out var c)
-                    && (c?.ToString() ?? "") == "phase-ring")
+        var arcs = rendered
+            .FindElements(e => e.Name == "circle" && e.Attributes.ContainsKey("data-phase"))
             .ToArray();
-
-        Assert.Equal(3, ringRoots.Length);
-        Assert.Contains("--phase-transcription", ringRoots[0].Attributes["style"]?.ToString() ?? "");
-        Assert.Contains("--phase-diarization", ringRoots[1].Attributes["style"]?.ToString() ?? "");
-        Assert.Contains("--phase-merge", ringRoots[2].Attributes["style"]?.ToString() ?? "");
+        Assert.Equal(3, arcs.Length);
+        Assert.Equal("transcription", arcs[0].Attributes["data-phase"]?.ToString());
+        Assert.Equal("diarization", arcs[1].Attributes["data-phase"]?.ToString());
+        Assert.Equal("merge", arcs[2].Attributes["data-phase"]?.ToString());
     }
 
     [Fact]
-    public async Task RendersChevronSeparatorsBetweenRings()
+    public async Task ArcsUseCorrectPhaseColorTokens()
     {
         await using var context = DesktopUiTestContext.Create();
         var clock = new ControllableTimeProvider(T0);
@@ -66,14 +51,35 @@ public sealed class PhaseRingStackTests
 
         var rendered = await context.RenderAsync<PhaseRingStack>(Params(tracker));
 
-        var chevrons = rendered.FindElements(
-            e => e.Attributes.TryGetValue("class", out var c)
-                && (c?.ToString() ?? "").Contains("phase-ring-chevron"));
-        Assert.Equal(2, chevrons.Count);
+        var transcription = rendered.FindElement(e => IsPhaseArc(e, "transcription"), "transcription arc");
+        var diarization = rendered.FindElement(e => IsPhaseArc(e, "diarization"), "diarization arc");
+        var merge = rendered.FindElement(e => IsPhaseArc(e, "merge"), "merge arc");
+
+        Assert.Contains("--phase-transcription", transcription.Attributes["style"]?.ToString() ?? "");
+        Assert.Contains("--phase-diarization", diarization.Attributes["style"]?.ToString() ?? "");
+        Assert.Contains("--phase-merge", merge.Attributes["style"]?.ToString() ?? "");
     }
 
     [Fact]
-    public async Task ReflectsRunningPhase_AfterTrackerProgressUpdate()
+    public async Task ArcRadiiMatchConcentricContract()
+    {
+        await using var context = DesktopUiTestContext.Create();
+        var clock = new ControllableTimeProvider(T0);
+        using var tracker = new PhaseProgressTracker(speakerLabelingEnabled: true, timeProvider: clock);
+
+        var rendered = await context.RenderAsync<PhaseRingStack>(Params(tracker));
+
+        var transcription = rendered.FindElement(e => IsPhaseArc(e, "transcription"), "transcription arc");
+        var diarization = rendered.FindElement(e => IsPhaseArc(e, "diarization"), "diarization arc");
+        var merge = rendered.FindElement(e => IsPhaseArc(e, "merge"), "merge arc");
+
+        Assert.Equal("92", transcription.Attributes["r"]?.ToString());
+        Assert.Equal("72", diarization.Attributes["r"]?.ToString());
+        Assert.Equal("52", merge.Attributes["r"]?.ToString());
+    }
+
+    [Fact]
+    public async Task ArcDashOffset_ReflectsLocalPercent()
     {
         await using var context = DesktopUiTestContext.Create();
         var clock = new ControllableTimeProvider(T0);
@@ -83,12 +89,16 @@ public sealed class PhaseRingStackTests
         tracker.OnProgress(Frame(ProgressStage.Transcribing, 45.0));
         await rendered.SynchronizeAsync();
 
-        Assert.Contains("50", rendered.TextContent);
-        Assert.Contains("transcribing", rendered.TextContent);
+        var transcription = rendered.FindElement(e => IsPhaseArc(e, "transcription"), "transcription arc");
+        var dashOffset = transcription.Attributes["stroke-dashoffset"]?.ToString() ?? "";
+        var parsed = double.Parse(dashOffset, System.Globalization.CultureInfo.InvariantCulture);
+        // Local percent for Transcribing @ 45% overall = 50%. Circumference 2π*92 ≈ 578.053.
+        // Expected dashoffset at 50% = ~289.027.
+        Assert.InRange(parsed, 288.5, 289.6);
     }
 
     [Fact]
-    public async Task SkippedDiarization_RendersSkippedRingInMiddle()
+    public async Task SkippedDiarization_MiddleArcUsesSkippedToken()
     {
         await using var context = DesktopUiTestContext.Create();
         var clock = new ControllableTimeProvider(T0);
@@ -96,6 +106,29 @@ public sealed class PhaseRingStackTests
 
         var rendered = await context.RenderAsync<PhaseRingStack>(Params(tracker));
 
-        Assert.Contains("skipped", rendered.TextContent, StringComparison.OrdinalIgnoreCase);
+        var diarization = rendered.FindElement(e => IsPhaseArc(e, "diarization"), "diarization arc");
+        Assert.Contains("--phase-skipped", diarization.Attributes["style"]?.ToString() ?? "");
+    }
+
+    [Fact]
+    public async Task Center_ShowsPercentAndStageLabel_DuringRunning()
+    {
+        await using var context = DesktopUiTestContext.Create();
+        var clock = new ControllableTimeProvider(T0);
+        using var tracker = new PhaseProgressTracker(speakerLabelingEnabled: true, timeProvider: clock);
+
+        var rendered = await context.RenderAsync<PhaseRingStack>(Params(tracker));
+        tracker.OnProgress(Frame(ProgressStage.Transcribing, 45.0));
+        await rendered.SynchronizeAsync();
+
+        var percent = rendered.FindElement(
+            e => e.HasClass("phase-center-percent"),
+            ".phase-center-percent");
+        Assert.Contains("50", percent.TextContent);
+
+        var label = rendered.FindElement(
+            e => e.HasClass("phase-center-label"),
+            ".phase-center-label");
+        Assert.Contains("TRANSCRIPTION", label.TextContent, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/tests/VoxFlow.Desktop.Tests/Components/SettingsPanelTests.cs
+++ b/tests/VoxFlow.Desktop.Tests/Components/SettingsPanelTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Components;
 using VoxFlow.Desktop.Components.Shared;
 using Xunit;
 
@@ -16,6 +17,58 @@ public sealed class SettingsPanelTests
             e => e.Attributes.TryGetValue("id", out var id)
                 && (id?.ToString() ?? string.Empty) == "speaker-labeling-toggle");
         Assert.Single(toggle);
+    }
+
+    [Fact]
+    public async Task SettingsPanel_WhenShowSheetFalse_SheetHasNoShowClass()
+    {
+        await using var context = DesktopUiTestContext.Create();
+        var parameters = ParameterView.FromDictionary(
+            new Dictionary<string, object?> { [nameof(SettingsPanel.ShowSheet)] = false });
+
+        var rendered = await context.RenderAsync<SettingsPanel>(parameters);
+
+        var sheet = rendered.FindElement(
+            e => e.HasClass("settings-sheet"),
+            ".settings-sheet container");
+        Assert.False(sheet.HasClass("show"));
+    }
+
+    [Fact]
+    public async Task SettingsPanel_WhenShowSheetTrue_SheetHasShowClass()
+    {
+        await using var context = DesktopUiTestContext.Create();
+        var parameters = ParameterView.FromDictionary(
+            new Dictionary<string, object?> { [nameof(SettingsPanel.ShowSheet)] = true });
+
+        var rendered = await context.RenderAsync<SettingsPanel>(parameters);
+
+        var sheet = rendered.FindElement(
+            e => e.HasClass("settings-sheet"),
+            ".settings-sheet container");
+        Assert.True(sheet.HasClass("show"));
+    }
+
+    [Fact]
+    public async Task SettingsPanel_WhenBackdropClicked_FiresOnSheetClose()
+    {
+        await using var context = DesktopUiTestContext.Create();
+        var closed = false;
+        var parameters = ParameterView.FromDictionary(
+            new Dictionary<string, object?>
+            {
+                [nameof(SettingsPanel.ShowSheet)] = true,
+                [nameof(SettingsPanel.OnSheetClose)] =
+                    EventCallback.Factory.Create(this, () => closed = true)
+            });
+
+        var rendered = await context.RenderAsync<SettingsPanel>(parameters);
+
+        await rendered.ClickAsync(
+            e => e.HasClass("settings-sheet-backdrop"),
+            ".settings-sheet-backdrop");
+
+        Assert.True(closed);
     }
 
     [Fact]

--- a/tests/VoxFlow.Desktop.Tests/DesktopCliBundleTests.cs
+++ b/tests/VoxFlow.Desktop.Tests/DesktopCliBundleTests.cs
@@ -1,0 +1,68 @@
+using Xunit;
+
+namespace VoxFlow.Desktop.Tests;
+
+public sealed class DesktopCliBundleTests
+{
+    [SkippableFact]
+    public void MonoBundleCli_IncludesPyannoteSidecarScript()
+    {
+        var cliBundleDir = ResolveBuiltCliBundleDir();
+        Skip.If(cliBundleDir is null, "Mac Catalyst Desktop app bundle has not been built yet.");
+
+        var expectedScript = Path.Combine(cliBundleDir, "python", "voxflow_diarize.py");
+        Assert.True(
+            File.Exists(expectedScript),
+            $"Pyannote sidecar script is missing from app bundle. Expected at: {expectedScript}. "
+                + "CopyBundledCliBridge must copy python/**/* from the CLI output alongside the DLLs.");
+    }
+
+    [SkippableFact]
+    public void MonoBundleCli_IncludesPythonRequirementsTxt()
+    {
+        var cliBundleDir = ResolveBuiltCliBundleDir();
+        Skip.If(cliBundleDir is null, "Mac Catalyst Desktop app bundle has not been built yet.");
+
+        var expectedRequirements = Path.Combine(cliBundleDir, "python", "python-requirements.txt");
+        Assert.True(
+            File.Exists(expectedRequirements),
+            $"Pinned Python requirements file is missing from app bundle. Expected at: {expectedRequirements}.");
+    }
+
+    private static string? ResolveBuiltCliBundleDir()
+    {
+        var repositoryRoot = TryFindRepositoryRoot();
+        if (repositoryRoot is null) return null;
+
+        var desktopBinRoot = Path.Combine(
+            repositoryRoot,
+            "src", "VoxFlow.Desktop", "bin");
+        if (!Directory.Exists(desktopBinRoot)) return null;
+
+        // Prefer the bundle whose CLI bridge was copied most recently. Bundle
+        // dir mtimes don't update when internal files change, so we rank by
+        // the CLI DLL's mtime (refreshed every CopyBundledCliBridge run).
+        var latestBundle = Directory
+            .EnumerateDirectories(desktopBinRoot, "VoxFlow.Desktop.app", SearchOption.AllDirectories)
+            .Select(dir => Path.Combine(dir, "Contents", "MonoBundle", "cli"))
+            .Where(cli => File.Exists(Path.Combine(cli, "VoxFlow.Cli.dll")))
+            .OrderByDescending(cli => File.GetLastWriteTimeUtc(Path.Combine(cli, "VoxFlow.Cli.dll")))
+            .FirstOrDefault();
+
+        return latestBundle;
+    }
+
+    private static string? TryFindRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "VoxFlow.sln")))
+            {
+                return directory.FullName;
+            }
+            directory = directory.Parent;
+        }
+        return null;
+    }
+}

--- a/tests/VoxFlow.Desktop.Tests/DesktopUiComponentTests.cs
+++ b/tests/VoxFlow.Desktop.Tests/DesktopUiComponentTests.cs
@@ -1121,4 +1121,42 @@ public sealed class DesktopUiComponentTests
         File.WriteAllText(configPath, root.ToJsonString(new System.Text.Json.JsonSerializerOptions { WriteIndented = true }));
         return configPath;
     }
+
+    [Fact]
+    public async Task CompleteView_RendersTopBar()
+    {
+        await using var context = DesktopUiTestContext.Create();
+        AppViewModelStateAccessor.SetState(
+            context.ViewModel,
+            currentState: AppState.Complete,
+            transcriptionResult: new TranscribeFileResult(
+                Success: true,
+                DetectedLanguage: "en",
+                ResultFilePath: null,
+                AcceptedSegmentCount: 2,
+                SkippedSegmentCount: 0,
+                Duration: TimeSpan.FromSeconds(5),
+                Warnings: [],
+                TranscriptPreview: "preview"));
+
+        var rendered = await context.RenderAsync<CompleteView>();
+
+        var topbar = rendered.FindElement(e => e.HasClass("topbar"), ".topbar header");
+        Assert.Contains("VoxFlow", topbar.TextContent);
+    }
+
+    [Fact]
+    public async Task FailedView_RendersTopBar()
+    {
+        await using var context = DesktopUiTestContext.Create();
+        AppViewModelStateAccessor.SetState(
+            context.ViewModel,
+            currentState: AppState.Failed,
+            errorMessage: "Something went wrong");
+
+        var rendered = await context.RenderAsync<FailedView>();
+
+        var topbar = rendered.FindElement(e => e.HasClass("topbar"), ".topbar header");
+        Assert.Contains("VoxFlow", topbar.TextContent);
+    }
 }

--- a/tests/VoxFlow.Desktop.Tests/DesktopUiComponentTests.cs
+++ b/tests/VoxFlow.Desktop.Tests/DesktopUiComponentTests.cs
@@ -811,6 +811,30 @@ public sealed class DesktopUiComponentTests
     }
 
     [Fact]
+    public async Task RunningView_ActivityPanel_RendersPulseDotAndStageMessage()
+    {
+        await using var context = DesktopUiTestContext.Create();
+        AppViewModelStateAccessor.SetState(
+            context.ViewModel,
+            currentState: AppState.Running,
+            currentProgress: new ProgressUpdate(
+                ProgressStage.LoadingModel,
+                8,
+                TimeSpan.FromSeconds(3),
+                null));
+
+        var rendered = await context.RenderAsync<RunningView>();
+
+        var panel = rendered.FindElement(
+            e => e.HasClass("activity-panel"),
+            ".activity-panel");
+        Assert.Contains("loading model", panel.TextContent, StringComparison.OrdinalIgnoreCase);
+
+        var pulseDots = rendered.FindElements(e => e.HasClass("activity-pulse-dot"));
+        Assert.Single(pulseDots);
+    }
+
+    [Fact]
     public async Task RunningView_ProgressBar_HasAccessibilityAttributes()
     {
         await using var context = DesktopUiTestContext.Create();

--- a/tests/VoxFlow.Desktop.Tests/DesktopUiComponentTests.cs
+++ b/tests/VoxFlow.Desktop.Tests/DesktopUiComponentTests.cs
@@ -405,7 +405,7 @@ public sealed class DesktopUiComponentTests
         var rendered = await context.RenderAsync<ReadyView>();
 
         Assert.Contains("Audio Transcription", rendered.TextContent);
-        Assert.Contains("M4A, WAV, MP3, AAC, FLAC, OGG, AIFF, MP4", rendered.TextContent);
+        Assert.Contains("M4A · WAV · MP3 · AAC · FLAC · OGG · AIFF · MP4", rendered.TextContent);
     }
 
     [Fact]
@@ -695,7 +695,7 @@ public sealed class DesktopUiComponentTests
 
         var rendered = await context.RenderAsync<ReadyView>();
 
-        Assert.Contains("M4A, WAV, MP3, AAC, FLAC, OGG, AIFF, MP4", rendered.TextContent);
+        Assert.Contains("M4A · WAV · MP3 · AAC · FLAC · OGG · AIFF · MP4", rendered.TextContent);
         Assert.DoesNotContain("upload", rendered.TextContent, StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain("multiple files", rendered.TextContent, StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain("Drop your M4A files", rendered.TextContent);

--- a/tests/VoxFlow.Desktop.Tests/DesktopUiComponentTests.cs
+++ b/tests/VoxFlow.Desktop.Tests/DesktopUiComponentTests.cs
@@ -827,11 +827,11 @@ public sealed class DesktopUiComponentTests
 
         var progressWrapper = rendered.FindElement(
             element => element.Name == "div"
-                       && element.HasClass("phase-ring")
+                       && element.HasClass("phase-ring-stack")
                        && element.Attributes.ContainsKey("role")
                        && element.Attributes.TryGetValue("aria-label", out var label)
                        && label?.ToString() == "Transcription progress",
-            "transcription phase ring with progressbar role");
+            "phase-ring-stack progressbar");
 
         Assert.Equal("progressbar", progressWrapper.Attributes["role"]?.ToString());
         // Transcribing at 45% overall → Transcription-local 50% (banding 0..90)

--- a/tests/VoxFlow.Desktop.Tests/VoxFlow.Desktop.Tests.csproj
+++ b/tests/VoxFlow.Desktop.Tests/VoxFlow.Desktop.Tests.csproj
@@ -16,6 +16,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
   </ItemGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />


### PR DESCRIPTION
## Summary

Phase-2 of the Desktop redesign. Ports the `running-screen.html` design artifact into Blazor and unifies the chrome across every pipeline state.

- **Shared TopBar** (gradient-dot wordmark + optional right slot) now renders on Ready, Running, Complete, and Failed.
- **Settings bottom-sheet** wires the speaker-labeling toggle into a dismissable sheet with a tappable backdrop.
- **Drop zone** rebuilt as a 180x180 purple pad wrapped in two concentric rings. The pre-existing ripple/wave animation around the drop zone is preserved.
- **Pill switch** resized to 40x24 (18px knob) with the accent-purple active state; **Output Format** picker restructured as a 5-column segmented control.
- **PhaseRingStack** replaced with nested concentric arcs (r=92 / r=72 / r=52) in a single 240x240 SVG: one big percent in the center, stage label under it, per-phase color tokens (`--phase-transcription`, `--phase-diarization`, `--phase-merge`) and skipped/failed variants driven by `PhaseStatus`.
- **Activity panel** (pulse dot + monospace message) replaces the old per-ring sub-status + elapsed rows. The caption above the rings now reads as a full sentence ("Transcribing…", "Identifying speakers…", "Writing output…").
- Typography palette shifted to Inter + JetBrains Mono.

## Test plan

- [x] Local full test suite green: Core (334 passed, 7 skipped), McpServer (35), Cli (18), Desktop (143 passed, 2 skipped).
- [x] New Blazor unit tests for SettingsPanel bottom-sheet open/close, PhaseRingStack arc geometry + phase color tokens + skipped token, RunningView Activity panel, and TopBar presence on Complete/Failed.
- [ ] Manual smoke on Mac Catalyst: drop an .m4a and confirm caption/ring animation transitions Transcription → Diarization → Merge, Cancel fades on Complete, Settings sheet opens/closes on Ready.
- [ ] Manual verification that the pre-existing ripple/wave animation on the drop zone still plays.

## Notes

- No changes to Core / Cli / McpServer / pipeline logic. Pure Desktop UI.
- Targets `Local-Speaker-Labeling` per ADR-024 branching strategy.