### PR TITLE
build: adopt central package management via Directory.Packages.props + global.json (#44)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,16 @@ If you cannot run a relevant validation step, say so clearly in the pull request
 - **Every `async void` event handler must wrap its body in a top-level `try`/`catch`** that logs via `DesktopDiagnostics.LogException` (or the equivalent host-specific logger) and surfaces a user-visible error. An exception that escapes an `async void` propagates to the synchronization context and crashes the app — the framework has no Task to observe.
 - **No `.GetAwaiter().GetResult()`, `.Result`, or `.Wait()` in `src/`.** These patterns deadlock under UI synchronization contexts and tie up thread-pool workers. If a sync API needs the result of async work, refactor to expose a sync core that both the async and sync paths call (`DesktopConfigurationService.LoadCore` is the reference example), or use the async-lazy `Lazy<Task<T>>` pattern (`PyannoteSidecarClient.ResponseSchema`).
 
+### Package management rules
+
+- **`Directory.Packages.props` at the repo root is the single source of truth for NuGet package versions.** Every `<PackageReference>` across `src/` and `tests/` is versionless; the version lives only in `Directory.Packages.props`.
+- **To upgrade a package, edit `Directory.Packages.props` only.** Do not add `Version="..."` back to any `.csproj`. The acceptance grep is:
+  ```bash
+  grep -rEn 'PackageReference[^>]*Version=' src/ tests/ --include='*.csproj'   # 0 matches expected
+  ```
+- **To add a new package**: add a `<PackageVersion Include="X" Version="Y" />` line to `Directory.Packages.props`, then add a versionless `<PackageReference Include="X" />` to the consuming `.csproj`.
+- **`global.json` pins the .NET SDK** to 9.0.x with `rollForward: latestFeature`. New contributors get reproducible restores without setting `DOTNET_ROOT` or pinning shells. To bump the SDK, edit `global.json` and verify CI's `actions/setup-dotnet` line still matches.
+
 ### Exception handling rules
 
 - **Every `catch` block in `src/` must do one of three things:**

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,56 @@
+<Project>
+  <!--
+    Central Package Management (CPM) for the VoxFlow solution.
+    Every PackageReference across src/ and tests/ is versioned here, never in
+    individual .csproj files. To upgrade a package, edit this file ONLY — see
+    CONTRIBUTING.md "Package management rules".
+
+    The MauiVersion property is set by the Microsoft.Maui.Sdk targets that
+    ship with the .NET SDK; it is undefined for non-MAUI projects but the
+    PackageVersion entry is inert unless a project actually references the
+    corresponding package, so the conditional indirection works without
+    breaking Core / CLI / MCP restores.
+  -->
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Microsoft.Extensions.* — pinned to 9.0.0 to match the .NET 9 SDK baseline. -->
+    <PackageVersion Include="Microsoft.Extensions.AI.Abstractions" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
+
+    <!-- Test infrastructure. -->
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageVersion Include="Xunit.SkippableFact" Version="1.4.13" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.2" />
+    <PackageVersion Include="xunit" Version="2.9.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
+
+    <!-- MCP transport / protocol library used by VoxFlow.McpServer. -->
+    <PackageVersion Include="ModelContextProtocol" Version="1.1.0" />
+
+    <!-- JSON Schema validation for the Pyannote sidecar contract. -->
+    <PackageVersion Include="NJsonSchema" Version="11.1.0" />
+
+    <!-- Whisper.net managed assembly + native runtimes (Metal acceleration on macOS). -->
+    <PackageVersion Include="Whisper.net" Version="1.9.0" />
+    <PackageVersion Include="Whisper.net.Runtime" Version="1.9.0" />
+    <PackageVersion Include="Whisper.net.Runtime.Metal" Version="1.9.0" />
+
+    <!--
+      MAUI / Mac Catalyst — VoxFlow.Desktop only. MauiVersion is set by the
+      Microsoft.Maui.Sdk targets and varies with the installed MAUI workload,
+      so we keep the property reference here rather than freezing a literal.
+    -->
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="$(MauiVersion)" />
+    <PackageVersion Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
+    <PackageVersion Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
+  </ItemGroup>
+</Project>

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "9.0.100",
+    "rollForward": "latestFeature",
+    "allowPrerelease": false
+  }
+}

