### PR TITLE
fix(catch): log or justify every catch in src/ + document the rule (#41)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,19 @@ If you cannot run a relevant validation step, say so clearly in the pull request
 - **Every `async void` event handler must wrap its body in a top-level `try`/`catch`** that logs via `DesktopDiagnostics.LogException` (or the equivalent host-specific logger) and surfaces a user-visible error. An exception that escapes an `async void` propagates to the synchronization context and crashes the app — the framework has no Task to observe.
 - **No `.GetAwaiter().GetResult()`, `.Result`, or `.Wait()` in `src/`.** These patterns deadlock under UI synchronization contexts and tie up thread-pool workers. If a sync API needs the result of async work, refactor to expose a sync core that both the async and sync paths call (`DesktopConfigurationService.LoadCore` is the reference example), or use the async-lazy `Lazy<Task<T>>` pattern (`PyannoteSidecarClient.ResponseSchema`).
 
+### Exception handling rules
+
+- **Every `catch` block in `src/` must do one of three things:**
+  1. **Rethrow** (after wrapping or logging) — preserve the inner exception via `throw new ... (..., ex)` so the original stack trace is recoverable.
+  2. **Log** the failure — use the host-specific logger (`DesktopDiagnostics.LogException` in Desktop, `Console.Error.WriteLine` in Core/CLI/MCP until #46 wires `ILogger<T>` at the composition root). The log line should name the operation that failed and surface `ex.GetType().Name` + `ex.Message`.
+  3. **Carry a one-line justification comment** explaining why the exception is intentionally suppressed (e.g. `// Process may have exited between HasExited check and Kill; swallow.`). Comments must justify silence, not just describe what's caught.
+- **No bare `catch { }` blocks** with no body, no comment, and no rethrow. The strict acceptance grep is:
+  ```bash
+  grep -rEn "catch\s*\([^)]*\)\s*\{\s*\}" src/ --include="*.cs"
+  grep -rEn "^\s*catch\s*\{" src/ --include="*.cs"
+  ```
+  Both should return no C# matches. Bare `catch` (no exception type) should narrow to a specific expected exception type whenever possible.
+
 ## Pull Request Expectations
 
 Each pull request should include:

--- a/src/VoxFlow.Core/Services/AudioConversionService.cs
+++ b/src/VoxFlow.Core/Services/AudioConversionService.cs
@@ -140,6 +140,7 @@ internal sealed class AudioConversionService : IAudioConversionService
             }
             catch (InvalidOperationException)
             {
+                // Process may have exited between HasExited check and Kill; swallow.
             }
         });
 

--- a/src/VoxFlow.Core/Services/ModelService.cs
+++ b/src/VoxFlow.Core/Services/ModelService.cs
@@ -62,8 +62,15 @@ internal sealed class ModelService : IModelService, IDisposable
                 using var factory = WhisperFactory.FromPath(options.ModelFilePath);
                 isLoadable = true;
             }
-            catch
+            catch (Exception ex)
             {
+                // Treat any load failure (corrupt file, version mismatch, native load
+                // error) as "needs re-download". Log to stderr so the operator can tell
+                // a corrupt-model recovery from a missing-model first-run; before #46
+                // ships ILogger<T> at the Core composition root, Console.Error is the
+                // only structured sink available without breaking the IModelService API.
+                Console.Error.WriteLine(
+                    $"ModelService.InspectModel: {options.ModelFilePath} failed to load — marking for re-download. {ex.GetType().Name}: {ex.Message}");
                 needsDownload = true;
             }
         }

--- a/src/VoxFlow.Desktop/Services/DesktopCliTranscriptionService.cs
+++ b/src/VoxFlow.Desktop/Services/DesktopCliTranscriptionService.cs
@@ -245,6 +245,7 @@ internal sealed class DesktopCliTranscriptionService : ITranscriptionService
         }
         catch
         {
+            // Process may have exited between HasExited check and Kill; swallow.
         }
     }
 
@@ -259,6 +260,9 @@ internal sealed class DesktopCliTranscriptionService : ITranscriptionService
         }
         catch
         {
+            // Best-effort cleanup of a disposable merged-config snapshot; a stray temp
+            // file is preferable to surfacing an unrelated cleanup error from the
+            // CLI bridge happy path.
         }
     }
 }

--- a/src/VoxFlow.Desktop/ViewModels/AppViewModel.cs
+++ b/src/VoxFlow.Desktop/ViewModels/AppViewModel.cs
@@ -236,6 +236,9 @@ public class AppViewModel : INotifyPropertyChanged
             if (TranscriptionResult.Success)
             {
                 try { await Task.Delay(1500, cts.Token); }
+                // Cancellation during the post-success settle delay: return to Ready
+                // without surfacing as failure. Outer catch handles cancel during the
+                // actual transcription.
                 catch (OperationCanceledException) { GoToReady(); return; }
             }
             CurrentState = TranscriptionResult.Success ? AppState.Complete : AppState.Failed;


