### PR TITLE
feat(batch)+test: cancellation + temp-WAV cleanup tests for BatchTranscriptionService + un-skip flake (#42)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,15 +50,11 @@ jobs:
       # verification checklist in docs/delivery/local-speaker-labeling/.
       #
       # Skip-count gate: with the RequiresPython filter every [SkippableFact] in Core is excluded
-      # (not skipped). Today exactly one Core test is skipped on CI: the parallel-flaky
-      # BatchTranscriptionServiceTests.TranscribeBatchAsync_ReportsNestedProgress_ForCurrentFile,
-      # tracked by #42. CLI and MCP have no SkippableFact and no skip-marked tests. Any other
-      # non-baseline value means a Skip.IfNot/Skip.If guard fired unexpectedly and the
-      # SkippableFact's [SKIP] reason in test output names exactly which one — silent skips on
-      # default CI verbosity used to hide this. See docs/delivery/local-speaker-labeling/
-      # phase-1-manual-verification.md for baselines.
-      # TODO(#42): drive Core skip count back to 0 by hardening the BatchTranscriptionService
-      # progress capture and assertion.
+      # (not skipped); CLI and MCP have no SkippableFact callsites. The expected Skipped count
+      # for all three Linux projects is 0. Any non-zero value means a Skip.IfNot/Skip.If guard
+      # fired unexpectedly and the SkippableFact's [SKIP] reason in the test output names which
+      # one — silent skips on default CI verbosity used to hide this. See docs/delivery/
+      # local-speaker-labeling/phase-1-manual-verification.md for baselines.
       - name: Run core tests
         run: |
           set -eo pipefail
@@ -82,7 +78,7 @@ jobs:
           dotnet test tests/VoxFlow.Cli.Tests/VoxFlow.Cli.Tests.csproj --no-restore --logger "trx;LogFileName=VoxFlow.Cli.Tests.trx" | tee "$cli_log"
           dotnet test tests/VoxFlow.McpServer.Tests/VoxFlow.McpServer.Tests.csproj --no-restore --logger "trx;LogFileName=VoxFlow.McpServer.Tests.trx" | tee "$mcp_log"
 
-          assert_skips "VoxFlow.Core.Tests"      "$core_log" 1
+          assert_skips "VoxFlow.Core.Tests"      "$core_log" 0
           assert_skips "VoxFlow.Cli.Tests"       "$cli_log"  0
           assert_skips "VoxFlow.McpServer.Tests" "$mcp_log"  0
 

--- a/docs/delivery/local-speaker-labeling/phase-1-manual-verification.md
+++ b/docs/delivery/local-speaker-labeling/phase-1-manual-verification.md
@@ -47,11 +47,11 @@ Tests under `[SkippableFact]` write their skip reason to the xUnit test-output s
 
 | Job leg | Project | Expected Skipped |
 |---|---|---|
-| Linux `core-hosts` | `VoxFlow.Core.Tests` (with `--filter Category!=RequiresPython`) | **1** — every `[SkippableFact]` is filtered out; the one explicit `[Fact(Skip=…)]` is `BatchTranscriptionServiceTests.TranscribeBatchAsync_ReportsNestedProgress_ForCurrentFile`, parallel-flaky and tracked by #42 |
+| Linux `core-hosts` | `VoxFlow.Core.Tests` (with `--filter Category!=RequiresPython`) | **0** — every `[SkippableFact]` is filtered out, no remaining `[Fact(Skip=…)]` |
 | Linux `core-hosts` | `VoxFlow.Cli.Tests` | **0** — no `[SkippableFact]` callsites |
 | Linux `core-hosts` | `VoxFlow.McpServer.Tests` | **0** — no `[SkippableFact]` callsites |
 | macOS `desktop` | `VoxFlow.Desktop.Tests` | **2** — runner Xcode forces `MtouchLink=SdkOnly`, which produces a Mac Catalyst bundle without the CLI bridge, so both `DesktopCliBundleTests` skip |
-| Local full solution (`dotnet test VoxFlow.sln`, no filter) | All projects | **7 + 1 + 2 = 10** — the 7 Core `RequiresPython` tests + the explicit `BatchTranscriptionService` skip + the 2 Desktop bundle tests |
+| Local full solution (`dotnet test VoxFlow.sln`, no filter) | All projects | **7 + 2 = 9** — the 7 Core `RequiresPython` tests + the 2 Desktop bundle tests |
 
 Drift = regression. If a count changes, the LoudSkip output names exactly which guard fired; update both this baseline table and the gate in `.github/workflows/ci.yml` only when the change is intentional.
 

--- a/src/VoxFlow.Core/Services/BatchTranscriptionService.cs
+++ b/src/VoxFlow.Core/Services/BatchTranscriptionService.cs
@@ -97,9 +97,21 @@ internal sealed class BatchTranscriptionService : IBatchTranscriptionService
         var speakerLabelingEnabled = request.EnableSpeakers ?? options.SpeakerLabeling.Enabled;
 
         // 4. Process each file
+        var cancelled = false;
+        var remainingStartIndex = discoveredFiles.Count;
         for (var i = 0; i < discoveredFiles.Count; i++)
         {
-            cancellationToken.ThrowIfCancellationRequested();
+            if (cancellationToken.IsCancellationRequested)
+            {
+                // Cancellation between files: stop the loop and let the post-loop
+                // block tag every remaining file as Cancelled in the result. This
+                // gives the caller a partial-progress BatchTranscribeResult instead
+                // of a bare OperationCanceledException with no visibility into
+                // which files completed.
+                cancelled = true;
+                remainingStartIndex = i;
+                break;
+            }
             var file = discoveredFiles[i];
 
             if (file.Status == DiscoveryStatus.Skipped)
@@ -204,7 +216,19 @@ internal sealed class BatchTranscriptionService : IBatchTranscriptionService
                     null, fileStopwatch.Elapsed,
                     detectedLanguage));
             }
