### PR TITLE
feat(core): wire ILogger<T> at composition root + adopt in 5 services (#46 Phase 1)

### DIFF
--- a/src/VoxFlow.Core/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/VoxFlow.Core/DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,5 +1,8 @@
 using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using VoxFlow.Core.Interfaces;
 using VoxFlow.Core.Services;
 using VoxFlow.Core.Services.Diarization;
@@ -14,10 +17,25 @@ public static class ServiceCollectionExtensions
 {
     /// <summary>
     /// Adds the core transcription pipeline services to the supplied service collection.
+    ///
+    /// Logging contract (#46 Phase 1): if the host has called
+    /// <c>services.AddLogging(...)</c> before this method, the host's
+    /// <see cref="ILoggerFactory"/> is reused and Core services receive its
+    /// <see cref="ILogger{T}"/> instances. If logging is not registered,
+    /// the open-generic <see cref="ILogger{T}"/> resolves to
+    /// <see cref="NullLogger{T}"/> — Core services keep working but their
+    /// log lines go nowhere. Phase 2 will roll the same wiring through
+    /// the CLI / MCP / Desktop hosts.
     /// </summary>
     public static IServiceCollection AddVoxFlowCore(this IServiceCollection services)
     {
         ArgumentNullException.ThrowIfNull(services);
+
+        // TryAdd, not Add: if the host has registered AddLogging() with real
+        // providers, that registration wins. This line only fires when nobody
+        // wired logging — the NullLogger fallback keeps tests and minimal hosts
+        // working without forcing them to set up logging up front.
+        services.TryAdd(ServiceDescriptor.Singleton(typeof(ILogger<>), typeof(NullLogger<>)));
 
         services.AddSingleton<IConfigurationService, ConfigurationService>();
         services.AddSingleton<IValidationService, ValidationService>();

--- a/src/VoxFlow.Core/Services/AudioConversionService.cs
+++ b/src/VoxFlow.Core/Services/AudioConversionService.cs
@@ -5,6 +5,8 @@ using System.Globalization;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using VoxFlow.Core.Configuration;
 using VoxFlow.Core.Interfaces;
 
@@ -15,6 +17,13 @@ namespace VoxFlow.Core.Services;
 /// </summary>
 internal sealed class AudioConversionService : IAudioConversionService
 {
+    private readonly ILogger<AudioConversionService> _logger;
+
+    public AudioConversionService(ILogger<AudioConversionService>? logger = null)
+    {
+        _logger = logger ?? NullLogger<AudioConversionService>.Instance;
+    }
+
     /// <summary>
     /// Converts a specific input file into WAV format at the specified output path.
     /// </summary>
@@ -65,6 +74,11 @@ internal sealed class AudioConversionService : IAudioConversionService
 
         if (result.ExitCode != 0)
         {
+            _logger.LogError(
+                "ffmpeg WAV conversion failed for {InputPath} with exit code {ExitCode}: {StandardError}",
+                inputPath,
+                result.ExitCode,
+                result.StandardError);
             throw new InvalidOperationException(
                 $"ffmpeg conversion failed with exit code {result.ExitCode}: {result.StandardError}".Trim());
         }

--- a/src/VoxFlow.Core/Services/BatchTranscriptionService.cs
+++ b/src/VoxFlow.Core/Services/BatchTranscriptionService.cs
@@ -1,6 +1,8 @@
 namespace VoxFlow.Core.Services;
 
 using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using VoxFlow.Core.Configuration;
 using VoxFlow.Core.Interfaces;
 using VoxFlow.Core.Models;
@@ -23,7 +25,11 @@ internal sealed class BatchTranscriptionService : IBatchTranscriptionService
     private readonly IBatchSummaryWriter _summaryWriter;
     private readonly ISpeakerEnrichmentService _speakerEnrichment;
     private readonly IVoxflowTranscriptArtifactWriter _artifactWriter;
+    private readonly ILogger<BatchTranscriptionService> _logger;
 
+    // ILogger<T> is optional (NullLogger fallback) so existing tests that
+    // construct the service directly do not need to thread a logger through.
+    // DI-resolved instances pick up the host's ILogger<T> via ServiceCollectionExtensions.
     public BatchTranscriptionService(
         IConfigurationService configService,
         IValidationService validationService,
@@ -35,7 +41,8 @@ internal sealed class BatchTranscriptionService : IBatchTranscriptionService
         IOutputWriter outputWriter,
         IBatchSummaryWriter summaryWriter,
         ISpeakerEnrichmentService speakerEnrichment,
-        IVoxflowTranscriptArtifactWriter artifactWriter)
+        IVoxflowTranscriptArtifactWriter artifactWriter,
+        ILogger<BatchTranscriptionService>? logger = null)
     {
         ArgumentNullException.ThrowIfNull(configService);
         ArgumentNullException.ThrowIfNull(validationService);
@@ -60,6 +67,7 @@ internal sealed class BatchTranscriptionService : IBatchTranscriptionService
         _summaryWriter = summaryWriter;
         _speakerEnrichment = speakerEnrichment;
         _artifactWriter = artifactWriter;
+        _logger = logger ?? NullLogger<BatchTranscriptionService>.Instance;
     }
 
     public async Task<BatchTranscribeResult> TranscribeBatchAsync(
@@ -232,6 +240,11 @@ internal sealed class BatchTranscriptionService : IBatchTranscriptionService
             catch (Exception ex)
             {
                 fileStopwatch.Stop();
+                _logger.LogError(
+                    ex,
+                    "Batch transcription failed for {InputPath} after {ElapsedMs} ms.",
+                    file.InputPath,
+                    (long)fileStopwatch.Elapsed.TotalMilliseconds);
                 results.Add(new BatchFileResult(
                     file.InputPath, file.OutputPath, "Failed",
                     ex.Message, fileStopwatch.Elapsed, null));

--- a/src/VoxFlow.Core/Services/ModelService.cs
+++ b/src/VoxFlow.Core/Services/ModelService.cs
@@ -2,6 +2,8 @@ using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using VoxFlow.Core.Configuration;
 using VoxFlow.Core.Interfaces;
 using VoxFlow.Core.Models;
@@ -15,8 +17,14 @@ namespace VoxFlow.Core.Services;
 /// </summary>
 internal sealed class ModelService : IModelService, IDisposable
 {
+    private readonly ILogger<ModelService> _logger;
     private WhisperFactory? _cachedFactory;
     private string? _cachedModelPath;
+
+    public ModelService(ILogger<ModelService>? logger = null)
+    {
+        _logger = logger ?? NullLogger<ModelService>.Instance;
+    }
 
     /// <summary>
     /// Returns a cached factory if available, or creates a new one from the configured model.
@@ -65,12 +73,14 @@ internal sealed class ModelService : IModelService, IDisposable
             catch (Exception ex)
             {
                 // Treat any load failure (corrupt file, version mismatch, native load
-                // error) as "needs re-download". Log to stderr so the operator can tell
-                // a corrupt-model recovery from a missing-model first-run; before #46
-                // ships ILogger<T> at the Core composition root, Console.Error is the
-                // only structured sink available without breaking the IModelService API.
-                Console.Error.WriteLine(
-                    $"ModelService.InspectModel: {options.ModelFilePath} failed to load — marking for re-download. {ex.GetType().Name}: {ex.Message}");
+                // error) as "needs re-download". Logged via ILogger<ModelService> so
+                // the operator can tell a corrupt-model recovery from a missing-model
+                // first-run. Falls back to NullLogger when the host hasn't wired
+                // logging — see ServiceCollectionExtensions logging contract.
+                _logger.LogError(
+                    ex,
+                    "Whisper model at {ModelPath} failed to load; marking for re-download.",
+                    options.ModelFilePath);
                 needsDownload = true;
             }
         }

--- a/src/VoxFlow.Core/Services/TranscriptionService.cs
+++ b/src/VoxFlow.Core/Services/TranscriptionService.cs
@@ -1,6 +1,8 @@
 namespace VoxFlow.Core.Services;
 
 using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using VoxFlow.Core.Configuration;
 using VoxFlow.Core.Interfaces;
 using VoxFlow.Core.Models;
@@ -19,6 +21,7 @@ internal sealed class TranscriptionService : ITranscriptionService
     private readonly IOutputWriter _outputWriter;
     private readonly ISpeakerEnrichmentService _speakerEnrichment;
     private readonly IVoxflowTranscriptArtifactWriter _artifactWriter;
+    private readonly ILogger<TranscriptionService> _logger;
 
     public TranscriptionService(
         IConfigurationService configService,
@@ -29,7 +32,8 @@ internal sealed class TranscriptionService : ITranscriptionService
         ILanguageSelectionService languageSelection,
         IOutputWriter outputWriter,
         ISpeakerEnrichmentService speakerEnrichment,
-        IVoxflowTranscriptArtifactWriter artifactWriter)
+        IVoxflowTranscriptArtifactWriter artifactWriter,
+        ILogger<TranscriptionService>? logger = null)
     {
         _configService = configService;
         _validationService = validationService;
@@ -40,6 +44,7 @@ internal sealed class TranscriptionService : ITranscriptionService
         _outputWriter = outputWriter;
         _speakerEnrichment = speakerEnrichment;
         _artifactWriter = artifactWriter;
+        _logger = logger ?? NullLogger<TranscriptionService>.Instance;
     }
 
     public async Task<TranscribeFileResult> TranscribeFileAsync(
@@ -136,6 +141,10 @@ internal sealed class TranscriptionService : ITranscriptionService
             }
             catch (Exception ex)
             {
+                _logger.LogError(
+                    ex,
+                    "Speaker enrichment failed for {WavPath}; falling back to plain transcript.",
+                    wavPath);
                 var warning = $"speaker-labeling: internal error: {ex.Message}";
                 enrichmentWarnings = new[] { warning };
                 warnings.Add(warning);

--- a/src/VoxFlow.Core/Services/ValidationService.cs
+++ b/src/VoxFlow.Core/Services/ValidationService.cs
@@ -5,6 +5,8 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using VoxFlow.Core.Configuration;
 using VoxFlow.Core.Interfaces;
 using VoxFlow.Core.Models;
@@ -21,18 +23,21 @@ internal sealed class ValidationService : IValidationService
 {
     private readonly IAudioConversionService _audioConversion;
     private readonly ISpeakerLabelingPreflight _speakerPreflight;
+    private readonly ILogger<ValidationService> _logger;
 
     public ValidationService(IAudioConversionService audioConversion)
-        : this(audioConversion, new NullSpeakerLabelingPreflight())
+        : this(audioConversion, new NullSpeakerLabelingPreflight(), logger: null)
     {
     }
 
     public ValidationService(
         IAudioConversionService audioConversion,
-        ISpeakerLabelingPreflight speakerPreflight)
+        ISpeakerLabelingPreflight speakerPreflight,
+        ILogger<ValidationService>? logger = null)
     {
         _audioConversion = audioConversion;
         _speakerPreflight = speakerPreflight;
+        _logger = logger ?? NullLogger<ValidationService>.Instance;
     }
 
     /// <summary>
@@ -165,6 +170,7 @@ internal sealed class ValidationService : IValidationService
         }
         catch (Exception ex)
         {
+            _logger.LogWarning(ex, "ffmpeg validation failed: {Message}", ex.Message);
             return new ValidationCheck("ffmpeg", ValidationCheckStatus.Failed, ex.Message);
         }
     }

--- a/src/VoxFlow.Core/VoxFlow.Core.csproj
+++ b/src/VoxFlow.Core/VoxFlow.Core.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Whisper.net" Version="1.9.0" ExcludeAssets="all" PrivateAssets="all" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.0" />


### PR DESCRIPTION
Closes #46. Phase 1 of the ILogger<T> rollout. Sub-PR for Epic #51.

## Scope (intentional)
**In scope:** wire ILogger<T> infrastructure into VoxFlow.Core's composition root and adopt it in five directly-DI-resolved Core services.
**Out of scope:** CLI / MCP / Desktop host wiring + the composition-built services (SpeakerEnrichmentService, PyannoteSidecarClient inside CompositionSpeakerEnrichmentService). Tracked in **follow-up issue #60**.

## Package + DI wiring
- `Microsoft.Extensions.Logging.Abstractions` 9.0.0 added to `VoxFlow.Core.csproj` alongside the existing `Microsoft.Extensions.DependencyInjection.Abstractions`.
- `ServiceCollectionExtensions.AddVoxFlowCore` now calls:
  ```csharp
  services.TryAdd(ServiceDescriptor.Singleton(typeof(ILogger<>), typeof(NullLogger<>)));
  ```
  `TryAdd`, not `Add` — when the host calls `services.AddLogging(...)` with real providers, that registration wins. The `NullLogger` fallback keeps tests and minimal hosts working without forcing them to set up logging up front. `AddVoxFlowCore`'s xmldoc spells out the contract so future host authors know how to override.

## Adopted in 5 services
Each service's constructor now takes an optional `ILogger<T>? logger = null` parameter at the end, with `NullLogger<T>.Instance` fallback. Existing test constructions keep compiling because the parameter is optional.

| Service | Error path now logged |
|---|---|
| `ModelService.InspectModel` | graduate the `Console.Error.WriteLine` that #41 left behind into `_logger.LogError(ex, "Whisper model at {ModelPath} failed to load; marking for re-download.", options.ModelFilePath)` |
| `BatchTranscriptionService.TranscribeBatchAsync` | log per-file failure path with `{InputPath}` and `{ElapsedMs}` before recording the `Failed` `BatchFileResult` |
| `AudioConversionService.ConvertToWavAsync` | log ffmpeg non-zero-exit failure with `{InputPath}`, `{ExitCode}`, `{StandardError}` before throwing |
| `ValidationService.CheckFfmpegAsync` | log ffmpeg-validation catch-all warning with the message |
| `TranscriptionService.TranscribeFileAsync` | log speaker-enrichment internal-error path with `{WavPath}` before adding the warning |

All log lines use placeholders, never string interpolation, so future log-aggregation can index by structured fields.

## Acceptance criteria (from #46)
- [x] `Microsoft.Extensions.Logging.Abstractions` referenced from `VoxFlow.Core` (csproj diff).
- [x] At least 5 Core services constructor-inject `ILogger<T>` and use it on error paths (ModelService, BatchTranscriptionService, AudioConversionService, ValidationService, TranscriptionService).
- [x] No new `Console.WriteLine` in the touched files. `grep -rn "Console\.WriteLine\|Console\.Error\.WriteLine" src/VoxFlow.Core/` returns 0 matches.
- [x] `AddVoxFlowCore()` documented in the xmldoc header to accept a host `ILoggerFactory` or fall back to `NullLoggerFactory` (the `TryAdd(ILogger<>, NullLogger<>)` line + xmldoc).
- [x] Existing tests still pass (using `NullLoggerFactory.Instance` in test composition) — Core 355/355, CLI 29/29, MCP 39/39, Desktop 145/2-skip; no test changes needed thanks to optional-param defaults.
- [x] A follow-up issue is created tracking CLI/MCP/Desktop adoption — **#60**.

## Test plan
- [x] `grep -rn "Console\.WriteLine\|Console\.Error\.WriteLine" src/VoxFlow.Core/` returns 0 matches.
- [x] All four test suites green (Linux + Desktop) without modification.
- [x] Desktop net9.0-maccatalyst build clean.
- [ ] CI Linux + macOS green (this PR validates).

## Files changed
- `src/VoxFlow.Core/VoxFlow.Core.csproj` (package add)
- `src/VoxFlow.Core/DependencyInjection/ServiceCollectionExtensions.cs` (TryAdd + xmldoc)
- `src/VoxFlow.Core/Services/ModelService.cs` (graduate + new ctor)
- `src/VoxFlow.Core/Services/BatchTranscriptionService.cs` (log per-file failure + new ctor)
- `src/VoxFlow.Core/Services/AudioConversionService.cs` (log ffmpeg failure + new ctor)
- `src/VoxFlow.Core/Services/ValidationService.cs` (log ffmpeg validation + new ctor param)
- `src/VoxFlow.Core/Services/TranscriptionService.cs` (log enrichment failure + new ctor)