--- a/src/VoxFlow.Cli/VoxFlow.Cli.csproj
+++ b/src/VoxFlow.Cli/VoxFlow.Cli.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
-    <PackageReference Include="Whisper.net.Runtime" Version="1.9.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Whisper.net.Runtime" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/VoxFlow.Core/VoxFlow.Core.csproj
+++ b/src/VoxFlow.Core/VoxFlow.Core.csproj
@@ -8,14 +8,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Whisper.net" Version="1.9.0" ExcludeAssets="all" PrivateAssets="all" GeneratePathProperty="true" />
-    <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="10.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.0" />
-    <PackageReference Include="NJsonSchema" Version="11.1.0" />
+    <PackageReference Include="Whisper.net" ExcludeAssets="all" PrivateAssets="all" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.Extensions.AI.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
+    <PackageReference Include="NJsonSchema" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/VoxFlow.Desktop/VoxFlow.Desktop.csproj
+++ b/src/VoxFlow.Desktop/VoxFlow.Desktop.csproj
@@ -49,9 +49,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
-    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="$(MauiVersion)" />
+    <PackageReference Include="Microsoft.Maui.Controls" />
+    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" />
   </ItemGroup>
 
   <ItemGroup>
@@ -59,12 +59,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Whisper.net" Version="1.9.0" ExcludeAssets="all" PrivateAssets="all" GeneratePathProperty="true" />
+    <PackageReference Include="Whisper.net" ExcludeAssets="all" PrivateAssets="all" GeneratePathProperty="true" />
     <!-- Restore the runtime packages but wire the native references manually.
          Whisper.net.Runtime 1.9.0 ships arm64-only maccatalyst archives, so
          Desktop uses the generic net9 Whisper.net assembly plus macOS dylibs. -->
-    <PackageReference Include="Whisper.net.Runtime" Version="1.9.0" ExcludeAssets="all" PrivateAssets="all" GeneratePathProperty="true" />
-    <PackageReference Include="Whisper.net.Runtime.Metal" Version="1.9.0" ExcludeAssets="all" PrivateAssets="all" GeneratePathProperty="true" />
+    <PackageReference Include="Whisper.net.Runtime" ExcludeAssets="all" PrivateAssets="all" GeneratePathProperty="true" />
+    <PackageReference Include="Whisper.net.Runtime.Metal" ExcludeAssets="all" PrivateAssets="all" GeneratePathProperty="true" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/VoxFlow.McpServer/VoxFlow.McpServer.csproj
+++ b/src/VoxFlow.McpServer/VoxFlow.McpServer.csproj
@@ -9,11 +9,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
-    <PackageReference Include="ModelContextProtocol" Version="1.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
-    <PackageReference Include="Whisper.net.Runtime" Version="1.9.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="ModelContextProtocol" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="Whisper.net.Runtime" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/VoxFlow.Cli.Tests/VoxFlow.Cli.Tests.csproj
+++ b/tests/VoxFlow.Cli.Tests/VoxFlow.Cli.Tests.csproj
@@ -9,13 +9,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/VoxFlow.Core.Tests/VoxFlow.Core.Tests.csproj
+++ b/tests/VoxFlow.Core.Tests/VoxFlow.Core.Tests.csproj
@@ -7,16 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="Whisper.net" Version="1.9.0" ExcludeAssets="all" PrivateAssets="all" GeneratePathProperty="true" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Whisper.net" ExcludeAssets="all" PrivateAssets="all" GeneratePathProperty="true" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
-    <PackageReference Include="NJsonSchema" Version="11.1.0" />
-    <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="NJsonSchema" />
+    <PackageReference Include="Xunit.SkippableFact" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/VoxFlow.Desktop.Tests/VoxFlow.Desktop.Tests.csproj
+++ b/tests/VoxFlow.Desktop.Tests/VoxFlow.Desktop.Tests.csproj
@@ -8,15 +8,15 @@
     <NoWarn>$(NoWarn);BL0006</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="Whisper.net" Version="1.9.0" ExcludeAssets="all" PrivateAssets="all" GeneratePathProperty="true" />
-    <PackageReference Include="Whisper.net.Runtime" Version="1.9.0" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Whisper.net" ExcludeAssets="all" PrivateAssets="all" GeneratePathProperty="true" />
+    <PackageReference Include="Whisper.net.Runtime" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
+    <PackageReference Include="Xunit.SkippableFact" />
   </ItemGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/tests/VoxFlow.Desktop.UiTests/VoxFlow.Desktop.UiTests.csproj
