### PR TITLE
test(desktop-ui): replace hardcoded fixture paths + ad-hoc temp dirs + polling loop (#43)

### DIFF
--- a/tests/TestSupport/TestFixtureLocator.cs
+++ b/tests/TestSupport/TestFixtureLocator.cs
@@ -1,0 +1,54 @@
+using System;
+using System.IO;
+
+/// <summary>
+/// Resolves on-disk fixture paths for tests in a portable, fail-loud way:
+/// 1. <c>VOXFLOW_TEST_FIXTURES_DIR</c> environment variable wins if set.
+/// 2. Otherwise the path is computed relative to the test assembly via
+///    <see cref="TestProjectPaths.RepositoryRoot"/>.
+/// Tests should pass the result to <see cref="LoudSkip.IfNot"/> with a
+/// reason that names the missing path so silent skips never hide a missing
+/// fixture from CI.
+/// </summary>
+internal static class TestFixtureLocator
+{
+    private const string FixturesDirEnvVar = "VOXFLOW_TEST_FIXTURES_DIR";
+
+    /// <summary>
+    /// Resolve a fixture path under the configured fixtures root. Does not
+    /// check existence — callers gate on <see cref="File.Exists"/> via
+    /// <see cref="LoudSkip"/> so the skip reason includes the resolved path.
+    /// </summary>
+    public static string Resolve(params string[] segments)
+    {
+        ArgumentNullException.ThrowIfNull(segments);
+        var root = ResolveFixturesRoot();
+        return segments.Length == 0
+            ? root
+            : Path.Combine(new[] { root }.Concat(segments).ToArray());
+    }
+
+    /// <summary>
+    /// Build a clear skip reason for a missing fixture, including the
+    /// resolved path and how to override it via environment variable.
+    /// </summary>
+    public static string FormatMissingFixtureReason(string resolvedPath)
+        => $"fixture not present at {resolvedPath}; set {FixturesDirEnvVar} to point at a directory that contains the expected files.";
+
+    private static string ResolveFixturesRoot()
+    {
+        var fromEnv = Environment.GetEnvironmentVariable(FixturesDirEnvVar);
+        if (!string.IsNullOrWhiteSpace(fromEnv))
+        {
+            return fromEnv;
+        }
+
+        // Default: <repo>/artifacts/Input — the location the original
+        // hardcoded paths used. Keeping it as the default means a clean
+        // checkout with the optional fixture set still finds the files
+        // without any env-var ceremony, while CI machines that lack the
+        // fixtures get a clear loud-skip message instead of a confusing
+        // "file not found" assertion.
+        return Path.Combine(TestProjectPaths.RepositoryRoot, "artifacts", "Input");
+    }
+}

--- a/tests/TestSupport/TestProjectPaths.cs
+++ b/tests/TestSupport/TestProjectPaths.cs
@@ -8,7 +8,9 @@ internal static class TestProjectPaths
 
     public static string RepositoryRoot => RepositoryRootPath.Value;
 
-    public static string AppProjectPath => Path.Combine(RepositoryRoot, "VoxFlow.csproj");
+    // Default app project path used by the legacy TestProcessRunner.RunAppAsync path.
+    // The CLI is the canonical app entry point in this repo.
+    public static string AppProjectPath => Path.Combine(RepositoryRoot, "src", "VoxFlow.Cli", "VoxFlow.Cli.csproj");
 
     private static string FindRepositoryRoot()
     {
@@ -16,9 +18,11 @@ internal static class TestProjectPaths
 
         while (currentDirectory is not null)
         {
-            // Walk upward from the test output directory until the app project is found.
-            var candidateProjectPath = Path.Combine(currentDirectory.FullName, "VoxFlow.csproj");
-            if (File.Exists(candidateProjectPath))
+            // Walk upward from the test output directory until VoxFlow.sln is found.
+            // (The legacy version of this helper looked for VoxFlow.csproj at the root,
+            //  which has not existed since the project moved to a multi-project solution.)
+            var candidateSolutionPath = Path.Combine(currentDirectory.FullName, "VoxFlow.sln");
+            if (File.Exists(candidateSolutionPath))
             {
                 return currentDirectory.FullName;
             }
@@ -26,6 +30,6 @@ internal static class TestProjectPaths
             currentDirectory = currentDirectory.Parent;
         }
 
-        throw new InvalidOperationException("Could not locate the repository root for tests.");
+        throw new InvalidOperationException("Could not locate the repository root for tests (no VoxFlow.sln found above the test output directory).");
     }
 }