-            catch (OperationCanceledException) { throw; }
+            catch (OperationCanceledException)
+            {
+                // Mid-file cancellation: record this file as Cancelled and exit the
+                // loop. The temp-WAV cleanup in `finally` still runs so the partially
+                // written WAV does not outlive the run.
+                fileStopwatch.Stop();
+                results.Add(new BatchFileResult(
+                    file.InputPath, file.OutputPath, "Cancelled",
+                    "Batch cancelled during transcription.", fileStopwatch.Elapsed, null));
+                cancelled = true;
+                remainingStartIndex = i + 1;
+                break;
+            }
             catch (Exception ex)
             {
                 fileStopwatch.Stop();
@@ -220,20 +244,42 @@ internal sealed class BatchTranscriptionService : IBatchTranscriptionService
             }
         }
 
+        // Mark every file that was discovered but never reached as Cancelled. This
+        // closes the gap left by the cancellation break above so caller-visible
+        // counts always satisfy succeeded + failed + skipped == TotalFiles.
+        for (var j = remainingStartIndex; j < discoveredFiles.Count; j++)
+        {
+            var remaining = discoveredFiles[j];
+            results.Add(new BatchFileResult(
+                remaining.InputPath, remaining.OutputPath, "Cancelled",
+                "Batch cancelled before this file started.", TimeSpan.Zero, null));
+        }
+
         // The summary writer already speaks the shared file-processing model, so project the batch-specific results once here.
+        // Cancelled buckets under Skipped for the summary file and for the integer
+        // counters: the existing FileProcessingStatus enum has Success/Failed/Skipped
+        // and the BatchTranscribeResult contract is positional, so adding a Cancelled
+        // counter would be a breaking record shape. The string Status preserves the
+        // distinction for callers that need it (Results[*].Status == "Cancelled").
         var fileResults = results.Select(r => new FileProcessingResult(
             r.InputPath, r.OutputPath,
             r.Status switch { "Success" => FileProcessingStatus.Success, "Failed" => FileProcessingStatus.Failed, _ => FileProcessingStatus.Skipped },
             r.ErrorMessage, r.Duration, r.DetectedLanguage)).ToList();
-        await _summaryWriter.WriteAsync(batchOptions.SummaryFilePath, fileResults, cancellationToken);
+        // The summary write itself uses the original (un-linked) cancellation token
+        // so an already-cancelled batch can still flush its partial summary to disk.
+        // Without this, a cancelled run would also lose its summary file.
+        await _summaryWriter.WriteAsync(batchOptions.SummaryFilePath, fileResults, CancellationToken.None);
 
         totalStopwatch.Stop();
         var succeeded = results.Count(r => r.Status == "Success");
         var failed = results.Count(r => r.Status == "Failed");
-        var skipped = results.Count(r => r.Status == "Skipped");
+        var skipped = results.Count(r => r.Status == "Skipped" || r.Status == "Cancelled");
+        var cancelledCount = results.Count(r => r.Status == "Cancelled");
 
