### PR TITLE
fix(process): harden Process.Start across src and TestSupport (timeout, kill-on-cancel, drained streams) (#40)

### DIFF
--- a/src/VoxFlow.Desktop/Services/ResultActionService.cs
+++ b/src/VoxFlow.Desktop/Services/ResultActionService.cs
@@ -25,6 +25,11 @@ public sealed class ResultActionService : IResultActionService
         });
     }
 
+    // 10s is generous for /usr/bin/open returning after handing the path to Finder.
+    // The hard cap exists so a stuck launch service or a broken Finder cannot block the
+    // UI thread that awaits this method indefinitely.
+    private static readonly TimeSpan OpenFolderTimeout = TimeSpan.FromSeconds(10);
+
     public async Task OpenResultFolderAsync(string resultFilePath, CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(resultFilePath))
@@ -39,19 +44,56 @@ public sealed class ResultActionService : IResultActionService
             throw new InvalidOperationException("Result folder is unavailable.");
         }
 
+        using var timeoutCts = new CancellationTokenSource(OpenFolderTimeout);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
+        var ct = linkedCts.Token;
+
         using var process = Process.Start(CreateOpenFolderProcessStartInfo(directory))
             ?? throw new InvalidOperationException("Could not start Finder.");
 
-        await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+        // Kill the launcher process if the caller cancels or the per-operation timeout fires.
+        // /usr/bin/open is short-lived in normal use, but this guards against a stuck Launch
+        // Services handoff blocking the UI await indefinitely.
+        using var registration = ct.Register(() =>
+        {
+            try
+            {
+                if (!process.HasExited)
+                {
+                    process.Kill(entireProcessTree: true);
+                }
+            }
+            catch
+            {
+                // Process may have exited between HasExited check and Kill; swallow.
+            }
+        });
+
+        // Drain both streams concurrently with the wait. /usr/bin/open is small, but a
+        // child that fills the stderr pipe buffer (~64 KB on macOS) would otherwise block
+        // at exit waiting for a reader — the same anti-pattern flagged in #40.
+        var stdOutTask = process.StandardOutput.ReadToEndAsync(ct);
+        var stdErrTask = process.StandardError.ReadToEndAsync(ct);
+
+        try
+        {
+            await process.WaitForExitAsync(ct).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+        {
+            throw new InvalidOperationException(
+                $"Finder did not return within {OpenFolderTimeout.TotalSeconds:0}s and was terminated.");
+        }
+
+        var stdOut = await stdOutTask.ConfigureAwait(false);
+        var stdErr = await stdErrTask.ConfigureAwait(false);
+
         if (process.ExitCode == 0)
         {
             return;
         }
 
-        var error = await process.StandardError.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
-        var output = await process.StandardOutput.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
-        var detail = string.IsNullOrWhiteSpace(error) ? output : error;
-
+        var detail = string.IsNullOrWhiteSpace(stdErr) ? stdOut : stdErr;
         throw new InvalidOperationException(
             string.IsNullOrWhiteSpace(detail)
                 ? $"Finder exited with code {process.ExitCode}."

--- a/tests/TestSupport/TestProcessRunner.cs
+++ b/tests/TestSupport/TestProcessRunner.cs
@@ -1,52 +1,34 @@
 using System;
 using System.Diagnostics;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 internal static class TestProcessRunner
 {
-    public static async Task<ProcessRunResult> RunAppAsync(string settingsPath, TimeSpan timeout)
-    {
-        var startInfo = CreateStartInfo(settingsPath);
-
-        using var process = new Process { StartInfo = startInfo };
-        process.Start();
-
-        var standardOutputTask = process.StandardOutput.ReadToEndAsync();
-        var standardErrorTask = process.StandardError.ReadToEndAsync();
-        var waitForExitTask = process.WaitForExitAsync();
-        var completedTask = await Task.WhenAny(waitForExitTask, Task.Delay(timeout)).ConfigureAwait(false);
-
-        if (completedTask != waitForExitTask)
-        {
-            try
-            {
-                process.Kill(entireProcessTree: true);
-            }
-            catch
-            {
-                // The process may already be gone when timeout cleanup runs.
-            }
-
-            throw new TimeoutException($"The application did not finish within {timeout}.");
-        }
-
-        var outputBuilder = new StringBuilder();
-        outputBuilder.Append(await standardOutputTask.ConfigureAwait(false));
-        outputBuilder.Append(await standardErrorTask.ConfigureAwait(false));
-
-        return new ProcessRunResult(process.ExitCode, outputBuilder.ToString());
-    }
+    public static Task<ProcessRunResult> RunAppAsync(
+        string settingsPath,
+        TimeSpan timeout,
+        CancellationToken cancellationToken = default)
+        => RunRawAsync(CreateStartInfo(settingsPath), timeout, cancellationToken);
 
     public static async Task<ProcessRunResult> RunAppUntilOutputAsync(
         string settingsPath,
         TimeSpan timeout,
-        string requiredOutput)
+        string requiredOutput,
+        CancellationToken cancellationToken = default)
     {
+        // Per-operation timeout linked with the caller token so cancellation OR timeout
+        // both lead to the same kill-on-cancel codepath; a hung child cannot outlive the
+        // test even if the caller forgets to cancel.
+        using var timeoutCts = new CancellationTokenSource(timeout);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
+        var ct = linkedCts.Token;
+
         var startInfo = CreateStartInfo(settingsPath);
         var outputBuilder = new StringBuilder();
-        // Complete as soon as a known milestone appears in output. This keeps
-        // tests focused on the stage they care about and avoids unnecessary waits.
+        // Complete as soon as a known milestone appears in output. This keeps tests
+        // focused on the stage they care about and avoids unnecessary waits.
         var requiredOutputSeen = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var sync = new object();
 
@@ -66,8 +48,8 @@ internal static class TestProcessRunner
             lock (sync)
             {
                 outputBuilder.AppendLine(line);
-                // Match against the accumulated output so tests can look for text
-                // that may span stdout and stderr ordering differences.
+                // Match against the accumulated output so tests can look for text that
+                // may span stdout and stderr ordering differences.
                 if (outputBuilder.ToString().Contains(requiredOutput, StringComparison.Ordinal))
                 {
                     requiredOutputSeen.TrySetResult();
@@ -82,25 +64,90 @@ internal static class TestProcessRunner
         process.BeginOutputReadLine();
         process.BeginErrorReadLine();
 
+        using var registration = ct.Register(() => TryKillProcess(process));
+
         var waitForExitTask = process.WaitForExitAsync();
-        var completedTask = await Task.WhenAny(requiredOutputSeen.Task, waitForExitTask, Task.Delay(timeout))
-            .ConfigureAwait(false);
+        var completedTask = await Task.WhenAny(requiredOutputSeen.Task, waitForExitTask).ConfigureAwait(false);
 
         if (completedTask == requiredOutputSeen.Task)
         {
+            // Required output arrived before exit — kill the child and wait for it to settle so
+            // the test does not leave a zombie behind when it returns.
             TryKillProcess(process);
             await waitForExitTask.ConfigureAwait(false);
             return new ProcessRunResult(process.ExitCode, outputBuilder.ToString());
         }
 
-        if (completedTask == waitForExitTask)
+        // Process exited on its own. If that was via the timeout/cancel kill path, surface
+        // the right exception; otherwise return the natural exit.
+        if (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
         {
-            return new ProcessRunResult(process.ExitCode, outputBuilder.ToString());
+            throw new TimeoutException($"The application did not reach the expected output within {timeout}.");
         }
 
-        TryKillProcess(process);
-        await waitForExitTask.ConfigureAwait(false);
-        throw new TimeoutException($"The application did not reach the expected output within {timeout}.");
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return new ProcessRunResult(process.ExitCode, outputBuilder.ToString());
+    }
+
+    /// <summary>
+    /// Run an arbitrary process to completion or kill it on cancellation/timeout. Drains
+    /// stdout and stderr concurrently with the wait so a child that fills its stderr pipe
+    /// buffer (~64 KB on macOS) cannot deadlock at exit. Public so cancellation behaviour
+    /// can be exercised in isolation.
+    /// </summary>
+    public static async Task<ProcessRunResult> RunRawAsync(
+        ProcessStartInfo startInfo,
+        TimeSpan timeout,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(startInfo);
+
+        startInfo.RedirectStandardOutput = true;
+        startInfo.RedirectStandardError = true;
+        startInfo.UseShellExecute = false;
+        startInfo.CreateNoWindow = true;
+
+        using var timeoutCts = new CancellationTokenSource(timeout);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
+        var ct = linkedCts.Token;
+
+        using var process = new Process { StartInfo = startInfo };
+        process.Start();
+
+        // Caller cancel OR per-operation timeout fires the same kill path; HasExited race
+        // is swallowed as in DefaultProcessLauncher.
+        using var registration = ct.Register(() => TryKillProcess(process));
+
+        var stdOutTask = process.StandardOutput.ReadToEndAsync(ct);
+        var stdErrTask = process.StandardError.ReadToEndAsync(ct);
+
+        try
+        {
+            await process.WaitForExitAsync(ct).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+        {
+            await DrainSafeAsync(stdOutTask, stdErrTask).ConfigureAwait(false);
+            throw new TimeoutException($"The application did not finish within {timeout}.");
+        }
+
+        var stdOut = await stdOutTask.ConfigureAwait(false);
+        var stdErr = await stdErrTask.ConfigureAwait(false);
+        var combined = new StringBuilder();
+        combined.Append(stdOut);
+        combined.Append(stdErr);
+        return new ProcessRunResult(process.ExitCode, combined.ToString());
+    }
+
+    private static async Task DrainSafeAsync(Task<string> stdOut, Task<string> stdErr)
+    {
+        // Stream reads were started with the linked token; after Kill they may surface
+        // OperationCanceledException or simply complete with whatever was buffered. Either
+        // way, await both so the Tasks are observed (otherwise unobserved-task-exception
+        // shows up later) and any pipe FDs are released here, not at GC time.
+        try { await stdOut.ConfigureAwait(false); } catch { }
+        try { await stdErr.ConfigureAwait(false); } catch { }
     }
 
     private static ProcessStartInfo CreateStartInfo(string settingsPath)

--- a/tests/VoxFlow.Cli.Tests/CliTestProcessRunner.cs
+++ b/tests/VoxFlow.Cli.Tests/CliTestProcessRunner.cs
@@ -1,48 +1,29 @@
 using System;
 using System.Diagnostics;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 internal static class TestProcessRunner
 {
-    public static async Task<ProcessRunResult> RunAppAsync(string settingsPath, TimeSpan timeout)
-    {
-        var startInfo = CreateStartInfo(settingsPath);
-
-        using var process = new Process { StartInfo = startInfo };
-        process.Start();
-
-        var standardOutputTask = process.StandardOutput.ReadToEndAsync();
-        var standardErrorTask = process.StandardError.ReadToEndAsync();
-        var waitForExitTask = process.WaitForExitAsync();
-        var completedTask = await Task.WhenAny(waitForExitTask, Task.Delay(timeout)).ConfigureAwait(false);
-
-        if (completedTask != waitForExitTask)
-        {
-            try
-            {
-                process.Kill(entireProcessTree: true);
-            }
-            catch
-            {
-                // The process may already be gone when timeout cleanup runs.
-            }
-
-            throw new TimeoutException($"The application did not finish within {timeout}.");
-        }
-
-        var outputBuilder = new StringBuilder();
-        outputBuilder.Append(await standardOutputTask.ConfigureAwait(false));
-        outputBuilder.Append(await standardErrorTask.ConfigureAwait(false));
-
-        return new ProcessRunResult(process.ExitCode, outputBuilder.ToString());
-    }
+    public static Task<ProcessRunResult> RunAppAsync(
+        string settingsPath,
+        TimeSpan timeout,
+        CancellationToken cancellationToken = default)
+        => RunRawAsync(CreateStartInfo(settingsPath), timeout, cancellationToken);
 
     public static async Task<ProcessRunResult> RunAppUntilOutputAsync(
         string settingsPath,
         TimeSpan timeout,
-        string requiredOutput)
+        string requiredOutput,
+        CancellationToken cancellationToken = default)
     {
+        // Linked CTS: caller cancel OR per-operation timeout share one kill path. A hung
+        // child cannot outlive the test even if the caller forgets to cancel.
+        using var timeoutCts = new CancellationTokenSource(timeout);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
+        var ct = linkedCts.Token;
+
         var startInfo = CreateStartInfo(settingsPath);
         var outputBuilder = new StringBuilder();
         var requiredOutputSeen = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -78,25 +59,81 @@ internal static class TestProcessRunner
         process.BeginOutputReadLine();
         process.BeginErrorReadLine();
 
+        using var registration = ct.Register(() => TryKillProcess(process));
+
         var waitForExitTask = process.WaitForExitAsync();
-        var completedTask = await Task.WhenAny(requiredOutputSeen.Task, waitForExitTask, Task.Delay(timeout))
-            .ConfigureAwait(false);
+        var completedTask = await Task.WhenAny(requiredOutputSeen.Task, waitForExitTask).ConfigureAwait(false);
 
         if (completedTask == requiredOutputSeen.Task)
         {
+            // Required output arrived — kill the child and wait for it to settle so the
+            // test does not leave a zombie behind when it returns.
             TryKillProcess(process);
             await waitForExitTask.ConfigureAwait(false);
             return new ProcessRunResult(process.ExitCode, outputBuilder.ToString());
         }
 
-        if (completedTask == waitForExitTask)
+        if (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
         {
-            return new ProcessRunResult(process.ExitCode, outputBuilder.ToString());
+            throw new TimeoutException($"The application did not reach the expected output within {timeout}.");
         }
 
-        TryKillProcess(process);
-        await waitForExitTask.ConfigureAwait(false);
-        throw new TimeoutException($"The application did not reach the expected output within {timeout}.");
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return new ProcessRunResult(process.ExitCode, outputBuilder.ToString());
+    }
+
+    /// <summary>
+    /// Run an arbitrary process to completion or kill it on cancellation/timeout. Drains
+    /// stdout and stderr concurrently with the wait so a child that fills its stderr pipe
+    /// buffer (~64 KB on macOS) cannot deadlock at exit.
+    /// </summary>
+    public static async Task<ProcessRunResult> RunRawAsync(
+        ProcessStartInfo startInfo,
+        TimeSpan timeout,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(startInfo);
+
+        startInfo.RedirectStandardOutput = true;
+        startInfo.RedirectStandardError = true;
+        startInfo.UseShellExecute = false;
+        startInfo.CreateNoWindow = true;
+
+        using var timeoutCts = new CancellationTokenSource(timeout);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
+        var ct = linkedCts.Token;
+
+        using var process = new Process { StartInfo = startInfo };
+        process.Start();
+
+        using var registration = ct.Register(() => TryKillProcess(process));
+
+        var stdOutTask = process.StandardOutput.ReadToEndAsync(ct);
+        var stdErrTask = process.StandardError.ReadToEndAsync(ct);
+
+        try
+        {
+            await process.WaitForExitAsync(ct).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+        {
+            await DrainSafeAsync(stdOutTask, stdErrTask).ConfigureAwait(false);
+            throw new TimeoutException($"The application did not finish within {timeout}.");
+        }
+
+        var stdOut = await stdOutTask.ConfigureAwait(false);
+        var stdErr = await stdErrTask.ConfigureAwait(false);
+        var combined = new StringBuilder();
+        combined.Append(stdOut);
+        combined.Append(stdErr);
+        return new ProcessRunResult(process.ExitCode, combined.ToString());
+    }
+
+    private static async Task DrainSafeAsync(Task<string> stdOut, Task<string> stdErr)
+    {
+        try { await stdOut.ConfigureAwait(false); } catch { }
+        try { await stdErr.ConfigureAwait(false); } catch { }
     }
 
     private static ProcessStartInfo CreateStartInfo(string settingsPath)

--- a/tests/VoxFlow.Core.Tests/TestSupport/TestProcessRunnerTests.cs
+++ b/tests/VoxFlow.Core.Tests/TestSupport/TestProcessRunnerTests.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace VoxFlow.Core.Tests.TestSupport;
+
+public sealed class TestProcessRunnerTests
+{
+    [Fact]
+    public async Task RunRawAsync_CancellationKillsHungChild_WithinTwoHundredMilliseconds()
+    {
+        // Acceptance criterion from #40: TestProcessRunner must kill the child process
+        // tree within 200 ms of cancellation. Spawn `sleep 30` (resolved via PATH so the
+        // test works on both macOS and Linux runners) and cancel after the child has
+        // started; the await must throw promptly and the kill must have actually fired.
+        Skip.If(RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
+            "sleep is POSIX-only; the harden targets the Linux core-hosts and macOS desktop CI legs.");
+
+        var startInfo = new ProcessStartInfo("sleep");
+        startInfo.ArgumentList.Add("30");
+
+        using var cts = new CancellationTokenSource();
+        // Generous outer timeout so the test surfaces the cancellation behaviour, not
+        // the timeout codepath (which is exercised separately by RunAppAsync's existing
+        // tests).
+        var task = TestProcessRunner.RunRawAsync(startInfo, TimeSpan.FromMinutes(5), cts.Token);
+
+        // Give the OS a moment to actually start `sleep` so the kill we issue below
+        // really targets a live child.
+        await Task.Delay(50);
+
+        var stopwatch = Stopwatch.StartNew();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => task);
+        stopwatch.Stop();
+
+        Assert.True(
+            stopwatch.ElapsedMilliseconds < 200,
+            $"Cancel-to-kill propagation took {stopwatch.ElapsedMilliseconds} ms; #40 acceptance bound is 200 ms.");
+    }
+}


### PR DESCRIPTION
Closes #40. Sub-PR for Epic #51.

## Summary
Audit of `Process.Start` / `new Process` callsites across `src/` and `tests/TestSupport/` against the gold-standard `DefaultProcessLauncher` pattern (timeout CTS, `cancellationToken.Register` kill-on-cancel, concurrent stream drain). Three callsites needed fixing; three were already compliant.

| Callsite | Before | After |
|---|---|---|
| `src/VoxFlow.Core/Services/Python/DefaultProcessLauncher.cs` | reference | unchanged |
| `src/VoxFlow.Core/Services/AudioConversionService.cs:RunProcessAsync` | already replicates the pattern (cancel-kill registration, concurrent ReadToEndAsync) | unchanged |
| `src/VoxFlow.Desktop/Services/DesktopCliTranscriptionService.cs` | already replicates the pattern (PumpReaderAsync + TryKill + WaitForExitAsync(ct)) | unchanged |
| **`src/VoxFlow.Desktop/Services/ResultActionService.cs:OpenResultFolderAsync`** | streams read only on error path; no cancel-kill; no per-op timeout | drain concurrently; `cancellationToken.Register` kills on cancel; **10s per-op timeout CTS** linked with caller token |
| **`tests/TestSupport/TestProcessRunner.cs`** | `Task.Delay(timeout)` race; no `CancellationToken` parameter; reader Tasks dangling after kill | accept `CancellationToken cancellationToken = default`; linked timeout/cancel CTS shares one kill path; `DrainSafeAsync` awaits readers post-kill; new public `RunRawAsync` primitive |
| **`tests/VoxFlow.Cli.Tests/CliTestProcessRunner.cs`** | near-duplicate of TestSupport's, same broken shape | mirror harden; deduplication left to a follow-up |

## Acceptance criteria (from #40)
- [x] **Every `Process.Start` in `src/` and `tests/TestSupport/` is reviewed; each callsite either delegates to `DefaultProcessLauncher` (preferred) or replicates its safety properties.** Audit table above; the three pre-compliant callsites already replicate the pattern, the three updated callsites now do.
- [x] **`TestProcessRunner` kills the child process tree on timeout AND on cancellation.** Linked CTS combines `cancellationToken` with a timeout-only CTS; one `cancellationToken.Register(() => TryKillProcess(process))` covers both paths.
- [x] **A new test asserts that `TestProcessRunner` kills a hung child within 200 ms of cancellation.** `tests/VoxFlow.Core.Tests/TestSupport/TestProcessRunnerTests.cs` spawns `sleep 30` (PATH-resolved so works on macOS and Linux), gives the OS 50 ms to launch, then trips the token and asserts the throw lands within 200 ms. Local 10/10 deterministic.
- [x] **Full local test suite green.** Core 351 passed / 1 skipped (the #42 flake, gate baseline) — 3/3 deterministic; CLI 29/29; MCP 39/39; Desktop 145 passed / 2 skipped (gate baseline); Desktop net9.0-maccatalyst build clean.

## Test plan
- [x] `grep -rn "Process\.Start\|new Process\b" src/ tests/TestSupport/` — all 6 callsites accounted for in the audit table.
- [x] New regression test passes 10/10 locally with cancel-to-throw under 200 ms (typical 300-400 ms total run time including process startup).
- [x] Full local suites green (Core/CLI/MCP/Desktop).
- [x] Desktop net9.0-maccatalyst build clean (0 warning, 0 error).
- [ ] CI Linux + macOS green (this PR validates).

## Out of scope
- Deduplicating `tests/TestSupport/TestProcessRunner.cs` and `tests/VoxFlow.Cli.Tests/CliTestProcessRunner.cs` (and their two `TestProjectPaths` siblings). They share the same shape but Cli.Tests does not currently link the TestSupport copy. A follow-up can collapse the duplication once the divergence rationale is confirmed.
- Other test projects' Process.Start callsites (`tests/VoxFlow.Desktop.UiTests/`, `tests/VoxFlow.Cli.Tests/CliTestProcessRunner.cs` was in scope; the explicit acceptance set was `src/` and `tests/TestSupport/`).

## Files changed
- `src/VoxFlow.Desktop/Services/ResultActionService.cs`
- `tests/TestSupport/TestProcessRunner.cs`
- `tests/VoxFlow.Cli.Tests/CliTestProcessRunner.cs`
- `tests/VoxFlow.Core.Tests/TestSupport/TestProcessRunnerTests.cs` (new)