--- a/tests/TestSupport/WaitForCondition.cs
+++ b/tests/TestSupport/WaitForCondition.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+/// <summary>
+/// Tiny polling helper that replaces ad-hoc <c>while (!cond) await Task.Delay(10)</c>
+/// loops in async tests. Polls a predicate at a fixed interval until it returns
+/// true or the timeout elapses. Returns the final value so callers can either
+/// branch or assert on it.
+/// </summary>
+internal static class WaitForCondition
+{
+    /// <summary>
+    /// Poll <paramref name="predicate"/> every <paramref name="pollInterval"/> (default 10 ms)
+    /// up to <paramref name="timeout"/> (default 5 s). Returns true if the predicate became
+    /// true within the timeout, false otherwise.
+    /// </summary>
+    public static async Task<bool> WaitForAsync(
+        Func<bool> predicate,
+        TimeSpan? timeout = null,
+        TimeSpan? pollInterval = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        var effectiveTimeout = timeout ?? TimeSpan.FromSeconds(5);
+        var effectivePoll = pollInterval ?? TimeSpan.FromMilliseconds(10);
+
+        using var timeoutCts = new CancellationTokenSource(effectiveTimeout);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
+
+        while (!predicate())
+        {
+            try
+            {
+                await Task.Delay(effectivePoll, linkedCts.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    throw;
+                }
+                // Timeout fired — predicate never became true within the budget.
+                return predicate();
+            }
+        }
+        return true;
+    }
+}

--- a/tests/VoxFlow.Desktop.Tests/DesktopUiComponentTests.cs
+++ b/tests/VoxFlow.Desktop.Tests/DesktopUiComponentTests.cs
@@ -12,6 +12,14 @@ namespace VoxFlow.Desktop.Tests;
 
 public sealed class DesktopUiComponentTests
 {
+    // Hardcoded POSIX-style paths are non-portable (Windows lacks them). Path.GetTempPath()
+    // resolves to the platform's temp directory at runtime — these helper paths are passed
+    // to mocked services that don't actually touch the filesystem; the helpers exist purely
+    // so assertions and stub data stay platform-agnostic.
+    private static string FakeAudioPath(string fileName) => Path.Combine(Path.GetTempPath(), fileName);
+
+    private static string FakeResultPath(string fileName) => FakeAudioPath(fileName);
+
     [Fact]
     public async Task Routes_WhenInitializationFails_ShowsStartupError_AndRetryRecovers()
     {
@@ -78,11 +86,11 @@ public sealed class DesktopUiComponentTests
         var transcriptionService = new DelegateTranscriptionService((request, _, _) =>
             Task.FromResult(TestTranscriptionFactory.Create(
                 success: true,
-                path: $"/tmp/{Path.GetFileNameWithoutExtension(request.InputPath)}.txt")));
+                path: FakeResultPath($"{Path.GetFileNameWithoutExtension(request.InputPath)}.txt"))));
 
         await using var context = DesktopUiTestContext.Create(transcriptionService: transcriptionService);
         VoxFlow.Desktop.Platform.MacFilePicker.PickAudioFileAsyncHandler =
-            static () => Task.FromResult<string?>("/tmp/interview.m4a");
+            static () => Task.FromResult<string?>(FakeAudioPath("interview.m4a"));
 
         var rendered = await context.RenderAsync<Routes>();
         Assert.Equal(AppState.Ready, context.ViewModel.CurrentState);
@@ -93,7 +101,7 @@ public sealed class DesktopUiComponentTests
             "browse files button");
 
         var delegateTranscriptionService = Assert.IsType<DelegateTranscriptionService>(context.TranscriptionService);
-        Assert.Equal("/tmp/interview.m4a", delegateTranscriptionService.LastFilePath);
+        Assert.Equal(FakeAudioPath("interview.m4a"), delegateTranscriptionService.LastFilePath);
         Assert.Equal(AppState.Complete, context.ViewModel.CurrentState);
         Assert.NotNull(context.ViewModel.TranscriptionResult);
         Assert.True(context.ViewModel.TranscriptionResult!.Success);
@@ -135,7 +143,7 @@ public sealed class DesktopUiComponentTests
 
         await using var context = DesktopUiTestContext.Create(transcriptionService: transcriptionService);
         VoxFlow.Desktop.Platform.MacFilePicker.PickAudioFileAsyncHandler =
