### PR TITLE
build: enforce TreatWarningsAsErrors + analyzers solution-wide (#45)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,41 @@
+# EditorConfig is awesome: https://editorconfig.org/
+#
+# Project-wide editor + analyzer settings. Severities live here so the IDE,
+# `dotnet build`, and CI all agree on what counts as an error.
+#
+# Severity model: AnalysisLevel=latest-default in Directory.Build.props ships
+# the .NET-default rule set. TreatWarningsAsErrors=true promotes every default
+# warning to a build break. To tighten further, add per-rule overrides below
+# (e.g. `dotnet_diagnostic.CA2007.severity = error`) AFTER the codebase is
+# clean against the new severity. To loosen, add a NoWarn entry in the
+# specific .csproj with a reason comment per CONTRIBUTING.md.
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{json,yml,yaml,xml,csproj,props,targets}]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.cs]
+# C# language defaults — keep aligned with the .NET 9 SDK style.
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_indent_case_contents = true
+csharp_indent_switch_labels = true
+
+# Rule overrides go here once the codebase is clean enough to enforce them.
+# Example:
+#   dotnet_diagnostic.CA2007.severity = error    # Always pass ConfigureAwait
+#   dotnet_diagnostic.CA1707.severity = none     # xUnit test method names with underscores

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,18 @@ If you cannot run a relevant validation step, say so clearly in the pull request
 - **Every `async void` event handler must wrap its body in a top-level `try`/`catch`** that logs via `DesktopDiagnostics.LogException` (or the equivalent host-specific logger) and surfaces a user-visible error. An exception that escapes an `async void` propagates to the synchronization context and crashes the app — the framework has no Task to observe.
 - **No `.GetAwaiter().GetResult()`, `.Result`, or `.Wait()` in `src/`.** These patterns deadlock under UI synchronization contexts and tie up thread-pool workers. If a sync API needs the result of async work, refactor to expose a sync core that both the async and sync paths call (`DesktopConfigurationService.LoadCore` is the reference example), or use the async-lazy `Lazy<Task<T>>` pattern (`PyannoteSidecarClient.ResponseSchema`).
 
+### Warnings and analyzer rules
+
+- **`Directory.Build.props` at the repo root sets `TreatWarningsAsErrors=true`** — every compiler or analyzer warning fails the build. New warnings can no longer accumulate silently.
+- **Analyzer level is `latest-default`** (the .NET-default rule set). It catches actual bugs (forward-cancellation-token, ConfigureAwait, etc.) without lighting up the perf-obsessed "recommended" rules that would force a rewrite of every log site and `IReadOnlyList<T>` signature.
+- **`EnforceCodeStyleInBuild=true`** runs the IDE / Roslyn code-style analyzers as part of `dotnet build`, so CI sees the same set as your editor.
+- **`.editorconfig`** at the repo root holds the per-rule severity overrides. Tighten by adding a line like `dotnet_diagnostic.CAxxxx.severity = error` once the codebase is already clean against the new severity. Loosen by adding a `<NoWarn>` to the specific `.csproj` **with a reason comment**; if the suppression is temporary, add a follow-up issue link.
+- **Acceptance check** before opening a PR:
+  ```bash
+  dotnet build VoxFlow.sln --no-incremental
+  ```
+  Must end with `0 Warning(s) / 0 Error(s)`.
+
 ### Package management rules
 
 - **`Directory.Packages.props` at the repo root is the single source of truth for NuGet package versions.** Every `<PackageReference>` across `src/` and `tests/` is versionless; the version lives only in `Directory.Packages.props`.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,36 @@