-        progress?.Report(new ProgressUpdate(ProgressStage.Complete, 100, totalStopwatch.Elapsed,
-            $"Batch complete: {succeeded} succeeded, {failed} failed, {skipped} skipped"));
+        var completionMessage = cancelled
+            ? $"Batch cancelled: {succeeded} succeeded, {failed} failed, {skipped - cancelledCount} skipped, {cancelledCount} cancelled"
+            : $"Batch complete: {succeeded} succeeded, {failed} failed, {skipped} skipped";
+        progress?.Report(new ProgressUpdate(ProgressStage.Complete, 100, totalStopwatch.Elapsed, completionMessage));
 
         return new BatchTranscribeResult(
             results.Count, succeeded, failed, skipped,

--- a/src/VoxFlow.Core/Services/BatchTranscriptionService.cs
+++ b/src/VoxFlow.Core/Services/BatchTranscriptionService.cs
@@ -309,7 +309,13 @@ internal sealed class BatchTranscriptionService : IBatchTranscriptionService
             return null;
         }
 
-        return new Progress<ProgressUpdate>(update =>
+        // Synchronous IProgress<T> adapter — Progress<T> would queue to
+        // SynchronizationContext/ThreadPool and lose FIFO ordering between
+        // reports, plus it would mean an `await TranscribeBatchAsync` could
+        // return before all per-file progress callbacks have committed (which
+        // makes downstream progress-bar rendering and tests racy). Same shape
+        // as SpeakerEnrichmentService.DelegateProgress<T>.
+        return new DelegateProgress<ProgressUpdate>(update =>
         {
             var filePercent = FileTranscribingStartPercent +
                               ((FileTranscribingEndPercent - FileTranscribingStartPercent) *
@@ -324,6 +330,13 @@ internal sealed class BatchTranscriptionService : IBatchTranscriptionService
                 BatchFileTotal = totalFiles
             });
         });
+    }
+
+    private sealed class DelegateProgress<T> : IProgress<T>
+    {
+        private readonly Action<T> _handler;
+        public DelegateProgress(Action<T> handler) => _handler = handler;
+        public void Report(T value) => _handler(value);
     }
 
     private static void ReportBatchFileProgress(

--- a/tests/VoxFlow.Core.Tests/BatchTranscriptionServiceTests.cs
+++ b/tests/VoxFlow.Core.Tests/BatchTranscriptionServiceTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using VoxFlow.Core.Configuration;
 using VoxFlow.Core.Interfaces;
 using VoxFlow.Core.Models;
@@ -356,15 +357,16 @@ public sealed class BatchTranscriptionServiceTests
         Assert.Equal(0, recordingArtifactWriter.CallCount);
     }
 
-    // Skipped because the test is racy on parallel runners: BatchTranscriptionService
-    // reports progress from multiple worker threads and the test asserts presence of a
-    // specific Transcribing-stage update in a plain List<ProgressUpdate>. Two distinct
-    // failure modes have been observed on CI:
-    //   1. "Collection was modified" — concurrent Add during Assert.Contains enumeration.
-    //   2. The Transcribing-stage update is absent from the captured list when the
-    //      production pipeline races past it before the IProgress callback lands.
-    // Issue #42 owns the proper fix (thread-safe capture + deterministic progress contract).
-    [Fact(Skip = "Flaky on parallel runners — race during Assert.Contains and intermittent missing Transcribing-stage update; tracked by #42.")]
+    // Was [Fact(Skip=...)] in PR #55 — the test was flaky on parallel CI runs in two
+    // ways: (1) the underlying List<ProgressUpdate> was being enumerated by Assert.Contains
+    // while a Progress<T> ThreadPool callback was still calling Add, surfacing as "Collection
+    // was modified"; (2) the Transcribing-stage update sometimes hadn't landed by the time
+    // the assertion ran because Progress<T>.Report is asynchronous. SynchronousProgress<T>
+    // calls the handler on the reporting thread inside the production code, so by the time
+    // `await service.TranscribeBatchAsync(...)` returns every progress.Report has already
+    // committed; ConcurrentBag<T> covers the residual case where progress is reported from
+    // multiple worker threads concurrently. Together they make the test deterministic.
+    [Fact]
     public async Task TranscribeBatchAsync_ReportsNestedProgress_ForCurrentFile()
     {
         using var directory = new TemporaryDirectory();
@@ -406,8 +408,8 @@ public sealed class BatchTranscriptionServiceTests
                     DiscoveryStatus.Ready,
                     null)
             ]);
-        var progressUpdates = new List<ProgressUpdate>();
-        var progress = new Progress<ProgressUpdate>(update => progressUpdates.Add(update));
+        var progressUpdates = new ConcurrentBag<ProgressUpdate>();
+        var progress = new SynchronousProgress<ProgressUpdate>(progressUpdates.Add);
 
         var service = new BatchTranscriptionService(
             new StubBatchConfigurationService(settingsPath),
@@ -436,6 +438,17 @@ public sealed class BatchTranscriptionServiceTests
                       update.Message is not null &&
                       update.Message.Contains("[1/1] demo.m4a", StringComparison.Ordinal) &&
                       update.Message.Contains("Transcribing English", StringComparison.Ordinal));