-            static () => Task.FromResult<string?>("/tmp/demo.m4a");
+            static () => Task.FromResult<string?>(FakeAudioPath("demo.m4a"));
         var rendered = await context.RenderAsync<Routes>();
 
         await rendered.ClickAsync(
@@ -162,11 +170,11 @@ public sealed class DesktopUiComponentTests
         var transcriptionService = new DelegateTranscriptionService((request, _, _) =>
             Task.FromResult(++attempts == 1
                 ? TestTranscriptionFactory.Create(success: false, warnings: ["retry me"])
-                : TestTranscriptionFactory.Create(success: true, path: $"/tmp/{Path.GetFileNameWithoutExtension(request.InputPath)}.txt")));
+                : TestTranscriptionFactory.Create(success: true, path: FakeResultPath($"{Path.GetFileNameWithoutExtension(request.InputPath)}.txt"))));
 
         await using var context = DesktopUiTestContext.Create(transcriptionService: transcriptionService);
         VoxFlow.Desktop.Platform.MacFilePicker.PickAudioFileAsyncHandler =
-            static () => Task.FromResult<string?>("/tmp/demo.wav");
+            static () => Task.FromResult<string?>(FakeAudioPath("demo.wav"));
         var rendered = await context.RenderAsync<Routes>();
 
         await rendered.ClickAsync(
@@ -183,7 +191,7 @@ public sealed class DesktopUiComponentTests
 
         var delegateTranscriptionService = Assert.IsType<DelegateTranscriptionService>(context.TranscriptionService);
         Assert.Equal(2, attempts);
-        Assert.Equal("/tmp/demo.wav", delegateTranscriptionService.LastFilePath);
+        Assert.Equal(FakeAudioPath("demo.wav"), delegateTranscriptionService.LastFilePath);
         Assert.Equal(AppState.Complete, context.ViewModel.CurrentState);
         Assert.NotNull(context.ViewModel.TranscriptionResult);
         Assert.True(context.ViewModel.TranscriptionResult!.Success);
@@ -197,46 +205,33 @@ public sealed class DesktopUiComponentTests
     {
         var repositoryRoot = Path.GetDirectoryName(ViewModelFactory.ResolveRootSettingsPath())
             ?? throw new InvalidOperationException("Could not resolve repository root.");
-        var inputPath = Path.Combine(repositoryRoot, "artifacts", "Input", fileName);
-        Assert.True(File.Exists(inputPath), $"Expected integration input file to exist: {inputPath}");
+        var inputPath = TestFixtureLocator.Resolve(fileName);
+        Assert.True(File.Exists(inputPath), TestFixtureLocator.FormatMissingFixtureReason(inputPath));
 
-        var tempDir = Path.Combine(Path.GetTempPath(), $"voxflow-ui-real-{Path.GetFileNameWithoutExtension(fileName)}-{Guid.NewGuid():N}");
-        Directory.CreateDirectory(tempDir);
+        // TemporaryDirectory.Dispose handles recursive delete on exit, so the test
+        // body no longer needs a try/finally + bare catch for cleanup.
+        using var tempDir = new TemporaryDirectory();
+        var configPath = WriteSingleFileConfig(repositoryRoot, tempDir.Path, inputPath);
+        await using var context = DesktopUiTestContext.CreateWithRealCore(configPath);
 
-        try
-        {
-            var configPath = WriteSingleFileConfig(repositoryRoot, tempDir, inputPath);
-            await using var context = DesktopUiTestContext.CreateWithRealCore(configPath);
+        VoxFlow.Desktop.Platform.MacFilePicker.PickAudioFileAsyncHandler =
+            () => Task.FromResult<string?>(inputPath);
 
-            VoxFlow.Desktop.Platform.MacFilePicker.PickAudioFileAsyncHandler =
-                () => Task.FromResult<string?>(inputPath);
+        var rendered = await context.RenderAsync<Routes>();
+        Assert.Equal(AppState.Ready, context.ViewModel.CurrentState);
 
-            var rendered = await context.RenderAsync<Routes>();
-            Assert.Equal(AppState.Ready, context.ViewModel.CurrentState);
+        await rendered.ClickAsync(
+            element => element.Name == "button" && element.TextContent == "Choose File",
+            "browse files button");
 
-            await rendered.ClickAsync(
-                element => element.Name == "button" && element.TextContent == "Choose File",
-                "browse files button");
+        var resultFilePath = Path.Combine(tempDir.Path, $"{Path.GetFileNameWithoutExtension(fileName)}.txt");
 
-            var resultFilePath = Path.Combine(tempDir, $"{Path.GetFileNameWithoutExtension(fileName)}.txt");
-
-            Assert.Equal(AppState.Complete, context.ViewModel.CurrentState);
-            Assert.NotNull(context.ViewModel.TranscriptionResult);
-            Assert.True(context.ViewModel.TranscriptionResult!.Success);
-            Assert.Equal(resultFilePath, context.ViewModel.TranscriptionResult.ResultFilePath);
-            Assert.True(File.Exists(resultFilePath), $"Expected result file to exist: {resultFilePath}");
-            Assert.Contains(Path.GetFileName(inputPath), rendered.TextContent);
-        }
-        finally
-        {
-            try
-            {
-                Directory.Delete(tempDir, recursive: true);
-            }
-            catch
-            {
-            }
-        }
+        Assert.Equal(AppState.Complete, context.ViewModel.CurrentState);
+        Assert.NotNull(context.ViewModel.TranscriptionResult);
+        Assert.True(context.ViewModel.TranscriptionResult!.Success);
+        Assert.Equal(resultFilePath, context.ViewModel.TranscriptionResult.ResultFilePath);
+        Assert.True(File.Exists(resultFilePath), $"Expected result file to exist: {resultFilePath}");
+        Assert.Contains(Path.GetFileName(inputPath), rendered.TextContent);
     }
 
     [DesktopRealAudioFact]
@@ -244,44 +239,29 @@ public sealed class DesktopUiComponentTests
     {
         var repositoryRoot = Path.GetDirectoryName(ViewModelFactory.ResolveRootSettingsPath())
             ?? throw new InvalidOperationException("Could not resolve repository root.");
-        var inputPath = Path.Combine(repositoryRoot, "artifacts", "Input", "Test 1.m4a");
-        Assert.True(File.Exists(inputPath), $"Expected integration input file to exist: {inputPath}");
+        var inputPath = TestFixtureLocator.Resolve("Test 1.m4a");
+        Assert.True(File.Exists(inputPath), TestFixtureLocator.FormatMissingFixtureReason(inputPath));
 
-        var tempDir = Path.Combine(Path.GetTempPath(), $"voxflow-ui-ready-{Guid.NewGuid():N}");
-        Directory.CreateDirectory(tempDir);
+        using var tempDir = new TemporaryDirectory();
+        var configPath = WriteSingleFileConfig(repositoryRoot, tempDir.Path, inputPath);
+        await using var context = DesktopUiTestContext.CreateWithRealCore(configPath);
 
-        try
-        {
-            var configPath = WriteSingleFileConfig(repositoryRoot, tempDir, inputPath);
-            await using var context = DesktopUiTestContext.CreateWithRealCore(configPath);
+        VoxFlow.Desktop.Platform.MacFilePicker.PickAudioFileAsyncHandler =
+            () => Task.FromResult<string?>(inputPath);
 
-            VoxFlow.Desktop.Platform.MacFilePicker.PickAudioFileAsyncHandler =
-                () => Task.FromResult<string?>(inputPath);
+        var rendered = await context.RenderAsync<ReadyView>();
 
-            var rendered = await context.RenderAsync<ReadyView>();
+        await rendered.ClickAsync(
+            element => element.Name == "button" && element.TextContent == "Choose File",
+            "browse files button");
 
-            await rendered.ClickAsync(
-                element => element.Name == "button" && element.TextContent == "Choose File",
-                "browse files button");
+        var resultFilePath = Path.Combine(tempDir.Path, "Test 1.txt");
 
-            var resultFilePath = Path.Combine(tempDir, "Test 1.txt");
-
-            Assert.Equal(AppState.Complete, context.ViewModel.CurrentState);
-            Assert.NotNull(context.ViewModel.TranscriptionResult);
-            Assert.True(context.ViewModel.TranscriptionResult!.Success);
-            Assert.Equal(resultFilePath, context.ViewModel.TranscriptionResult.ResultFilePath);
-            Assert.True(File.Exists(resultFilePath), $"Expected result file to exist: {resultFilePath}");
-        }
-        finally
-        {
-            try
-            {
-                Directory.Delete(tempDir, recursive: true);
-            }
-            catch
-            {
-            }
-        }
+        Assert.Equal(AppState.Complete, context.ViewModel.CurrentState);
+        Assert.NotNull(context.ViewModel.TranscriptionResult);
+        Assert.True(context.ViewModel.TranscriptionResult!.Success);
+        Assert.Equal(resultFilePath, context.ViewModel.TranscriptionResult.ResultFilePath);
+        Assert.True(File.Exists(resultFilePath), $"Expected result file to exist: {resultFilePath}");
     }
 
     [Fact]
@@ -317,11 +297,11 @@ public sealed class DesktopUiComponentTests
         var transcriptionService = new DelegateTranscriptionService((request, _, _) =>
             Task.FromResult(TestTranscriptionFactory.Create(
                 success: true,
-                path: $"/tmp/{Path.GetFileNameWithoutExtension(request.InputPath)}.txt")));
+                path: FakeResultPath($"{Path.GetFileNameWithoutExtension(request.InputPath)}.txt"))));
 
         await using var context = DesktopUiTestContext.Create(transcriptionService: transcriptionService);
         VoxFlow.Desktop.Platform.MacFilePicker.PickAudioFileAsyncHandler =