### PR DESCRIPTION
Closes #41. Sub-PR for Epic #51 — first P2 task.

## Summary
Audit walked every `catch` block in `src/` (~40 sites across 16 files) and classified each as rethrow / log / silent. Five callsites needed adjustment to satisfy the project rule that no catch may be silent without justification.

## Per-callsite changes

| File:line | Before | After |
|---|---|---|
| `src/VoxFlow.Core/Services/ModelService.cs:65` | bare `catch { needsDownload = true; }` swallowing every load failure (corrupt model, version mismatch, permission) | narrow to `catch (Exception ex)`, log `ex.GetType().Name + ex.Message` to `Console.Error` before flipping the flag — operator can now distinguish corrupt-model recovery from missing-model first-run |
| `src/VoxFlow.Core/Services/AudioConversionService.cs:141` | empty `catch (InvalidOperationException) { }` around `process.Kill` in cancellation registration | add the same "Process may have exited between HasExited check and Kill; swallow." comment used in `DefaultProcessLauncher` |
| `src/VoxFlow.Desktop/Services/DesktopCliTranscriptionService.cs:246,260` | two bare empty `catch { }` blocks in `TryKill` / `TryDelete` | add justification comments matching the existing patterns in `DefaultProcessLauncher` / `DesktopConfigurationService` |
| `src/VoxFlow.Desktop/ViewModels/AppViewModel.cs:239` | one-line action catch (`GoToReady(); return;`) with no comment | add a one-liner explaining intent so the outer "actual transcription cancel" catch is clearly distinct |

`Console.Error.WriteLine` is the agreed bridge in Core/CLI/MCP code paths until #46 (P2) wires `ILogger<T>` at the composition root; once that lands, the `ModelService.InspectModel` log line will graduate to the structured logger.

## CONTRIBUTING.md addition
New "Exception handling rules" subsection codifies the rule for future PRs:

> Every `catch` block in `src/` must do one of three things:
> 1. **Rethrow** (after wrapping or logging) — preserve the inner exception via `throw new ... (..., ex)` so the original stack trace is recoverable.
> 2. **Log** the failure — use the host-specific logger (`DesktopDiagnostics.LogException` in Desktop, `Console.Error.WriteLine` in Core/CLI/MCP until #46 wires `ILogger<T>` at the composition root).
> 3. **Carry a one-line justification comment** explaining why the exception is intentionally suppressed.
>
> No bare `catch { }` blocks with no body, no comment, and no rethrow.

Plus the strict acceptance grep is documented inline so future contributors can self-check before opening a PR.

## Acceptance criteria (from #41)
- [x] **No bare `catch {}` block remains in `src/`** — strict greps return zero C# matches:
  ```
  grep -rEn "catch\s*\([^)]*\)\s*\{\s*\}" src/ --include="*.cs"   # 0 matches
  grep -rEn "^\s*catch\s*\{" src/ --include="*.cs"                # 0 matches
  ```
- [x] **Every catch in `src/` either rethrows, logs, or has a 1-line justification comment** — verified by a Python silent-catch detector that walks every catch block and checks for body / inline comment / immediately-preceding comment line. Reports `OK: no silent catches`.
- [x] **`CONTRIBUTING.md` documents the rule.** New "Exception handling rules" subsection.
- [x] **Full local test suite green** — Core 355/355 (`Category!=RequiresPython`), CLI 29/29, MCP 39/39, Desktop 145/2-skip (matches the gate baselines).

## Test plan
- [x] Strict acceptance greps return 0 C# matches.
- [x] Silent-catch detector returns `OK`.
- [x] Core/CLI/MCP/Desktop suites green.
- [x] Desktop net9.0-maccatalyst build clean (0 warning, 0 error).
- [ ] CI Linux + macOS green (this PR validates).

## Out of scope (follow-ups)
- The `Console.Error.WriteLine` line in `ModelService.InspectModel` is a temporary bridge. When #46 lands `ILogger<T>` at the Core composition root, that line should graduate to the structured logger.
- The audit found ~40 catch sites; nothing else needed adjustment. Future contributions are gated by the new CONTRIBUTING.md rule.

## Files changed
- `src/VoxFlow.Core/Services/ModelService.cs` (narrow + log)
- `src/VoxFlow.Core/Services/AudioConversionService.cs` (justify)
- `src/VoxFlow.Desktop/Services/DesktopCliTranscriptionService.cs` (justify both)
- `src/VoxFlow.Desktop/ViewModels/AppViewModel.cs` (justify)
- `CONTRIBUTING.md` (new "Exception handling rules" section)