+    }
+
+    // Synchronous IProgress<T>: Progress<T> dispatches callbacks via SynchronizationContext
+    // or ThreadPool, so progressUpdates.Add can race with Assert.Contains' enumeration on
+    // CI. Capturing on the reporting thread is deterministic and exercises the same
+    // production code path. Same shape as SpeakerEnrichmentServiceTests.SynchronousProgress<T>.
+    private sealed class SynchronousProgress<T> : IProgress<T>
+    {
+        private readonly Action<T> _handler;
+        public SynchronousProgress(Action<T> handler) => _handler = handler;
+        public void Report(T value) => _handler(value);
     }
 
     private sealed class StubBatchConfigurationService(string settingsPath) : IConfigurationService

--- a/tests/VoxFlow.Core.Tests/Services/BatchTranscriptionServiceCancellationTests.cs
+++ b/tests/VoxFlow.Core.Tests/Services/BatchTranscriptionServiceCancellationTests.cs
@@ -1,0 +1,391 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using VoxFlow.Core.Configuration;
+using VoxFlow.Core.Interfaces;
+using VoxFlow.Core.Models;
+using VoxFlow.Core.Services;
+using Whisper.net;
+using Xunit;
+
+namespace VoxFlow.Core.Tests.Services;
+
+/// <summary>
+/// Cancellation and temp-WAV cleanup coverage for BatchTranscriptionService.
+/// IAsyncLifetime owns the temp-dir setup/teardown so tests do not have to
+/// orchestrate try/finally Delete blocks of their own (#42 acceptance).
+/// </summary>
+public sealed class BatchTranscriptionServiceCancellationTests : IAsyncLifetime
+{
+    private string _rootDir = null!;
+    private string _inputDir = null!;
+    private string _outputDir = null!;
+    private string _tempDir = null!;
+    private string _settingsPath = null!;
+
+    public Task InitializeAsync()
+    {
+        _rootDir = Path.Combine(Path.GetTempPath(), $"voxflow-batch-cancel-{Guid.NewGuid():N}");
+        _inputDir = Path.Combine(_rootDir, "input");
+        _outputDir = Path.Combine(_rootDir, "output");
+        _tempDir = Path.Combine(_rootDir, "temp");
+        Directory.CreateDirectory(_inputDir);
+        Directory.CreateDirectory(_outputDir);
+        Directory.CreateDirectory(_tempDir);
+
+        _settingsPath = TestSettingsFileFactory.Write(
+            _rootDir,
+            inputFilePath: string.Empty,
+            wavFilePath: string.Empty,
+            resultFilePath: string.Empty,
+            modelFilePath: Path.Combine(_rootDir, "model.bin"),
+            ffmpegExecutablePath: "ffmpeg",
+            processingMode: "batch",
+            batch: new
+            {
+                inputDirectory = _inputDir,
+                outputDirectory = _outputDir,
+                tempDirectory = _tempDir,
+                filePattern = "*.m4a",
+                summaryFilePath = Path.Combine(_outputDir, "summary.txt")
+            });
+
+        return Task.CompletedTask;
+    }
+
+    public Task DisposeAsync()
+    {
+        TryRestoreWritableMode(_tempDir);
+        try
+        {
+            if (Directory.Exists(_rootDir))
+            {
+                Directory.Delete(_rootDir, recursive: true);
+            }
+        }
+        catch
+        {
+            // Test temp dirs are disposable — best-effort cleanup is acceptable.
+        }
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task TranscribeBatchAsync_CancelBetweenFiles_ReturnsPartialResults_RemainingMarkedCancelled()
+    {
+        // Three discovered files. AudioConversion succeeds for file 0 and trips the
+        // shared CTS at the end of file 0's conversion. The loop's between-files
+        // cancellation check then marks files 1 and 2 as Cancelled before they start.
+        var files = BuildDiscoveredFiles("a.m4a", "b.m4a", "c.m4a");
+        using var cts = new CancellationTokenSource();
+        var conversion = new ScriptedAudioConversion(async (index, _, outputPath) =>
+        {
+            await File.WriteAllTextAsync(outputPath, "wav");
+            if (index == 0)
+            {
+                cts.Cancel();
+            }
+        });
+        var service = BuildService(files, conversion);
+
+        var result = await service.TranscribeBatchAsync(
+            new BatchTranscribeRequest(_inputDir, _outputDir, ConfigurationPath: _settingsPath),
+            progress: null,
+            cts.Token);
+
+        Assert.Equal(3, result.TotalFiles);
+        Assert.Equal(1, result.Succeeded);
+        Assert.Equal(0, result.Failed);
+        Assert.Equal(2, result.Skipped); // both Cancelled bucket under Skipped in the integer counters
+        Assert.Equal("Success", result.Results[0].Status);
+        Assert.Equal("Cancelled", result.Results[1].Status);
+        Assert.Equal("Cancelled", result.Results[2].Status);
+        Assert.Contains("cancelled", result.Results[1].ErrorMessage ?? string.Empty, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task TranscribeBatchAsync_CancelDuringFile_DeletesPartialTempWav()
+    {
+        // Two files. AudioConversion writes a partial WAV for file 0 then throws OCE
+        // (simulating a cancellation mid-write). The mid-file catch must record file 0
+        // as Cancelled and the temp-WAV cleanup in `finally` must remove the partial
+        // file so the test directory is left empty.
+        var files = BuildDiscoveredFiles("a.m4a", "b.m4a");
+        var partialWavPath = files[0].TempWavPath;
+        using var cts = new CancellationTokenSource();
+        var conversion = new ScriptedAudioConversion(async (index, _, outputPath) =>
+        {
+            if (index == 0)
+            {
+                await File.WriteAllTextAsync(outputPath, "partial-wav");
+                throw new OperationCanceledException("cancelled mid-file");
+            }
+            await File.WriteAllTextAsync(outputPath, "wav");
+        });
+        var service = BuildService(files, conversion);
+
+        var result = await service.TranscribeBatchAsync(
+            new BatchTranscribeRequest(_inputDir, _outputDir, ConfigurationPath: _settingsPath),
+            progress: null,
+            cts.Token);
+
+        Assert.Equal(2, result.TotalFiles);
+        Assert.Equal(0, result.Succeeded);
+        Assert.Equal("Cancelled", result.Results[0].Status);
+        Assert.Equal("Cancelled", result.Results[1].Status);
+        Assert.False(File.Exists(partialWavPath),
+            $"Partial temp WAV should have been cleaned up by the finally block; still present at {partialWavPath}.");
+    }
+
+    [Fact]
+    public async Task TranscribeBatchAsync_TempWavCleanupFails_BatchCompletesWithoutPropagating()
+    {
+        // POSIX-only: simulate an undeletable temp WAV by writing it inside a directory
+        // whose mode is then dropped to read+execute (no write). File.Delete on the
+        // child raises UnauthorizedAccessException, which CleanupTempWav swallows.
+        // The batch must still complete normally — cleanup failure must not poison the
+        // overall result.
+        if (!OperatingSystem.IsLinux() && !OperatingSystem.IsMacOS())
+        {
+            return; // chmod-style permission tricks are POSIX-only; the test asserts the swallow path.
+        }
+
+        var lockedDir = Path.Combine(_tempDir, "locked");
+        Directory.CreateDirectory(lockedDir);
+        var inputPath = Path.Combine(_inputDir, "demo.m4a");
+        await File.WriteAllTextAsync(inputPath, "stub");
+        var tempWavPath = Path.Combine(lockedDir, "demo.wav");
+        var outputPath = Path.Combine(_outputDir, "demo.txt");
+
+        var files = new List<DiscoveredFile>
+        {
+            new(inputPath, outputPath, tempWavPath, DiscoveryStatus.Ready, null)
+        };
+        var conversion = new ScriptedAudioConversion(async (_, _, wavPath) =>
+        {
+            await File.WriteAllTextAsync(wavPath, "wav");
+            // Drop the parent dir to r-x so File.Delete on the child raises
+            // UnauthorizedAccessException (the path the issue's "permission denied"
+            // scenario targets). DisposeAsync restores write perms before teardown.
+            // The OS check below makes the analyzer happy across the lambda boundary;
+            // the test method itself returns above on non-POSIX platforms.
+            if (OperatingSystem.IsLinux() || OperatingSystem.IsMacOS())
+            {
+                File.SetUnixFileMode(
+                    lockedDir,
+                    UnixFileMode.UserRead | UnixFileMode.UserExecute |
+                    UnixFileMode.GroupRead | UnixFileMode.GroupExecute |
+                    UnixFileMode.OtherRead | UnixFileMode.OtherExecute);
+            }
+        });
+        var service = BuildService(files, conversion);
+
+        var result = await service.TranscribeBatchAsync(
+            new BatchTranscribeRequest(_inputDir, _outputDir, ConfigurationPath: _settingsPath),
+            progress: null,
+            cancellationToken: CancellationToken.None);
+
+        Assert.Equal(1, result.TotalFiles);
+        Assert.Equal(1, result.Succeeded);
+        Assert.Equal(0, result.Failed);
+        Assert.Equal("Success", result.Results[0].Status);
+        // Cleanup failed silently; the WAV is still in the locked dir and DisposeAsync
+        // will restore perms and clean up the temp tree.
+        Assert.True(File.Exists(tempWavPath), "Cleanup was supposed to fail; the partial WAV should still exist.");
+    }
+
+    private List<DiscoveredFile> BuildDiscoveredFiles(params string[] fileNames)
+    {
+        var list = new List<DiscoveredFile>(fileNames.Length);
+        foreach (var name in fileNames)
+        {
+            var inputPath = Path.Combine(_inputDir, name);
+            var outputPath = Path.Combine(_outputDir, Path.ChangeExtension(name, ".txt"));
+            var tempWavPath = Path.Combine(_tempDir, Path.ChangeExtension(name, ".wav"));
+            File.WriteAllText(inputPath, "stub");
+            list.Add(new DiscoveredFile(inputPath, outputPath, tempWavPath, DiscoveryStatus.Ready, null));
+        }
+        return list;
+    }
+
+    private BatchTranscriptionService BuildService(
+        IReadOnlyList<DiscoveredFile> files,
+        IAudioConversionService conversion)
+    {
+        return new BatchTranscriptionService(
+            new StubBatchConfigurationService(_settingsPath),
+            new AlwaysPassValidationService(),
+            new RecordingFileDiscoveryService(files),
+            conversion,
+            new NullModelService(),
+            new TrivialWavAudioLoader(),
+            new TrivialLanguageSelectionService(),
+            new TouchFileOutputWriter(),
+            new RecordingBatchSummaryWriter(),
+            new NullSpeakerEnrichmentService(),
+            new NullVoxflowArtifactWriter());
+    }
+
+    private static void TryRestoreWritableMode(string dir)
+    {
+        if (!OperatingSystem.IsLinux() && !OperatingSystem.IsMacOS())
+        {
+            return;
+        }
+        try
+        {
+            if (Directory.Exists(dir))
+            {
+                File.SetUnixFileMode(
+                    dir,
+                    UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
+                    UnixFileMode.GroupRead | UnixFileMode.GroupExecute |
+                    UnixFileMode.OtherRead | UnixFileMode.OtherExecute);
+                foreach (var sub in Directory.EnumerateDirectories(dir, "*", SearchOption.AllDirectories))
+                {
+                    File.SetUnixFileMode(
+                        sub,
+                        UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
+                        UnixFileMode.GroupRead | UnixFileMode.GroupExecute |
+                        UnixFileMode.OtherRead | UnixFileMode.OtherExecute);
+                }
+            }
+        }
+        catch
+        {
+            // Best-effort restore; DisposeAsync will surface the rmdir failure if any.
+        }
+    }
+
+    private sealed class ScriptedAudioConversion(Func<int, string, string, Task> script) : IAudioConversionService
+    {
+        private int _index = -1;
+
+        public Task ConvertToWavAsync(
+            string inputPath,
+            string outputPath,
+            TranscriptionOptions options,
+            CancellationToken cancellationToken = default)
+        {
+            var thisIndex = Interlocked.Increment(ref _index);
+            return script(thisIndex, inputPath, outputPath);
+        }
+
+        public Task<bool> ValidateFfmpegAsync(
+            TranscriptionOptions options,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(true);
+    }
+
+    private sealed class StubBatchConfigurationService(string settingsPath) : IConfigurationService
+    {
+        public Task<TranscriptionOptions> LoadAsync(string? configurationPath = null)
+            => Task.FromResult(TranscriptionOptions.LoadFromPath(configurationPath ?? settingsPath));
+
+        public IReadOnlyList<SupportedLanguage> GetSupportedLanguages(string? configurationPath = null)
+            => LoadAsync(configurationPath).GetAwaiter().GetResult().SupportedLanguages;
+    }
+
+    private sealed class AlwaysPassValidationService : IValidationService
+    {
+        public Task<ValidationResult> ValidateAsync(
+            TranscriptionOptions options,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(new ValidationResult(
+                "PASSED",
+                CanStart: true,
+                HasWarnings: false,
+                options.ConfigurationPath,
+                [new ValidationCheck("Settings file", ValidationCheckStatus.Passed, options.ConfigurationPath)]));
+    }
+
+    private sealed class RecordingFileDiscoveryService(IReadOnlyList<DiscoveredFile> files) : IFileDiscoveryService
+    {
+        public IReadOnlyList<DiscoveredFile> DiscoverInputFiles(BatchOptions batchOptions, int? maxFiles = null, string outputExtension = ".txt")
+            => files;
+    }
+
+    private sealed class NullModelService : IModelService
+    {
+        public Task<WhisperFactory> GetOrCreateFactoryAsync(
+            TranscriptionOptions options,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult<WhisperFactory>(null!);
+
+        public ModelInfo InspectModel(TranscriptionOptions options)
+            => new(options.ModelFilePath, options.ModelType, false, null, false, true);
+    }
+
+    private sealed class TrivialWavAudioLoader : IWavAudioLoader
+    {
+        public Task<float[]> LoadSamplesAsync(
+            string wavPath,
+            TranscriptionOptions options,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(new float[16_000]);
+    }
+
+    private sealed class TrivialLanguageSelectionService : ILanguageSelectionService
+    {
+        public Task<LanguageSelectionResult> SelectBestCandidateAsync(
+            WhisperFactory factory,
+            float[] audioSamples,
+            TranscriptionOptions options,
+            IProgress<ProgressUpdate>? progress = null,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(new LanguageSelectionResult(
+                new SupportedLanguage("en", "English", 0),
+                0.9,
+                TimeSpan.FromSeconds(1),
+                [new FilteredSegment(TimeSpan.Zero, TimeSpan.FromSeconds(1), "hello", 0.9)],
+                Array.Empty<SkippedSegment>()));
+    }
+
+    private sealed class TouchFileOutputWriter : IOutputWriter
+    {
+        public Task WriteAsync(
+            string outputPath,
+            IReadOnlyList<FilteredSegment> segments,
+            TranscriptOutputContext context,
+            CancellationToken cancellationToken = default)
+        {
+            File.WriteAllText(outputPath, "out");
+            return Task.CompletedTask;
+        }
+
+        public string BuildOutputText(IReadOnlyList<FilteredSegment> segments, TranscriptOutputContext context)
+            => string.Empty;
+    }
+
+    private sealed class RecordingBatchSummaryWriter : IBatchSummaryWriter
+    {
+        public Task WriteAsync(
+            string summaryPath,
+            IReadOnlyList<FileProcessingResult> results,
+            CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+    }
+
+    private sealed class NullSpeakerEnrichmentService : ISpeakerEnrichmentService
+    {
+        public Task<SpeakerEnrichmentResult> EnrichAsync(
+            string wavPath,
+            IReadOnlyList<FilteredSegment> segments,
+            TranscriptMetadata metadata,
+            SpeakerLabelingOptions options,
+            IProgress<ProgressUpdate>? progress,
+            CancellationToken cancellationToken)
+            => Task.FromResult(SpeakerEnrichmentResult.Empty);
+    }
+
+    private sealed class NullVoxflowArtifactWriter : IVoxflowTranscriptArtifactWriter
+    {
+        public Task WriteAsync(
+            string resultPath,
+            TranscriptDocument document,
+            CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
Closes #42. Sub-PR for Epic #51.

## Summary
Three uncovered paths in `BatchTranscriptionService` (mid-batch cancellation, mid-file cancellation, temp-WAV cleanup failure) plus the parallel-flaky `TranscribeBatchAsync_ReportsNestedProgress_ForCurrentFile` test that PR #55 had to skip to unblock CI. This PR adds the cancellation tests, hardens cancellation semantics, fixes the underlying production race in the per-file progress reporter, un-skips the flaky test, and tightens the CI gate back to `Skipped: 0`.

## Production changes
- **`BatchTranscriptionService.TranscribeBatchAsync`**: replaces `cancellationToken.ThrowIfCancellationRequested()` at the loop top with an `IsCancellationRequested` check that flags `cancelled = true` and breaks out, recording the index of the first unprocessed file. Catches `OperationCanceledException` inside the per-file try block, records the in-flight file as `Status="Cancelled"`, and after the loop walks the remaining files marking each as `Cancelled`. The integer counters bucket `Cancelled` under `Skipped` (positional record — adding a counter would be a breaking shape change); the string `Status` preserves the distinction for callers who want it. The summary writer is invoked with `CancellationToken.None` so a cancelled run still flushes its partial summary to disk.
- **`BatchTranscriptionService.CreateBatchFileProgressReporter`**: replaces the inner `Progress<ProgressUpdate>` adapter with a synchronous `DelegateProgress<T>` (same shape as `SpeakerEnrichmentService.DelegateProgress<T>`). `Progress<T>` queues every per-file progress event to the ThreadPool, which a) loses FIFO ordering between reports, and b) means `await TranscribeBatchAsync(...)` could return before per-file callbacks have committed. The synchronous wrapper makes the callback ordering deterministic and fixes the production-side root cause of the flake.

## New tests
`tests/VoxFlow.Core.Tests/Services/BatchTranscriptionServiceCancellationTests.cs` — class implements xUnit `IAsyncLifetime` so all temp-dir setup/teardown lives in `InitializeAsync` / `DisposeAsync`; no bare `try/finally Delete` in the test bodies (per #42 acceptance):

1. **`Cancel_BetweenFiles_ReturnsPartialResults_RemainingMarkedCancelled`** — three discovered files; the fake conversion succeeds for file 0 then trips the shared CTS. Asserts `1 Success` + `2 Cancelled`, with the right `ErrorMessage`.
2. **`Cancel_DuringFile_DeletesPartialTempWav`** — two files; the fake conversion writes a partial WAV for file 0 then throws `OperationCanceledException`. Asserts the per-file `finally` cleanup deleted the partial WAV (no orphan in the temp dir).
3. **`TempWavCleanup_FailsGracefully_BatchCompletesWithoutPropagating`** — POSIX-only: writes WAV inside a sub-directory, then drops the dir to `r-x` via `File.SetUnixFileMode`, so `File.Delete` raises `UnauthorizedAccessException`. `CleanupTempWav` swallows it; the batch result is `Success` and the failure does not propagate. `DisposeAsync` restores write permissions before teardown.

## Un-skip + flake fix
`BatchTranscriptionServiceTests.TranscribeBatchAsync_ReportsNestedProgress_ForCurrentFile` was `[Fact(Skip="…")]`'d in PR #55 because of two failure modes on parallel CI:

1. **"Collection was modified"** during `Assert.Contains` — concurrent `Add` from a still-pending Progress<T> ThreadPool callback.
2. **Missing Transcribing-stage update** — `Progress<T>.Report` is async, so `await TranscribeBatchAsync` returned before the callback ran.

Production fix above eliminates root cause #2. Test fix swaps `List<ProgressUpdate>` + `Progress<T>` for `ConcurrentBag<ProgressUpdate>` + `SynchronousProgress<T>` to cover the residual case. Verified locally: 20/20 deterministic across the full Core suite, 10/10 in isolation.

## CI gate + doc
- `assert_skips $expected` Linux Core baseline drops from `1` back to `0`. CLI/MCP stay at `0`. macOS Desktop stays at `2` (still pending the bundle-fix follow-up).
- `phase-1-manual-verification.md` baseline table updated: Linux Core `1 → 0`; full local-solution run `10 → 9`.

## Acceptance criteria (from #42)
- [x] **All three new tests added and passing.** Cancel-between-files, Cancel-during-file, TempWav-cleanup-failure-graceful — 3/3 green locally.
- [x] **Each test uses `IAsyncLifetime` for temp-dir setup/teardown — no bare `try/finally Delete`.** Class-level `IAsyncLifetime` owns `_rootDir`, `_inputDir`, `_outputDir`, `_tempDir`, `_settingsPath`. `DisposeAsync` does the cleanup, including `TryRestoreWritableMode` for the chmod test.
- [x] **If the cleanup-failure path requires a small code change in `BatchTranscriptionService` to surface the result, that change is included.** The behaviour we cared about — cleanup failure does not propagate to the caller — was already correct; test #3 codifies it. The cancellation-related code change (Cancelled status surface) IS included.
- [x] **Full local test suite green.** Core 355/355 (20/20 deterministic); CLI 29/29; MCP 39/39; Desktop 145 passed / 2 skipped (gate baseline).

## Test plan
- [x] `dotnet test … VoxFlow.Core.Tests --filter Category!=RequiresPython` — 355/355 (20/20 deterministic across sequential runs)
- [x] Cancellation tests — 3/3
- [x] Un-skipped flaky test — 10/10 in isolation, 20/20 in full suite
- [x] CLI and MCP suites — unchanged, green
- [x] Desktop suite — 145/2-skip (matches the macOS gate baseline)
- [ ] CI Linux + macOS green (this PR validates)

## Files changed
- `src/VoxFlow.Core/Services/BatchTranscriptionService.cs` (Cancelled status + sync `DelegateProgress`)
- `tests/VoxFlow.Core.Tests/Services/BatchTranscriptionServiceCancellationTests.cs` (new)
- `tests/VoxFlow.Core.Tests/BatchTranscriptionServiceTests.cs` (un-skip + thread-safe progress capture)
- `.github/workflows/ci.yml` (Linux Core baseline 1 → 0)
- `docs/delivery/local-speaker-labeling/phase-1-manual-verification.md` (baseline table)