-            static () => Task.FromResult<string?>("/tmp/meeting_01.m4a");
+            static () => Task.FromResult<string?>(FakeAudioPath("meeting_01.m4a"));
 
         var rendered = await context.RenderAsync<Routes>();
 
@@ -348,7 +328,7 @@ public sealed class DesktopUiComponentTests
 
         await using var context = DesktopUiTestContext.Create();
         VoxFlow.Desktop.Platform.MacFilePicker.PickAudioFileAsyncHandler =
-            static () => Task.FromResult<string?>("/tmp/interview.wav");
+            static () => Task.FromResult<string?>(FakeAudioPath("interview.wav"));
         var parameters = ParameterView.FromDictionary(new Dictionary<string, object?>
         {
             [nameof(DropZone.Label)] = "Pick audio",
@@ -363,7 +343,7 @@ public sealed class DesktopUiComponentTests
             element => element.Name == "button" && element.TextContent == "Choose File",
             "browse files button");
 
-        Assert.Equal("/tmp/interview.wav", selectedFile);
+        Assert.Equal(FakeAudioPath("interview.wav"), selectedFile);
         Assert.Contains("Drop audio file here", rendered.TextContent);
     }
 
@@ -420,7 +400,7 @@ public sealed class DesktopUiComponentTests
 
         await using var context = DesktopUiTestContext.Create(transcriptionService: transcriptionService);
         VoxFlow.Desktop.Platform.MacFilePicker.PickAudioFileAsyncHandler =
