### PR TITLE
test+ci: make [SkippableFact] tests emit skip reason loudly + skip-count CI gate (#37)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,11 +48,38 @@ jobs:
       # and a diarization model available, which is out of scope for the default CI image. They
       # are run on machines with the full Python/pyannote environment as part of the Post-Phase-0
       # verification checklist in docs/delivery/local-speaker-labeling/.
+      #
+      # Skip-count gate: with the RequiresPython filter every [SkippableFact] in Core is excluded
+      # (not skipped), so the expected Skipped count for all three Linux projects is 0. Any non-zero
+      # value means a Skip.IfNot/Skip.If guard fired unexpectedly and the SkippableFact's [SKIP] reason
+      # in test output names exactly which one — silent skips on default CI verbosity used to hide
+      # this. See docs/delivery/local-speaker-labeling/phase-1-manual-verification.md for baselines.
       - name: Run core tests
         run: |
-          dotnet test tests/VoxFlow.Core.Tests/VoxFlow.Core.Tests.csproj --no-restore --filter "Category!=RequiresPython" --logger "trx;LogFileName=VoxFlow.Core.Tests.trx"
-          dotnet test tests/VoxFlow.Cli.Tests/VoxFlow.Cli.Tests.csproj --no-restore --logger "trx;LogFileName=VoxFlow.Cli.Tests.trx"
-          dotnet test tests/VoxFlow.McpServer.Tests/VoxFlow.McpServer.Tests.csproj --no-restore --logger "trx;LogFileName=VoxFlow.McpServer.Tests.trx"
+          set -eo pipefail
+          assert_no_skips() {
+            local label="$1" log="$2"
+            local skipped
+            # `|| true` keeps pipefail from aborting if dotnet test ever stops printing
+            # the "Skipped: N" summary line (older runner glitch); empty → treated as 0.
+            skipped=$(grep -oE "Skipped:[[:space:]]+[0-9]+" "$log" | tail -1 | grep -oE "[0-9]+" || true)
+            if [ "${skipped:-0}" != "0" ]; then
+              echo "::error::${label} reported ${skipped} skipped test(s); expected 0. Check the test output above for the [SKIP] reason and the uploaded .trx artifact."
+              exit 1
+            fi
+          }
+
+          core_log=$(mktemp)
+          cli_log=$(mktemp)
+          mcp_log=$(mktemp)
+
+          dotnet test tests/VoxFlow.Core.Tests/VoxFlow.Core.Tests.csproj --no-restore --filter "Category!=RequiresPython" --logger "trx;LogFileName=VoxFlow.Core.Tests.trx" | tee "$core_log"
+          dotnet test tests/VoxFlow.Cli.Tests/VoxFlow.Cli.Tests.csproj --no-restore --logger "trx;LogFileName=VoxFlow.Cli.Tests.trx" | tee "$cli_log"
+          dotnet test tests/VoxFlow.McpServer.Tests/VoxFlow.McpServer.Tests.csproj --no-restore --logger "trx;LogFileName=VoxFlow.McpServer.Tests.trx" | tee "$mcp_log"
+
+          assert_no_skips "VoxFlow.Core.Tests"      "$core_log"
+          assert_no_skips "VoxFlow.Cli.Tests"       "$cli_log"
+          assert_no_skips "VoxFlow.McpServer.Tests" "$mcp_log"
 
       - name: Upload test results
         if: always()
@@ -94,9 +121,27 @@ jobs:
 
       # Real Desktop UI automation is intentionally excluded from default CI because it is slower
       # and depends on a more specialized interactive macOS environment than the headless suite.
+      #
+      # Skip-count gate: the macOS CI build uses `-p:MtouchLink=SdkOnly` to stay compatible with
+      # the runner Xcode, which produces a Mac Catalyst .app that does NOT run CopyBundledCliBridge,
+      # so the two [SkippableFact] DesktopCliBundleTests both skip ("Mac Catalyst Desktop app bundle
+      # has not been built yet."). Expected Skipped: 2 — see docs/delivery/local-speaker-labeling/
+      # phase-1-manual-verification.md. Until the SdkOnly link is replaced and the bridge runs in CI,
+      # this gate freezes the count at 2 so any drift (1, 3, ...) surfaces a real change.
+      # TODO(#37 follow-up): drive Skipped down to 0 by populating the bundle in CI.
       - name: Run desktop tests
         run: |
-          dotnet test tests/VoxFlow.Desktop.Tests/VoxFlow.Desktop.Tests.csproj --no-restore --logger "trx;LogFileName=VoxFlow.Desktop.Tests.trx"
+          set -eo pipefail
+          desktop_log=$(mktemp)
+          dotnet test tests/VoxFlow.Desktop.Tests/VoxFlow.Desktop.Tests.csproj --no-restore --logger "trx;LogFileName=VoxFlow.Desktop.Tests.trx" | tee "$desktop_log"
+
+          expected_skips=2
+          # `|| true` keeps pipefail from aborting if the summary line is missing.
+          skipped=$(grep -oE "Skipped:[[:space:]]+[0-9]+" "$desktop_log" | tail -1 | grep -oE "[0-9]+" || true)
+          if [ "${skipped:-0}" != "$expected_skips" ]; then
+            echo "::error::VoxFlow.Desktop.Tests reported ${skipped} skipped test(s); expected ${expected_skips}. Check the test output above for the [SKIP] reason and the uploaded .trx artifact, then update phase-1-manual-verification.md and this workflow if the drift is intentional."
+            exit 1
+          fi
 
       - name: Upload test results
         if: always()

--- a/docs/delivery/local-speaker-labeling/phase-1-manual-verification.md
+++ b/docs/delivery/local-speaker-labeling/phase-1-manual-verification.md
@@ -34,12 +34,26 @@ dotnet test VoxFlow.sln
 
 Expected: **all tests pass.** You should see roughly:
 
-- `VoxFlow.Core.Tests`: 296 passed, 7 skipped (the skipped tests are `Category=RequiresPython` / real-sidecar integration tests that need pyannote preinstalled — they stay skipped in a clean environment)
-- `VoxFlow.McpServer.Tests`: 35 passed
-- `VoxFlow.Cli.Tests`: 6 passed
-- `VoxFlow.Desktop.Tests`: 70 passed, 2 skipped
+- `VoxFlow.Core.Tests`: ≈340 passed, **7 skipped** (the skipped tests are `Category=RequiresPython` / real-sidecar integration tests that need pyannote preinstalled — they stay skipped in a clean environment)
+- `VoxFlow.McpServer.Tests`: 39 passed
+- `VoxFlow.Cli.Tests`: 29 passed
+- `VoxFlow.Desktop.Tests`: ≈145 passed, **2 skipped** (the two `DesktopCliBundleTests` skip until the Mac Catalyst `.app` bundle is built locally — they pass once the bundle has been produced via Visual Studio for Mac or `dotnet build … -t:Run` from `src/VoxFlow.Desktop/`)
 
 If any test **fails**, stop here and report the failure.
+
+### 1a. Skip-count baselines and the CI gate
+
+Tests under `[SkippableFact]` write their skip reason to the xUnit test-output sink via `LoudSkip.IfNot` / `LoudSkip.If` (see `tests/TestSupport/LoudSkip.cs`). The reason is visible regardless of `--verbosity` — look for lines like `[SKIP] python3 not available on PATH`. The CI workflow (`.github/workflows/ci.yml`) hard-fails the job if a project's `Skipped: N` summary drifts from the documented baseline:
+
+| Job leg | Project | Expected Skipped |
+|---|---|---|
+| Linux `core-hosts` | `VoxFlow.Core.Tests` (with `--filter Category!=RequiresPython`) | **0** — every `[SkippableFact]` in Core is filtered out, not skipped |
+| Linux `core-hosts` | `VoxFlow.Cli.Tests` | **0** — no `[SkippableFact]` callsites |
+| Linux `core-hosts` | `VoxFlow.McpServer.Tests` | **0** — no `[SkippableFact]` callsites |
+| macOS `desktop` | `VoxFlow.Desktop.Tests` | **2** — runner Xcode forces `MtouchLink=SdkOnly`, which produces a Mac Catalyst bundle without the CLI bridge, so both `DesktopCliBundleTests` skip |
+| Local full solution (`dotnet test VoxFlow.sln`, no filter) | All projects | **7 + 2 = 9** — the 7 Core `RequiresPython` tests + the 2 Desktop bundle tests, both classes of skip described above |
+
+Drift = regression. If a count changes, the LoudSkip output names exactly which guard fired; update both this baseline table and the gate in `.github/workflows/ci.yml` only when the change is intentional.
 
 ## 2. Disabled-path regression guard
 

--- a/tests/TestSupport/LoudSkip.cs
+++ b/tests/TestSupport/LoudSkip.cs
@@ -1,0 +1,30 @@
+using Xunit;
+using Xunit.Abstractions;
+
+/// <summary>
+/// Wrapper around <see cref="Skip.IfNot(bool, string)"/> / <see cref="Skip.If(bool, string)"/>
+/// that emits the skip reason to the xUnit test output sink before the underlying
+/// <see cref="SkipException"/> is raised. Plain Skip.IfNot/If only surface the reason
+/// at xUnit-detailed verbosity, so on default-verbosity CI runs silent skips look
+/// like passing tests. Logging upfront keeps the reason visible regardless of verbosity.
+/// </summary>
+internal static class LoudSkip
+{
+    public static void IfNot(ITestOutputHelper output, bool condition, string reason)
+    {
+        if (!condition)
+        {
+            output.WriteLine($"[SKIP] {reason}");
+        }
+        Skip.IfNot(condition, reason);
+    }
+
+    public static void If(ITestOutputHelper output, bool condition, string reason)
+    {
+        if (condition)
+        {
+            output.WriteLine($"[SKIP] {reason}");
+        }
+        Skip.If(condition, reason);
+    }
+}

--- a/tests/TestSupport/LoudSkip.cs
+++ b/tests/TestSupport/LoudSkip.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -7,10 +8,13 @@ using Xunit.Abstractions;
 /// <see cref="SkipException"/> is raised. Plain Skip.IfNot/If only surface the reason
 /// at xUnit-detailed verbosity, so on default-verbosity CI runs silent skips look
 /// like passing tests. Logging upfront keeps the reason visible regardless of verbosity.
+/// The DoesNotReturnIf attributes preserve the null-flow analysis callers get from
+/// the underlying Skip helpers (e.g. "after LoudSkip.If(x is null, ...) the value is
+/// known non-null").
 /// </summary>
 internal static class LoudSkip
 {
-    public static void IfNot(ITestOutputHelper output, bool condition, string reason)
+    public static void IfNot(ITestOutputHelper output, [DoesNotReturnIf(false)] bool condition, string reason)
     {
         if (!condition)
         {
@@ -19,7 +23,7 @@ internal static class LoudSkip
         Skip.IfNot(condition, reason);
     }
 
-    public static void If(ITestOutputHelper output, bool condition, string reason)
+    public static void If(ITestOutputHelper output, [DoesNotReturnIf(true)] bool condition, string reason)
     {
         if (condition)
         {

--- a/tests/VoxFlow.Core.Tests/Services/Diarization/PyannoteSidecarClientIntegrationTests.cs
+++ b/tests/VoxFlow.Core.Tests/Services/Diarization/PyannoteSidecarClientIntegrationTests.cs
@@ -6,6 +6,7 @@ using VoxFlow.Core.Models;
 using VoxFlow.Core.Services.Diarization;
 using VoxFlow.Core.Services.Python;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace VoxFlow.Core.Tests.Services.Diarization;
 
@@ -20,6 +21,13 @@ namespace VoxFlow.Core.Tests.Services.Diarization;
 [Trait("Category", "RequiresPython")]
 public sealed class PyannoteSidecarClientIntegrationTests
 {
+    private readonly ITestOutputHelper _output;
+
+    public PyannoteSidecarClientIntegrationTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
     private static string ScriptPath => Path.Combine(
         AppContext.BaseDirectory, "python", "voxflow_diarize.py");
 
@@ -35,11 +43,11 @@ public sealed class PyannoteSidecarClientIntegrationTests
     [SkippableFact]
     public async Task DiarizeAsync_RealSidecar_SingleSpeakerWav_Returns1Speaker()
     {
-        Skip.IfNot(RequiresPythonOptedIn(), OptInSkipReason);
-        Skip.IfNot(File.Exists(ScriptPath), $"sidecar script missing at {ScriptPath}");
-        Skip.IfNot(await SystemPythonRuntimeReadyAsync(),
+        LoudSkip.IfNot(_output, RequiresPythonOptedIn(), OptInSkipReason);
+        LoudSkip.IfNot(_output, File.Exists(ScriptPath), $"sidecar script missing at {ScriptPath}");
+        LoudSkip.IfNot(_output, await SystemPythonRuntimeReadyAsync(),
             "system python3 not ready (missing or below required 3.10)");
-        Skip.IfNot(File.Exists(SingleSpeakerFixturePath),
+        LoudSkip.IfNot(_output, File.Exists(SingleSpeakerFixturePath),
             "fixture not yet committed; will be enabled in P0.8");
 
         var client = CreateClient();
@@ -55,11 +63,11 @@ public sealed class PyannoteSidecarClientIntegrationTests
     [SkippableFact]
     public async Task DiarizeAsync_RealSidecar_TwoSpeakerWav_Returns2Speakers()
     {
-        Skip.IfNot(RequiresPythonOptedIn(), OptInSkipReason);
-        Skip.IfNot(File.Exists(ScriptPath), $"sidecar script missing at {ScriptPath}");
-        Skip.IfNot(await SystemPythonRuntimeReadyAsync(),
+        LoudSkip.IfNot(_output, RequiresPythonOptedIn(), OptInSkipReason);
+        LoudSkip.IfNot(_output, File.Exists(ScriptPath), $"sidecar script missing at {ScriptPath}");
+        LoudSkip.IfNot(_output, await SystemPythonRuntimeReadyAsync(),
             "system python3 not ready (missing or below required 3.10)");
-        Skip.IfNot(File.Exists(TwoSpeakerFixturePath),
+        LoudSkip.IfNot(_output, File.Exists(TwoSpeakerFixturePath),
             "fixture not yet committed; will be enabled in P0.8");
 
         var client = CreateClient();
@@ -74,11 +82,11 @@ public sealed class PyannoteSidecarClientIntegrationTests
     [SkippableFact]
     public async Task DiarizeAsync_RealSidecar_ThreeSpeakerWav_ReturnsAtLeast3Speakers()
     {
-        Skip.IfNot(RequiresPythonOptedIn(), OptInSkipReason);
-        Skip.IfNot(File.Exists(ScriptPath), $"sidecar script missing at {ScriptPath}");
-        Skip.IfNot(await SystemPythonRuntimeReadyAsync(),
+        LoudSkip.IfNot(_output, RequiresPythonOptedIn(), OptInSkipReason);
+        LoudSkip.IfNot(_output, File.Exists(ScriptPath), $"sidecar script missing at {ScriptPath}");
+        LoudSkip.IfNot(_output, await SystemPythonRuntimeReadyAsync(),
             "system python3 not ready (missing or below required 3.10)");
-        Skip.IfNot(File.Exists(ThreeSpeakerFixturePath),
+        LoudSkip.IfNot(_output, File.Exists(ThreeSpeakerFixturePath),
             "fixture not yet committed; will be enabled in P0.8");
 
         var client = CreateClient();

--- a/tests/VoxFlow.Core.Tests/Services/Python/SidecarScriptContractTests.cs
+++ b/tests/VoxFlow.Core.Tests/Services/Python/SidecarScriptContractTests.cs
@@ -6,6 +6,7 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace VoxFlow.Core.Tests.Services.Python;
 
@@ -19,6 +20,13 @@ namespace VoxFlow.Core.Tests.Services.Python;
 [Trait("Category", "RequiresPython")]
 public sealed class SidecarScriptContractTests
 {
+    private readonly ITestOutputHelper _output;
+
+    public SidecarScriptContractTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
     private static string ScriptPath => Path.Combine(
         AppContext.BaseDirectory, "python", "voxflow_diarize.py");
 
@@ -31,10 +39,10 @@ public sealed class SidecarScriptContractTests
     [SkippableFact]
     public async Task RunAgainstSingleSpeakerWav_ReturnsOkResponse_WithOneSpeaker()
     {
-        Skip.IfNot(RequiresPythonOptedIn(), OptInSkipReason);
-        Skip.IfNot(Python3Available(), "python3 not available on PATH");
-        Skip.IfNot(File.Exists(ScriptPath), $"sidecar script missing at {ScriptPath}");
-        Skip.IfNot(File.Exists(SingleSpeakerFixturePath),
+        LoudSkip.IfNot(_output, RequiresPythonOptedIn(), OptInSkipReason);
+        LoudSkip.IfNot(_output, Python3Available(), "python3 not available on PATH");
+        LoudSkip.IfNot(_output, File.Exists(ScriptPath), $"sidecar script missing at {ScriptPath}");
+        LoudSkip.IfNot(_output, File.Exists(SingleSpeakerFixturePath),
             "fixture not yet committed; will be enabled in P0.8");
 
         var result = await RunSidecarAsync(
@@ -51,10 +59,10 @@ public sealed class SidecarScriptContractTests
     [SkippableFact]
     public async Task RunAgainstTwoSpeakerWav_ReturnsOkResponse_WithTwoSpeakers()
     {
-        Skip.IfNot(RequiresPythonOptedIn(), OptInSkipReason);
-        Skip.IfNot(Python3Available(), "python3 not available on PATH");
-        Skip.IfNot(File.Exists(ScriptPath), $"sidecar script missing at {ScriptPath}");
-        Skip.IfNot(File.Exists(TwoSpeakerFixturePath),
+        LoudSkip.IfNot(_output, RequiresPythonOptedIn(), OptInSkipReason);
+        LoudSkip.IfNot(_output, Python3Available(), "python3 not available on PATH");
+        LoudSkip.IfNot(_output, File.Exists(ScriptPath), $"sidecar script missing at {ScriptPath}");
+        LoudSkip.IfNot(_output, File.Exists(TwoSpeakerFixturePath),
             "fixture not yet committed; will be enabled in P0.8");
 
         var result = await RunSidecarAsync(
@@ -70,9 +78,9 @@ public sealed class SidecarScriptContractTests
     [SkippableFact]
     public async Task RunAgainstMissingWav_ReturnsErrorResponse()
     {
-        Skip.IfNot(RequiresPythonOptedIn(), OptInSkipReason);
-        Skip.IfNot(Python3Available(), "python3 not available on PATH");
-        Skip.IfNot(File.Exists(ScriptPath), $"sidecar script missing at {ScriptPath}");
+        LoudSkip.IfNot(_output, RequiresPythonOptedIn(), OptInSkipReason);
+        LoudSkip.IfNot(_output, Python3Available(), "python3 not available on PATH");
+        LoudSkip.IfNot(_output, File.Exists(ScriptPath), $"sidecar script missing at {ScriptPath}");
 
         var missing = Path.Combine(Path.GetTempPath(), $"voxflow-missing-{Guid.NewGuid():N}.wav");
         var result = await RunSidecarAsync(
@@ -89,9 +97,9 @@ public sealed class SidecarScriptContractTests
     [SkippableFact]
     public async Task RunWithMalformedJsonRequest_ReturnsErrorResponse_AndExitsNonZero()
     {
-        Skip.IfNot(RequiresPythonOptedIn(), OptInSkipReason);
-        Skip.IfNot(Python3Available(), "python3 not available on PATH");
-        Skip.IfNot(File.Exists(ScriptPath), $"sidecar script missing at {ScriptPath}");
+        LoudSkip.IfNot(_output, RequiresPythonOptedIn(), OptInSkipReason);
+        LoudSkip.IfNot(_output, Python3Available(), "python3 not available on PATH");
+        LoudSkip.IfNot(_output, File.Exists(ScriptPath), $"sidecar script missing at {ScriptPath}");
 
         var result = await RunSidecarAsync("{ this is not json");
 

--- a/tests/VoxFlow.Core.Tests/TestSupport/LoudSkipTests.cs
+++ b/tests/VoxFlow.Core.Tests/TestSupport/LoudSkipTests.cs
@@ -1,0 +1,62 @@
+using System.Collections.Generic;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace VoxFlow.Core.Tests.TestSupport;
+
+public sealed class LoudSkipTests
+{
+    [Fact]
+    public void IfNot_ConditionFalse_LogsReason_AndThrowsSkip()
+    {
+        var fake = new RecordingTestOutputHelper();
+
+        var ex = Assert.Throws<SkipException>(() =>
+            LoudSkip.IfNot(fake, condition: false, reason: "missing fixture"));
+
+        Assert.Contains("[SKIP] missing fixture", fake.Lines);
+        Assert.Equal("missing fixture", ex.Message);
+    }
+
+    [Fact]
+    public void IfNot_ConditionTrue_NoOutput_NoThrow()
+    {
+        var fake = new RecordingTestOutputHelper();
+
+        LoudSkip.IfNot(fake, condition: true, reason: "should not appear");
+
+        Assert.Empty(fake.Lines);
+    }
+
+    [Fact]
+    public void If_ConditionTrue_LogsReason_AndThrowsSkip()
+    {
+        var fake = new RecordingTestOutputHelper();
+
+        var ex = Assert.Throws<SkipException>(() =>
+            LoudSkip.If(fake, condition: true, reason: "bundle absent"));
+
+        Assert.Contains("[SKIP] bundle absent", fake.Lines);
+        Assert.Equal("bundle absent", ex.Message);
+    }
+
+    [Fact]
+    public void If_ConditionFalse_NoOutput_NoThrow()
+    {
+        var fake = new RecordingTestOutputHelper();
+
+        LoudSkip.If(fake, condition: false, reason: "should not appear");
+
+        Assert.Empty(fake.Lines);
+    }
+
+    private sealed class RecordingTestOutputHelper : ITestOutputHelper
+    {
+        public List<string> Lines { get; } = new();
+
+        public void WriteLine(string message) => Lines.Add(message);
+
+        public void WriteLine(string format, params object[] args)
+            => Lines.Add(string.Format(format, args));
+    }
+}

--- a/tests/VoxFlow.Desktop.Tests/DesktopCliBundleTests.cs
+++ b/tests/VoxFlow.Desktop.Tests/DesktopCliBundleTests.cs
@@ -1,14 +1,22 @@
 using Xunit;
+using Xunit.Abstractions;
 
 namespace VoxFlow.Desktop.Tests;
 
 public sealed class DesktopCliBundleTests
 {
+    private readonly ITestOutputHelper _output;
+
+    public DesktopCliBundleTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
     [SkippableFact]
     public void MonoBundleCli_IncludesPyannoteSidecarScript()
     {
         var cliBundleDir = ResolveBuiltCliBundleDir();
-        Skip.If(cliBundleDir is null, "Mac Catalyst Desktop app bundle has not been built yet.");
+        LoudSkip.If(_output, cliBundleDir is null, "Mac Catalyst Desktop app bundle has not been built yet.");
 
         var expectedScript = Path.Combine(cliBundleDir, "python", "voxflow_diarize.py");
         Assert.True(
@@ -21,7 +29,7 @@ public sealed class DesktopCliBundleTests
     public void MonoBundleCli_IncludesPythonRequirementsTxt()
     {
         var cliBundleDir = ResolveBuiltCliBundleDir();
-        Skip.If(cliBundleDir is null, "Mac Catalyst Desktop app bundle has not been built yet.");
+        LoudSkip.If(_output, cliBundleDir is null, "Mac Catalyst Desktop app bundle has not been built yet.");
 
         var expectedRequirements = Path.Combine(cliBundleDir, "python", "python-requirements.txt");
         Assert.True(

--- a/tests/VoxFlow.Desktop.Tests/VoxFlow.Desktop.Tests.csproj
+++ b/tests/VoxFlow.Desktop.Tests/VoxFlow.Desktop.Tests.csproj
@@ -35,6 +35,9 @@
     <RazorComponent Include="..\..\src\VoxFlow.Desktop\Components\**\*.razor" Link="Components\%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\TestSupport\LoudSkip.cs" Link="TestSupport\LoudSkip.cs" />
+  </ItemGroup>
+  <ItemGroup>
     <Compile Include="..\..\src\VoxFlow.Desktop\ViewModels\AppViewModel.cs" Link="ViewModels\AppViewModel.cs" />
     <Compile Include="..\..\src\VoxFlow.Desktop\ViewModels\PhaseProgressTracker.cs" Link="ViewModels\PhaseProgressTracker.cs" />
     <Compile Include="..\..\src\VoxFlow.Desktop\Configuration\DesktopConfigurationService.cs" Link="Configuration\DesktopConfigurationService.cs" />


### PR DESCRIPTION
Closes #37. Sub-PR for Epic #51.

## Summary
Plain `Skip.IfNot` / `Skip.If` fire silently at default `dotnet test` verbosity — a fixture-missing or runtime-missing skip looks identical to a passing test in CI logs. This PR makes those skips loud in two complementary ways:

1. **`LoudSkip` helper** (`tests/TestSupport/LoudSkip.cs`): drop-in wrapper that writes `[SKIP] {reason}` to the xUnit `ITestOutputHelper` sink before re-raising via `Skip`. The reason now lands in the trx test-result artifact regardless of verbosity, and surfaces in stdout at `--verbosity detailed`. `[DoesNotReturnIf]` flow attributes preserve null-flow analysis at every callsite (e.g. `LoudSkip.If(_, x is null, …)` keeps `x` non-null below).
2. **CI skip-count gate** (`.github/workflows/ci.yml`): every `dotnet test` step is teed into a log, parsed for the `Skipped: N` summary line, and fails the job if `N` drifts from the documented baseline. The error message points at the test output and the uploaded trx artifact.

Migrated callsites: 3 test files, 9 `[SkippableFact]` methods, 28 `Skip.*` callsites in total — all converted to `LoudSkip.*`. Behavior unchanged.

## Acceptance criteria (from #37)
- [x] **Every `Skip.IfNot` callsite logs the reason to test output before skipping.** Migrated `PyannoteSidecarClientIntegrationTests` (12 callsites), `SidecarScriptContractTests` (14 callsites), `DesktopCliBundleTests` (2 callsites). New `LoudSkipTests` covers helper behavior in 4 unit tests (Red-then-Green).
- [x] **Linux Core CI fails (or warns visibly) if Core.Tests reports a skip count differing from the documented baseline.** Linux baseline = 0 across Core/CLI/MCP (RequiresPython filter excludes the SkippableFact tests; CLI and MCP have no SkippableFact callsites). macOS Desktop baseline = 2 (current empirical state — runner Xcode forces `MtouchLink=SdkOnly` which produces a bundle without the CLI bridge; both `DesktopCliBundleTests` skip). The gate fails the job on any drift.
- [x] **`phase-1-manual-verification.md` documents the expected skip counts.** Added a per-leg baseline table (Linux Core/CLI/MCP, macOS Desktop, full local-solution run) with the rationale for each row, plus a pointer to LoudSkip and the rule that drift = regression.
- [x] **Full local test suite green.** Core 351/351 (RequiresPython filter), CLI 29/29, MCP 39/39. New `LoudSkipTests` adds 4 tests (Core 347 → 351). The `[SKIP] {reason}` line is visible in `--verbosity detailed` runs (verified locally) and in trx artifacts.

## Test plan
- [x] `dotnet test … --filter Category!=RequiresPython` — Core 351/351, Skipped: 0
- [x] `dotnet test … VoxFlow.Cli.Tests.csproj` — 29/29, Skipped: 0
- [x] `dotnet test … VoxFlow.McpServer.Tests.csproj` — 39/39, Skipped: 0
- [x] `dotnet test … --filter Category=RequiresPython --logger "console;verbosity=detailed"` — 7 skipped, each with a specific `[SKIP] {reason}` from LoudSkip in test output
- [x] CI gate logic smoke-tested locally against three scenarios (empty log, Skipped:0, Skipped:3) — passes the first two, fails the third with a `::error::` GitHub annotation
- [ ] CI Linux + macOS green with the new gate (this PR validates it)

## Out of scope (follow-up under #37)
- The macOS Desktop CI gate is frozen at `expected_skips=2` because `MtouchLink=SdkOnly` does not run `CopyBundledCliBridge`. A follow-up should populate the bundle in CI so the count drops to 0 and the gate tightens.

## Files changed
- `tests/TestSupport/LoudSkip.cs` (new)
- `tests/VoxFlow.Core.Tests/TestSupport/LoudSkipTests.cs` (new)
- `tests/VoxFlow.Core.Tests/Services/Diarization/PyannoteSidecarClientIntegrationTests.cs`
- `tests/VoxFlow.Core.Tests/Services/Python/SidecarScriptContractTests.cs`
- `tests/VoxFlow.Desktop.Tests/DesktopCliBundleTests.cs`
- `tests/VoxFlow.Desktop.Tests/VoxFlow.Desktop.Tests.csproj` (selective Compile-link of `LoudSkip.cs`)
- `.github/workflows/ci.yml` (skip-count gates on both jobs)
- `docs/delivery/local-speaker-labeling/phase-1-manual-verification.md` (baselines table)
