### PR TITLE
test(speaker-enrichment): remove 30s Task.Delay synchronization (#36)

### DIFF
--- a/tests/VoxFlow.Core.Tests/Services/Diarization/SpeakerEnrichmentServiceTests.cs
+++ b/tests/VoxFlow.Core.Tests/Services/Diarization/SpeakerEnrichmentServiceTests.cs
@@ -228,7 +228,10 @@ public sealed class SpeakerEnrichmentServiceTests
         var runtime = new FakePythonRuntime();
         var sidecar = new FakeDiarizationSidecar(async (_, _, ct) =>
         {
-            await Task.Delay(TimeSpan.FromSeconds(30), ct).ConfigureAwait(false);
+            // Block until the linked CTS (driven by options.TimeoutSeconds) cancels us.
+            // No magic upper bound — if cancellation is broken, the suite-level timeout
+            // is the only safety net, which is what we want a regression to surface.
+            await Task.Delay(Timeout.InfiniteTimeSpan, ct).ConfigureAwait(false);
             return new DiarizationResult(1, Array.Empty<DiarizationSpeaker>(), Array.Empty<DiarizationSegment>());
         });
         var mergeService = new ThrowingSpeakerMergeService();
@@ -257,7 +260,10 @@ public sealed class SpeakerEnrichmentServiceTests
         var sidecar = new FakeDiarizationSidecar(async (_, _, ct) =>
         {
             cts.Cancel();
-            await Task.Delay(TimeSpan.FromSeconds(30), ct).ConfigureAwait(false);
+            // After cts.Cancel() the linked token is already cancellation-requested,
+            // so this throws OperationCanceledException synchronously. Timeout.Infinite
+            // documents the intent ("never return on its own — only via ct").
+            await Task.Delay(Timeout.InfiniteTimeSpan, ct).ConfigureAwait(false);
             return new DiarizationResult(1, Array.Empty<DiarizationSpeaker>(), Array.Empty<DiarizationSegment>());
         });
         var mergeService = new ThrowingSpeakerMergeService();


### PR DESCRIPTION
Closes #36. Sub-PR for Epic #51.

## Summary
- `SpeakerEnrichmentServiceTests.cs:231` and `:260` used `Task.Delay(TimeSpan.FromSeconds(30), ct)` inside fake sidecar callbacks as a "long enough" upper bound while the test waited for the linked timeout CTS / outer token to fire.
- Cancellation propagates today, so wall time was ~1s — but a regression in cancellation propagation would have been masked by the 30s ceiling instead of surfacing against the suite-level timeout.
- Replaced both with `Task.Delay(Timeout.InfiniteTimeSpan, ct)` — same cancellation semantics, no magic duration, intent is now explicit ("block until cancelled").

## Acceptance criteria (from #36)
- [x] No `Task.Delay(TimeSpan.FromSeconds(...))` longer than 1 second remains in `SpeakerEnrichmentServiceTests.cs` (`grep "Task.Delay"` → only `Timeout.InfiniteTimeSpan` matches).
- [x] Both affected tests pass deterministically across **50 consecutive local runs** (passed=50, failed=0, total=167s ≈ 3.3s/run).
- [x] Wall time of `SpeakerEnrichmentService` filter stays at `Duration: 1s` (same as before — the 30s was never reached, just made the intent confusing).
- [x] Full local test suite green: Core 347/347 (RequiresPython filter), CLI 29/29, MCP 39/39.

## Test plan
- [x] `dotnet test … --filter FullyQualifiedName~SpeakerEnrichmentService` — 17/17 pass
- [x] 50× loop per issue's validation script — 50/50 pass
- [x] Full local Core+CLI+MCP suites — all pass
- [ ] CI Linux + macOS green