-            static () => Task.FromResult<string?>("/tmp/long-recording.m4a");
+            static () => Task.FromResult<string?>(FakeAudioPath("long-recording.m4a"));
 
         var rendered = await context.RenderAsync<Routes>();
         Assert.Equal(AppState.Ready, context.ViewModel.CurrentState);
@@ -433,15 +413,12 @@ public sealed class DesktopUiComponentTests
                 "browse files button");
         });
 
-        // Wait until the ViewModel enters Running state
-        var timeout = Task.Delay(TimeSpan.FromSeconds(5));
-        while (context.ViewModel.CurrentState != AppState.Running)
-        {
-            if (timeout.IsCompleted) throw new TimeoutException("ViewModel did not enter Running state.");
-            await Task.Delay(10);
-        }
-
-        Assert.Equal(AppState.Running, context.ViewModel.CurrentState);
+        // Wait until the ViewModel enters Running state. WaitForCondition replaces the
+        // ad-hoc polling loop the test had before; the helper polls at 10 ms with a 5 s
+        // cap and surfaces a clear failure if the predicate never holds.
+        var becameRunning = await WaitForCondition.WaitForAsync(
+            () => context.ViewModel.CurrentState == AppState.Running);
+        Assert.True(becameRunning, "ViewModel did not enter Running state within 5 s.");
 
         // Click Cancel
         context.ViewModel.CancelTranscription();
@@ -460,7 +437,7 @@ public sealed class DesktopUiComponentTests
 
         await using var context = DesktopUiTestContext.Create();
         VoxFlow.Desktop.Platform.MacFilePicker.PickAudioFileAsyncHandler =