+<Project>
+  <!--
+    Project-wide build settings shared across every src/ and tests/ csproj.
+    Sibling Directory.Packages.props (#44) owns NuGet versions; this file
+    owns warnings, code-style enforcement, and analyzer level.
+  -->
+  <PropertyGroup>
+    <!--
+      Treat all compiler and analyzer warnings as errors. New warnings can
+      no longer accumulate silently — the build fails until the regression
+      is fixed or explicitly opted out via NoWarn (with a reason + follow-up
+      issue link, see CONTRIBUTING.md "Warnings and analyzer rules").
+    -->
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+
+    <!--
+      Run the IDE / Roslyn code-style analyzers as part of `dotnet build`,
+      not only inside Visual Studio / Rider. Combined with the default
+      .NET SDK analyzer pack (Microsoft.CodeAnalysis.NetAnalyzers ships
+      with the .NET 9 SDK), this gives the same set of rules to the CI
+      build that contributors see in their editor.
+    -->
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+
+    <!--
+      "latest-default" is the standard Microsoft analyzer set for the
+      current SDK level — the rules .NET ships enabled by default. It
+      catches actual bugs (CA2016 forward-cancellation-token, CA2007
+      ConfigureAwait, etc.) without lighting up the perf-obsessed
+      "recommended" rules (CA1848 LoggerMessage delegates, CA1859
+      concrete-list returns) that would force a rewrite of every log
+      site and IReadOnlyList<T> signature.
+    -->
+    <AnalysisLevel>latest-default</AnalysisLevel>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
Closes #45. Sub-PR for Epic #51 — final P2 task, completing the P1+P2 stabilization layer.

## Summary
Lock the existing `0 Warning(s)` baseline into a hard contract: every compiler or analyzer warning now fails the build. Future regressions can no longer slip through silently.

## Directory.Build.props (new)
```xml
<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
<EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
<AnalysisLevel>latest-default</AnalysisLevel>
```

- **`latest-default`** is the .NET-default rule set for the current SDK level — it catches actual bugs (CA2016 forward-cancellation-token, etc.) without lighting up the perf-obsessed "recommended" rules (CA1848 LoggerMessage delegates, CA1859 concrete-list returns) that would force a rewrite of every log site and `IReadOnlyList<T>` signature for marginal gain. The trial run with `latest-recommended` surfaced ~30 errors in production code, primarily perf rules; the per-PR-velocity / signal ratio favours starting at default and tightening per-rule via `.editorconfig` overrides.
- **`EnforceCodeStyleInBuild`** promotes IDE / Roslyn code-style analyzers into the build pipeline so CI fails on the same diagnostics a contributor sees in their editor — not just inside Visual Studio / Rider.

## .editorconfig (new)
Holds the universal style baseline (LF, UTF-8, indent-size, brace placement) and a comment block explaining how to tighten or loosen specific rules. Future "promote CAxxxx to error" PRs land their `dotnet_diagnostic.*.severity` lines here. No per-rule overrides yet — the codebase is already clean against the default analyzer level.

## CONTRIBUTING.md addition
New "Warnings and analyzer rules" subsection documenting the model:
- Tighten via `.editorconfig` per-rule severity overrides (after the codebase is clean against the new severity).
- Loosen via `<NoWarn>` in the specific `.csproj` with a reason comment; if the suppression is temporary, add a follow-up issue link.
- Pre-PR acceptance check: `dotnet build VoxFlow.sln --no-incremental` must end with `0 Warning(s) / 0 Error(s)`.

## Acceptance criteria (from #45)
- [x] `TreatWarningsAsErrors` enabled solution-wide via `Directory.Build.props`.
- [x] An `.editorconfig` at the repo root encodes the agreed analyzer rules (style baseline + override-friendly structure; current overrides are zero because the default rule set already passes).
- [x] `dotnet build VoxFlow.sln` succeeds with `0 Warning(s)` after the new infrastructure — verified locally; existing code passed without any production-side fixes.
- [x] No `<NoWarn>` entries needed at this analysis level. If a future PR adds one, the new CONTRIBUTING.md rule requires an inline reason comment + follow-up issue link.
- [ ] CI green (this PR validates).

## Test plan
- [x] `dotnet build VoxFlow.sln --no-incremental` → `0 Warning(s), 0 Error(s)`.
- [x] Core 355/355 (`Category!=RequiresPython`).
- [x] CLI 29/29.
- [x] MCP 39/39.
- [x] Desktop 145/2-skip (gate baseline).
- [x] Desktop net9.0-maccatalyst build clean.
- [ ] CI Linux + macOS green (this PR validates).

## Files changed
- `Directory.Build.props` (new — TreatWarningsAsErrors + EnforceCodeStyleInBuild + AnalysisLevel)
- `.editorconfig` (new — style baseline + override location)
- `CONTRIBUTING.md` (new "Warnings and analyzer rules" subsection)

## Note on tighter rule sets (future)
The trial run with `latest-recommended` showed the top noisy rules:
- **CA1848** LoggerMessage delegates (perf): pervasive in `_logger.LogError(...)` calls. Heavy refactor for marginal gain at current scale.
- **CA1859** concrete-list returns: hurts API readability across `IReadOnlyList<T>` signatures.
- **CA1305** globalization (`StringBuilder.AppendLine` needs `IFormatProvider`): mostly false positives in test scaffolding.
- **CA1707** test method underscores: clashes with xUnit conventions.

If we want any of these at error severity later, the path is: add `dotnet_diagnostic.CAxxxx.severity = error` to `.editorconfig`, fix the offenders in a focused PR. Closing this issue at "infrastructure in place + zero current warnings" matches the issue's "if warning count is large (>20), this issue stops at 'infrastructure + small set of fixes'" guidance.