+++ b/tests/VoxFlow.Desktop.UiTests/VoxFlow.Desktop.UiTests.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/VoxFlow.McpServer.Tests/VoxFlow.McpServer.Tests.csproj
+++ b/tests/VoxFlow.McpServer.Tests/VoxFlow.McpServer.Tests.csproj
@@ -9,14 +9,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="Whisper.net" Version="1.9.0" ExcludeAssets="all" PrivateAssets="all" GeneratePathProperty="true" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Whisper.net" ExcludeAssets="all" PrivateAssets="all" GeneratePathProperty="true" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Closes #44. Sub-PR for Epic #51.

## Summary
Add a single `Directory.Packages.props` at the repo root that owns the version of every NuGet package referenced across `src/` and `tests/`. Each `.csproj`'s `<PackageReference Include="X" Version="Y" />` becomes the versionless `<PackageReference Include="X" />` form, and the version moves to one `<PackageVersion Include="X" Version="Y" />` entry in the central file. Future security upgrades and coordinated bumps now touch one file instead of fanning out across nine `.csproj`s.

Pin the .NET SDK to 9.0.x via `global.json` with `rollForward: latestFeature` so reproducible restores work without setting `DOTNET_ROOT` or pinning shells.

## Audit (21 unique packages)

| Group | Packages |
|---|---|
| Microsoft.Extensions.* | `AI.Abstractions` 10.0.0, `Configuration.Binder/EnvironmentVariables/Json` 9.0.0, `DependencyInjection` 9.0.0, `DependencyInjection.Abstractions` 9.0.0, `Hosting` 9.0.0, `Logging.Abstractions` 9.0.0 |
| Test infra | `Microsoft.NET.Test.Sdk` 17.12.0, `Xunit.SkippableFact` 1.4.13, `coverlet.collector` 6.0.2, `xunit` 2.9.2, `xunit.runner.visualstudio` 2.8.2 |
| Other | `ModelContextProtocol` 1.1.0, `NJsonSchema` 11.1.0 |
| Whisper.net | `Whisper.net` 1.9.0, `Whisper.net.Runtime` 1.9.0, `Whisper.net.Runtime.Metal` 1.9.0 |
| MAUI | `Microsoft.AspNetCore.Components.WebView.Maui` `$(MauiVersion)`, `Microsoft.Maui.Controls` `$(MauiVersion)`, `Microsoft.Maui.Controls.Compatibility` `$(MauiVersion)` |

`$(MauiVersion)` is set by the `Microsoft.Maui.Sdk` targets per the installed MAUI workload — keeping the property reference (rather than freezing a literal) avoids drift when the workload bumps.

## Acceptance criteria (from #44)
- [x] `Directory.Packages.props` at repo root with all package versions centralized.
- [x] No `<PackageReference ... Version="..."/>` remains in any csproj — `grep -rEn 'PackageReference[^>]*Version=' src/ tests/ --include='*.csproj'` returns 0 matches.
- [x] `global.json` pinning .NET SDK 9.0.x at root (`rollForward: latestFeature`).
- [x] `dotnet restore VoxFlow.sln` succeeds for all 9 csproj's; each project builds cleanly (Core, CLI, MCP, Desktop net9.0-maccatalyst).
- [ ] CI green (this PR validates).

## CONTRIBUTING.md addition
New "Package management rules" subsection codifies the workflow:
- `Directory.Packages.props` is the single source of truth; do not add `Version="..."` back to any `.csproj`.
- To upgrade: edit `Directory.Packages.props` only.
- To add a new package: one `<PackageVersion>` line + one versionless `<PackageReference>`.
- `global.json` pins the SDK; bump it with the matching CI `actions/setup-dotnet` line.
- Acceptance grep documented inline.

## Test plan
- [x] Acceptance grep returns 0 matches.
- [x] All four test suites green: Core 355/355 (`Category!=RequiresPython`), CLI 29/29, MCP 39/39, Desktop 145/2-skip.
- [x] Desktop net9.0-maccatalyst build clean.
- [ ] CI Linux + macOS green (this PR validates).

## Files changed
- `Directory.Packages.props` (new)
- `global.json` (new)
- `CONTRIBUTING.md` (new "Package management rules" section)
- 9 `.csproj` files: stripped `Version="..."` from every `<PackageReference>`.