-            static () => Task.FromResult<string?>("/tmp/keyboard-test.wav");
+            static () => Task.FromResult<string?>(FakeAudioPath("keyboard-test.wav"));
         var parameters = ParameterView.FromDictionary(new Dictionary<string, object?>
         {
             [nameof(DropZone.OnFileSelected)] = EventCallback.Factory.Create<string>(
@@ -475,7 +452,7 @@ public sealed class DesktopUiComponentTests
             "drop zone div",
             "Enter");
 
-        Assert.Equal("/tmp/keyboard-test.wav", selectedFile);
+        Assert.Equal(FakeAudioPath("keyboard-test.wav"), selectedFile);
     }
 
     [Fact]
@@ -485,7 +462,7 @@ public sealed class DesktopUiComponentTests
 
         await using var context = DesktopUiTestContext.Create();
         VoxFlow.Desktop.Platform.MacFilePicker.PickAudioFileAsyncHandler =
-            static () => Task.FromResult<string?>("/tmp/space-key.wav");
+            static () => Task.FromResult<string?>(FakeAudioPath("space-key.wav"));
         var parameters = ParameterView.FromDictionary(new Dictionary<string, object?>
         {
             [nameof(DropZone.OnFileSelected)] = EventCallback.Factory.Create<string>(
@@ -500,7 +477,7 @@ public sealed class DesktopUiComponentTests
             "drop zone div",
             " ");
 
-        Assert.Equal("/tmp/space-key.wav", selectedFile);
+        Assert.Equal(FakeAudioPath("space-key.wav"), selectedFile);
     }
 
     [Fact]
@@ -510,7 +487,7 @@ public sealed class DesktopUiComponentTests
 
         await using var context = DesktopUiTestContext.Create();
         VoxFlow.Desktop.Platform.MacFilePicker.PickAudioFileAsyncHandler =
-            static () => Task.FromResult<string?>("/tmp/should-not-select.wav");
+            static () => Task.FromResult<string?>(FakeAudioPath("should-not-select.wav"));
         var parameters = ParameterView.FromDictionary(new Dictionary<string, object?>
         {
             [nameof(DropZone.OnFileSelected)] = EventCallback.Factory.Create<string>(
@@ -538,7 +515,7 @@ public sealed class DesktopUiComponentTests
             transcriptionResult: new TranscribeFileResult(
                 Success: true,
                 DetectedLanguage: "en",
-                ResultFilePath: "/tmp/output/result.txt",
+                ResultFilePath: Path.Combine(Path.GetTempPath(), "output", "result.txt"),
                 AcceptedSegmentCount: 5,
                 SkippedSegmentCount: 0,
                 Duration: TimeSpan.FromSeconds(10),
@@ -551,7 +528,7 @@ public sealed class DesktopUiComponentTests
             element => element.Name == "button" && element.TextContent.Contains("Open Folder"),
             "open folder button");
 
-        Assert.Equal(["/tmp/output/result.txt"], context.ResultActionService.OpenedResultPaths);
+        Assert.Equal([Path.Combine(Path.GetTempPath(), "output", "result.txt")], context.ResultActionService.OpenedResultPaths);
     }
 
     [Fact]
@@ -606,7 +583,7 @@ public sealed class DesktopUiComponentTests
         AppViewModelStateAccessor.SetState(
             context.ViewModel,
             currentState: AppState.Running,
-            lastFilePath: "/tmp/audio.m4a");
+            lastFilePath: FakeAudioPath("audio.m4a"));
 
         var rendered = await context.RenderAsync<RunningView>();
 
@@ -664,7 +641,7 @@ public sealed class DesktopUiComponentTests
 
         await using var context = DesktopUiTestContext.Create();
         VoxFlow.Desktop.Platform.MacFilePicker.PickAudioFileAsyncHandler =
-            static () => Task.FromResult<string?>("/tmp/should-not-select.wav");
+            static () => Task.FromResult<string?>(FakeAudioPath("should-not-select.wav"));
         var parameters = ParameterView.FromDictionary(new Dictionary<string, object?>
         {
             [nameof(DropZone.IsDisabled)] = true,
@@ -735,7 +712,7 @@ public sealed class DesktopUiComponentTests
         AppViewModelStateAccessor.SetState(
             context.ViewModel,
             currentState: AppState.Running,
-            lastFilePath: "/tmp/audio.m4a");
+            lastFilePath: FakeAudioPath("audio.m4a"));
 
         var rendered = await context.RenderAsync<RunningView>();
 
@@ -872,7 +849,7 @@ public sealed class DesktopUiComponentTests
             transcriptionResult: new TranscribeFileResult(
                 Success: true,
                 DetectedLanguage: "en",
-                ResultFilePath: "/tmp/result.txt",
+                ResultFilePath: FakeResultPath("result.txt"),
                 AcceptedSegmentCount: 5,
                 SkippedSegmentCount: 0,
                 Duration: TimeSpan.FromSeconds(8),
@@ -971,7 +948,7 @@ public sealed class DesktopUiComponentTests
             transcriptionResult: new TranscribeFileResult(
                 Success: true,
                 DetectedLanguage: "en",
-                ResultFilePath: "/tmp/result.txt",
+                ResultFilePath: FakeResultPath("result.txt"),
                 AcceptedSegmentCount: 5,
                 SkippedSegmentCount: 0,
                 Duration: TimeSpan.FromSeconds(8),
@@ -996,7 +973,7 @@ public sealed class DesktopUiComponentTests
             transcriptionResult: new TranscribeFileResult(
                 Success: true,
                 DetectedLanguage: "en",
-                ResultFilePath: "/tmp/result.voxflow.json",
+                ResultFilePath: FakeResultPath("result.voxflow.json"),
                 AcceptedSegmentCount: 2,
                 SkippedSegmentCount: 0,
                 Duration: TimeSpan.FromSeconds(2),
@@ -1025,7 +1002,7 @@ public sealed class DesktopUiComponentTests
             transcriptionResult: new TranscribeFileResult(
                 Success: true,
                 DetectedLanguage: "en",
-                ResultFilePath: "/tmp/result.txt",
+                ResultFilePath: FakeResultPath("result.txt"),
                 AcceptedSegmentCount: 5,
                 SkippedSegmentCount: 0,
                 Duration: TimeSpan.FromSeconds(8),
@@ -1049,7 +1026,7 @@ public sealed class DesktopUiComponentTests
             transcriptionResult: new TranscribeFileResult(
                 Success: true,
                 DetectedLanguage: "en",
-                ResultFilePath: "/tmp/result.txt",
+                ResultFilePath: FakeResultPath("result.txt"),
                 AcceptedSegmentCount: 5,
                 SkippedSegmentCount: 0,
                 Duration: TimeSpan.FromSeconds(8),
@@ -1073,7 +1050,7 @@ public sealed class DesktopUiComponentTests
             transcriptionResult: new TranscribeFileResult(
                 Success: true,
                 DetectedLanguage: "en",
-                ResultFilePath: "/tmp/result.voxflow.json",
+                ResultFilePath: FakeResultPath("result.voxflow.json"),
                 AcceptedSegmentCount: 1,
                 SkippedSegmentCount: 0,
                 Duration: TimeSpan.FromSeconds(1),

--- a/tests/VoxFlow.Desktop.Tests/VoxFlow.Desktop.Tests.csproj
+++ b/tests/VoxFlow.Desktop.Tests/VoxFlow.Desktop.Tests.csproj
@@ -36,6 +36,10 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\TestSupport\LoudSkip.cs" Link="TestSupport\LoudSkip.cs" />
+    <Compile Include="..\TestSupport\TemporaryDirectory.cs" Link="TestSupport\TemporaryDirectory.cs" />
+    <Compile Include="..\TestSupport\TestProjectPaths.cs" Link="TestSupport\TestProjectPaths.cs" />
+    <Compile Include="..\TestSupport\TestFixtureLocator.cs" Link="TestSupport\TestFixtureLocator.cs" />
+    <Compile Include="..\TestSupport\WaitForCondition.cs" Link="TestSupport\WaitForCondition.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\src\VoxFlow.Desktop\ViewModels\AppViewModel.cs" Link="ViewModels\AppViewModel.cs" />


### PR DESCRIPTION
Closes #43. Sub-PR for Epic #51 — final P1 task.

## Summary
`DesktopUiComponentTests` had three portability and reliability issues called out in #43, plus ~17 magic-string fake input paths that failed the strict `/tmp` grep:

1. **Hardcoded fixture path.** Two real-audio tests resolved fixtures via `Path.Combine(repositoryRoot, "artifacts", "Input", fileName)` — non-portable to checkouts that keep the audio fixtures elsewhere, and the assertion message gave no hint about how to override the location.
2. **Ad-hoc `/tmp/voxflow-ui-real-*` temp dirs + bare `try/finally Delete`.** Cleanup was best-effort; the directory survived if the test crashed before the `finally` ran.
3. **Hand-rolled polling loop.** `Routes_CancelDuringTranscription_ReturnsToReady` polled `ViewModel.CurrentState` with `while (state != Running) await Task.Delay(10)` and a separate `Task.Delay(5s)` for the timeout — flaky on slow CI.
4. **Magic-string `/tmp/foo.m4a` literals** used as stub data for mocked services. They never touched the filesystem at runtime but failed the strict `/tmp` portability grep.

## TestSupport additions
- `tests/TestSupport/TestFixtureLocator.cs` — resolves on-disk fixture paths through the `VOXFLOW_TEST_FIXTURES_DIR` env var, falling back to `<repo>/artifacts/Input`. Pairs with `FormatMissingFixtureReason` for clear skip messages that include the resolved path and the override mechanism.
- `tests/TestSupport/WaitForCondition.cs` — small async polling helper. Polls a predicate at 10 ms with a 5 s default cap; returns the predicate value so callers branch or assert.
- `tests/TestSupport/TestProjectPaths.cs` (fix) — the legacy version walked the directory tree looking for a `VoxFlow.csproj` at the repository root, but the project has been a multi-project solution for a while now. Switch the lookup to `VoxFlow.sln` and point `AppProjectPath` at `src/VoxFlow.Cli/VoxFlow.Cli.csproj`. The legacy helper was unused by tests that actually run; linking it into Desktop.Tests for #43 surfaced the broken state.

## DesktopUiComponentTests changes
- Real-audio tests use `TestFixtureLocator.Resolve(...)` for fixture paths and `TestFixtureLocator.FormatMissingFixtureReason` for the defensive `Assert.True` message. The `[DesktopRealAudio*]` attribute remains the primary skip gate (env-var opt-in plus fixture presence check); the body now reflects the same locator default.
- `TemporaryDirectory` (existing TestSupport helper) replaces the ad-hoc temp-dir + try/finally cleanup. `using var` guarantees deletion on exit, including crashes.
- `Routes_CancelDuringTranscription_ReturnsToReady` uses `WaitForCondition.WaitForAsync(() => CurrentState == Running)`.
- ~17 magic-string fake paths go through new private `FakeAudioPath` / `FakeResultPath` helpers that wrap `Path.Combine(Path.GetTempPath(), ...)`. Strings stay byte-identical at runtime on POSIX hosts but the file no longer hard-codes "/tmp" anywhere.
- `Desktop.Tests.csproj` selectively links the four TestSupport files (`LoudSkip` was already linked from #37, plus new `TemporaryDirectory`, `TestProjectPaths`, `TestFixtureLocator`, `WaitForCondition`).

## Acceptance criteria (from #43)
- [x] **No hardcoded `/tmp` or `artifacts/Input/` literal in `DesktopUiComponentTests.cs`.** `grep -nE "/tmp|artifacts/Input"` returns 0 matches.
- [x] **No `try/finally { Directory.Delete; } catch { }` in the file.** `grep -n Directory.Delete` returns 0 matches.
- [x] **No `while ... await Task.Delay(10)` polling loops.** `grep` confirms.
- [x] **Tests pass on a clean clone where fixtures live in the expected location, and skip loudly otherwise.** Default behaviour unchanged (resolves to `<repo>/artifacts/Input`); `VOXFLOW_TEST_FIXTURES_DIR` overrides; `FormatMissingFixtureReason` names the resolved path and the env var.
- [x] **Full local test suite green.** Desktop 145 passed / 2 skipped (matches gate baseline); Core 355/355; CLI 29/29; MCP 39/39.

## Test plan
- [x] Acceptance grep is empty.
- [x] `dotnet test … VoxFlow.Desktop.Tests` — 145 passed / 2 skipped (real-audio tests skip on default env, same as master).
- [x] `dotnet test … VoxFlow.Core.Tests --filter Category!=RequiresPython` — 355/355.
- [x] `dotnet test … VoxFlow.Cli.Tests` — 29/29.
- [x] `dotnet test … VoxFlow.McpServer.Tests` — 39/39.
- [ ] CI Linux + macOS green (this PR validates).

## Out of scope (follow-ups)
- `tests/VoxFlow.Desktop.Tests/DesktopRealAudioTestAttributes.cs` still has hardcoded `artifacts/Input` paths in its skip-reason logic. The issue's literal scope was `DesktopUiComponentTests.cs`, so the attribute stays as-is; once both consumers use `TestFixtureLocator` the env-var override flows end-to-end.
- Deduplicating `tests/TestSupport/TestProjectPaths.cs` (fixed here) and `tests/VoxFlow.Cli.Tests/CliTestProjectPaths.cs` (its diverged sibling). Same shape; the sibling already had the correct lookup path. Tracked alongside the `TestProcessRunner` deduplication noted in #40's PR.

## Files changed
- `tests/TestSupport/TestFixtureLocator.cs` (new)
- `tests/TestSupport/WaitForCondition.cs` (new)
- `tests/TestSupport/TestProjectPaths.cs` (fix lookup)
- `tests/VoxFlow.Desktop.Tests/DesktopUiComponentTests.cs` (refactor)
- `tests/VoxFlow.Desktop.Tests/VoxFlow.Desktop.Tests.csproj` (selective Compile of 4 TestSupport files)
