### PR TITLE
Stabilize and harden the application for reliable production-grade behavior — P1 + P2 (#51)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,41 @@
+# EditorConfig is awesome: https://editorconfig.org/
+#
+# Project-wide editor + analyzer settings. Severities live here so the IDE,
+# `dotnet build`, and CI all agree on what counts as an error.
+#
+# Severity model: AnalysisLevel=latest-default in Directory.Build.props ships
+# the .NET-default rule set. TreatWarningsAsErrors=true promotes every default
+# warning to a build break. To tighten further, add per-rule overrides below
+# (e.g. `dotnet_diagnostic.CA2007.severity = error`) AFTER the codebase is
+# clean against the new severity. To loosen, add a NoWarn entry in the
+# specific .csproj with a reason comment per CONTRIBUTING.md.
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{json,yml,yaml,xml,csproj,props,targets}]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.cs]
+# C# language defaults — keep aligned with the .NET 9 SDK style.
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_indent_case_contents = true
+csharp_indent_switch_labels = true
+
+# Rule overrides go here once the codebase is clean enough to enforce them.
+# Example:
+#   dotnet_diagnostic.CA2007.severity = error    # Always pass ConfigureAwait
+#   dotnet_diagnostic.CA1707.severity = none     # xUnit test method names with underscores

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,11 +48,38 @@ jobs:
       # and a diarization model available, which is out of scope for the default CI image. They
       # are run on machines with the full Python/pyannote environment as part of the Post-Phase-0
       # verification checklist in docs/delivery/local-speaker-labeling/.
+      #
+      # Skip-count gate: with the RequiresPython filter every [SkippableFact] in Core is excluded
+      # (not skipped), so the expected Skipped count for all three Linux projects is 0. Any non-zero
+      # value means a Skip.IfNot/Skip.If guard fired unexpectedly and the SkippableFact's [SKIP] reason
+      # in test output names exactly which one — silent skips on default CI verbosity used to hide
+      # this. See docs/delivery/local-speaker-labeling/phase-1-manual-verification.md for baselines.
       - name: Run core tests
         run: |
-          dotnet test tests/VoxFlow.Core.Tests/VoxFlow.Core.Tests.csproj --no-restore --filter "Category!=RequiresPython" --logger "trx;LogFileName=VoxFlow.Core.Tests.trx"
-          dotnet test tests/VoxFlow.Cli.Tests/VoxFlow.Cli.Tests.csproj --no-restore --logger "trx;LogFileName=VoxFlow.Cli.Tests.trx"
-          dotnet test tests/VoxFlow.McpServer.Tests/VoxFlow.McpServer.Tests.csproj --no-restore --logger "trx;LogFileName=VoxFlow.McpServer.Tests.trx"
+          set -eo pipefail
+          assert_no_skips() {
+            local label="$1" log="$2"
+            local skipped
+            # `|| true` keeps pipefail from aborting if dotnet test ever stops printing
+            # the "Skipped: N" summary line (older runner glitch); empty → treated as 0.
+            skipped=$(grep -oE "Skipped:[[:space:]]+[0-9]+" "$log" | tail -1 | grep -oE "[0-9]+" || true)
+            if [ "${skipped:-0}" != "0" ]; then
+              echo "::error::${label} reported ${skipped} skipped test(s); expected 0. Check the test output above for the [SKIP] reason and the uploaded .trx artifact."
+              exit 1
+            fi
+          }
+
+          core_log=$(mktemp)
+          cli_log=$(mktemp)
+          mcp_log=$(mktemp)
+
+          dotnet test tests/VoxFlow.Core.Tests/VoxFlow.Core.Tests.csproj --no-restore --filter "Category!=RequiresPython" --logger "trx;LogFileName=VoxFlow.Core.Tests.trx" | tee "$core_log"
+          dotnet test tests/VoxFlow.Cli.Tests/VoxFlow.Cli.Tests.csproj --no-restore --logger "trx;LogFileName=VoxFlow.Cli.Tests.trx" | tee "$cli_log"
+          dotnet test tests/VoxFlow.McpServer.Tests/VoxFlow.McpServer.Tests.csproj --no-restore --logger "trx;LogFileName=VoxFlow.McpServer.Tests.trx" | tee "$mcp_log"
+
+          assert_no_skips "VoxFlow.Core.Tests"      "$core_log"
+          assert_no_skips "VoxFlow.Cli.Tests"       "$cli_log"
+          assert_no_skips "VoxFlow.McpServer.Tests" "$mcp_log"
 
       - name: Upload test results
         if: always()
@@ -94,9 +121,27 @@ jobs:
 
       # Real Desktop UI automation is intentionally excluded from default CI because it is slower
       # and depends on a more specialized interactive macOS environment than the headless suite.
+      #
+      # Skip-count gate: the macOS CI build uses `-p:MtouchLink=SdkOnly` to stay compatible with
+      # the runner Xcode, which produces a Mac Catalyst .app that does NOT run CopyBundledCliBridge,
+      # so the two [SkippableFact] DesktopCliBundleTests both skip ("Mac Catalyst Desktop app bundle
+      # has not been built yet."). Expected Skipped: 2 — see docs/delivery/local-speaker-labeling/
+      # phase-1-manual-verification.md. Until the SdkOnly link is replaced and the bridge runs in CI,
+      # this gate freezes the count at 2 so any drift (1, 3, ...) surfaces a real change.
+      # TODO(#37 follow-up): drive Skipped down to 0 by populating the bundle in CI.
       - name: Run desktop tests
         run: |
-          dotnet test tests/VoxFlow.Desktop.Tests/VoxFlow.Desktop.Tests.csproj --no-restore --logger "trx;LogFileName=VoxFlow.Desktop.Tests.trx"
+          set -eo pipefail
+          desktop_log=$(mktemp)
+          dotnet test tests/VoxFlow.Desktop.Tests/VoxFlow.Desktop.Tests.csproj --no-restore --logger "trx;LogFileName=VoxFlow.Desktop.Tests.trx" | tee "$desktop_log"
+
+          expected_skips=2
+          # `|| true` keeps pipefail from aborting if the summary line is missing.
+          skipped=$(grep -oE "Skipped:[[:space:]]+[0-9]+" "$desktop_log" | tail -1 | grep -oE "[0-9]+" || true)
+          if [ "${skipped:-0}" != "$expected_skips" ]; then
+            echo "::error::VoxFlow.Desktop.Tests reported ${skipped} skipped test(s); expected ${expected_skips}. Check the test output above for the [SKIP] reason and the uploaded .trx artifact, then update phase-1-manual-verification.md and this workflow if the drift is intentional."
+            exit 1
+          fi
 
       - name: Upload test results
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,15 +50,11 @@ jobs:
       # verification checklist in docs/delivery/local-speaker-labeling/.
       #
       # Skip-count gate: with the RequiresPython filter every [SkippableFact] in Core is excluded
-      # (not skipped). Today exactly one Core test is skipped on CI: the parallel-flaky
-      # BatchTranscriptionServiceTests.TranscribeBatchAsync_ReportsNestedProgress_ForCurrentFile,
-      # tracked by #42. CLI and MCP have no SkippableFact and no skip-marked tests. Any other
-      # non-baseline value means a Skip.IfNot/Skip.If guard fired unexpectedly and the
-      # SkippableFact's [SKIP] reason in test output names exactly which one — silent skips on
-      # default CI verbosity used to hide this. See docs/delivery/local-speaker-labeling/
-      # phase-1-manual-verification.md for baselines.
-      # TODO(#42): drive Core skip count back to 0 by hardening the BatchTranscriptionService
-      # progress capture and assertion.
+      # (not skipped); CLI and MCP have no SkippableFact callsites. The expected Skipped count
+      # for all three Linux projects is 0. Any non-zero value means a Skip.IfNot/Skip.If guard
+      # fired unexpectedly and the SkippableFact's [SKIP] reason in the test output names which
+      # one — silent skips on default CI verbosity used to hide this. See docs/delivery/
+      # local-speaker-labeling/phase-1-manual-verification.md for baselines.
       - name: Run core tests
         run: |
           set -eo pipefail
@@ -82,7 +78,7 @@ jobs:
           dotnet test tests/VoxFlow.Cli.Tests/VoxFlow.Cli.Tests.csproj --no-restore --logger "trx;LogFileName=VoxFlow.Cli.Tests.trx" | tee "$cli_log"
           dotnet test tests/VoxFlow.McpServer.Tests/VoxFlow.McpServer.Tests.csproj --no-restore --logger "trx;LogFileName=VoxFlow.McpServer.Tests.trx" | tee "$mcp_log"
 
-          assert_skips "VoxFlow.Core.Tests"      "$core_log" 1
+          assert_skips "VoxFlow.Core.Tests"      "$core_log" 0
           assert_skips "VoxFlow.Cli.Tests"       "$cli_log"  0
           assert_skips "VoxFlow.McpServer.Tests" "$mcp_log"  0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,21 +50,26 @@ jobs:
       # verification checklist in docs/delivery/local-speaker-labeling/.
       #
       # Skip-count gate: with the RequiresPython filter every [SkippableFact] in Core is excluded
-      # (not skipped), so the expected Skipped count for all three Linux projects is 0. Any non-zero
-      # value means a Skip.IfNot/Skip.If guard fired unexpectedly and the SkippableFact's [SKIP] reason
-      # in test output names exactly which one — silent skips on default CI verbosity used to hide
-      # this. See docs/delivery/local-speaker-labeling/phase-1-manual-verification.md for baselines.
+      # (not skipped). Today exactly one Core test is skipped on CI: the parallel-flaky
+      # BatchTranscriptionServiceTests.TranscribeBatchAsync_ReportsNestedProgress_ForCurrentFile,
+      # tracked by #42. CLI and MCP have no SkippableFact and no skip-marked tests. Any other
+      # non-baseline value means a Skip.IfNot/Skip.If guard fired unexpectedly and the
+      # SkippableFact's [SKIP] reason in test output names exactly which one — silent skips on
+      # default CI verbosity used to hide this. See docs/delivery/local-speaker-labeling/
+      # phase-1-manual-verification.md for baselines.
+      # TODO(#42): drive Core skip count back to 0 by hardening the BatchTranscriptionService
+      # progress capture and assertion.
       - name: Run core tests
         run: |
           set -eo pipefail
-          assert_no_skips() {
-            local label="$1" log="$2"
+          assert_skips() {
+            local label="$1" log="$2" expected="$3"
             local skipped
             # `|| true` keeps pipefail from aborting if dotnet test ever stops printing
             # the "Skipped: N" summary line (older runner glitch); empty → treated as 0.
             skipped=$(grep -oE "Skipped:[[:space:]]+[0-9]+" "$log" | tail -1 | grep -oE "[0-9]+" || true)
-            if [ "${skipped:-0}" != "0" ]; then
-              echo "::error::${label} reported ${skipped} skipped test(s); expected 0. Check the test output above for the [SKIP] reason and the uploaded .trx artifact."
+            if [ "${skipped:-0}" != "$expected" ]; then
+              echo "::error::${label} reported ${skipped} skipped test(s); expected ${expected}. Check the test output above for the [SKIP] reason and the uploaded .trx artifact."
               exit 1
             fi
           }
@@ -77,9 +82,9 @@ jobs:
           dotnet test tests/VoxFlow.Cli.Tests/VoxFlow.Cli.Tests.csproj --no-restore --logger "trx;LogFileName=VoxFlow.Cli.Tests.trx" | tee "$cli_log"
           dotnet test tests/VoxFlow.McpServer.Tests/VoxFlow.McpServer.Tests.csproj --no-restore --logger "trx;LogFileName=VoxFlow.McpServer.Tests.trx" | tee "$mcp_log"
 
-          assert_no_skips "VoxFlow.Core.Tests"      "$core_log"
-          assert_no_skips "VoxFlow.Cli.Tests"       "$cli_log"
-          assert_no_skips "VoxFlow.McpServer.Tests" "$mcp_log"
+          assert_skips "VoxFlow.Core.Tests"      "$core_log" 1
+          assert_skips "VoxFlow.Cli.Tests"       "$cli_log"  0
+          assert_skips "VoxFlow.McpServer.Tests" "$mcp_log"  0
 
       - name: Upload test results
         if: always()

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,12 @@ If you cannot run a relevant validation step, say so clearly in the pull request
 - When changing product behavior, update the relevant docs in `README.md`, `SETUP.md`, `docs/product/`, or `docs/architecture/`.
 - Add comments only where the code would otherwise be hard to understand.
 
+### Async / concurrency rules
+
+- **`async void` is only allowed for UI event handlers** (MAUI/Mac Catalyst handlers such as `*_Click`, `*_Tapped`, `*_Loaded`, drop handlers). Anything invoked from your own code returns `async Task`.
+- **Every `async void` event handler must wrap its body in a top-level `try`/`catch`** that logs via `DesktopDiagnostics.LogException` (or the equivalent host-specific logger) and surfaces a user-visible error. An exception that escapes an `async void` propagates to the synchronization context and crashes the app — the framework has no Task to observe.
+- **No `.GetAwaiter().GetResult()`, `.Result`, or `.Wait()` in `src/`.** These patterns deadlock under UI synchronization contexts and tie up thread-pool workers. If a sync API needs the result of async work, refactor to expose a sync core that both the async and sync paths call (`DesktopConfigurationService.LoadCore` is the reference example), or use the async-lazy `Lazy<Task<T>>` pattern (`PyannoteSidecarClient.ResponseSchema`).
+
 ## Pull Request Expectations
 
 Each pull request should include:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,16 @@ If you cannot run a relevant validation step, say so clearly in the pull request
 - **Every `async void` event handler must wrap its body in a top-level `try`/`catch`** that logs via `DesktopDiagnostics.LogException` (or the equivalent host-specific logger) and surfaces a user-visible error. An exception that escapes an `async void` propagates to the synchronization context and crashes the app — the framework has no Task to observe.
 - **No `.GetAwaiter().GetResult()`, `.Result`, or `.Wait()` in `src/`.** These patterns deadlock under UI synchronization contexts and tie up thread-pool workers. If a sync API needs the result of async work, refactor to expose a sync core that both the async and sync paths call (`DesktopConfigurationService.LoadCore` is the reference example), or use the async-lazy `Lazy<Task<T>>` pattern (`PyannoteSidecarClient.ResponseSchema`).
 
+### Package management rules
+
+- **`Directory.Packages.props` at the repo root is the single source of truth for NuGet package versions.** Every `<PackageReference>` across `src/` and `tests/` is versionless; the version lives only in `Directory.Packages.props`.
+- **To upgrade a package, edit `Directory.Packages.props` only.** Do not add `Version="..."` back to any `.csproj`. The acceptance grep is:
+  ```bash
+  grep -rEn 'PackageReference[^>]*Version=' src/ tests/ --include='*.csproj'   # 0 matches expected
+  ```
+- **To add a new package**: add a `<PackageVersion Include="X" Version="Y" />` line to `Directory.Packages.props`, then add a versionless `<PackageReference Include="X" />` to the consuming `.csproj`.
+- **`global.json` pins the .NET SDK** to 9.0.x with `rollForward: latestFeature`. New contributors get reproducible restores without setting `DOTNET_ROOT` or pinning shells. To bump the SDK, edit `global.json` and verify CI's `actions/setup-dotnet` line still matches.
+
 ### Exception handling rules
 
 - **Every `catch` block in `src/` must do one of three things:**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,19 @@ If you cannot run a relevant validation step, say so clearly in the pull request
 - **Every `async void` event handler must wrap its body in a top-level `try`/`catch`** that logs via `DesktopDiagnostics.LogException` (or the equivalent host-specific logger) and surfaces a user-visible error. An exception that escapes an `async void` propagates to the synchronization context and crashes the app — the framework has no Task to observe.
 - **No `.GetAwaiter().GetResult()`, `.Result`, or `.Wait()` in `src/`.** These patterns deadlock under UI synchronization contexts and tie up thread-pool workers. If a sync API needs the result of async work, refactor to expose a sync core that both the async and sync paths call (`DesktopConfigurationService.LoadCore` is the reference example), or use the async-lazy `Lazy<Task<T>>` pattern (`PyannoteSidecarClient.ResponseSchema`).
 
+### Exception handling rules
+
+- **Every `catch` block in `src/` must do one of three things:**
+  1. **Rethrow** (after wrapping or logging) — preserve the inner exception via `throw new ... (..., ex)` so the original stack trace is recoverable.
+  2. **Log** the failure — use the host-specific logger (`DesktopDiagnostics.LogException` in Desktop, `Console.Error.WriteLine` in Core/CLI/MCP until #46 wires `ILogger<T>` at the composition root). The log line should name the operation that failed and surface `ex.GetType().Name` + `ex.Message`.
+  3. **Carry a one-line justification comment** explaining why the exception is intentionally suppressed (e.g. `// Process may have exited between HasExited check and Kill; swallow.`). Comments must justify silence, not just describe what's caught.
+- **No bare `catch { }` blocks** with no body, no comment, and no rethrow. The strict acceptance grep is:
+  ```bash
+  grep -rEn "catch\s*\([^)]*\)\s*\{\s*\}" src/ --include="*.cs"
+  grep -rEn "^\s*catch\s*\{" src/ --include="*.cs"
+  ```
+  Both should return no C# matches. Bare `catch` (no exception type) should narrow to a specific expected exception type whenever possible.
+
 ## Pull Request Expectations
 
 Each pull request should include:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,18 @@ If you cannot run a relevant validation step, say so clearly in the pull request
 - **Every `async void` event handler must wrap its body in a top-level `try`/`catch`** that logs via `DesktopDiagnostics.LogException` (or the equivalent host-specific logger) and surfaces a user-visible error. An exception that escapes an `async void` propagates to the synchronization context and crashes the app — the framework has no Task to observe.
 - **No `.GetAwaiter().GetResult()`, `.Result`, or `.Wait()` in `src/`.** These patterns deadlock under UI synchronization contexts and tie up thread-pool workers. If a sync API needs the result of async work, refactor to expose a sync core that both the async and sync paths call (`DesktopConfigurationService.LoadCore` is the reference example), or use the async-lazy `Lazy<Task<T>>` pattern (`PyannoteSidecarClient.ResponseSchema`).
 
+### Warnings and analyzer rules
+
+- **`Directory.Build.props` at the repo root sets `TreatWarningsAsErrors=true`** — every compiler or analyzer warning fails the build. New warnings can no longer accumulate silently.
+- **Analyzer level is `latest-default`** (the .NET-default rule set). It catches actual bugs (forward-cancellation-token, ConfigureAwait, etc.) without lighting up the perf-obsessed "recommended" rules that would force a rewrite of every log site and `IReadOnlyList<T>` signature.
+- **`EnforceCodeStyleInBuild=true`** runs the IDE / Roslyn code-style analyzers as part of `dotnet build`, so CI sees the same set as your editor.
+- **`.editorconfig`** at the repo root holds the per-rule severity overrides. Tighten by adding a line like `dotnet_diagnostic.CAxxxx.severity = error` once the codebase is already clean against the new severity. Loosen by adding a `<NoWarn>` to the specific `.csproj` **with a reason comment**; if the suppression is temporary, add a follow-up issue link.
+- **Acceptance check** before opening a PR:
+  ```bash
+  dotnet build VoxFlow.sln --no-incremental
+  ```
+  Must end with `0 Warning(s) / 0 Error(s)`.
+
 ### Package management rules
 
 - **`Directory.Packages.props` at the repo root is the single source of truth for NuGet package versions.** Every `<PackageReference>` across `src/` and `tests/` is versionless; the version lives only in `Directory.Packages.props`.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,36 @@
+<Project>
+  <!--
+    Project-wide build settings shared across every src/ and tests/ csproj.
+    Sibling Directory.Packages.props (#44) owns NuGet versions; this file
+    owns warnings, code-style enforcement, and analyzer level.
+  -->
+  <PropertyGroup>
+    <!--
+      Treat all compiler and analyzer warnings as errors. New warnings can
+      no longer accumulate silently — the build fails until the regression
+      is fixed or explicitly opted out via NoWarn (with a reason + follow-up
+      issue link, see CONTRIBUTING.md "Warnings and analyzer rules").
+    -->
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+
+    <!--
+      Run the IDE / Roslyn code-style analyzers as part of `dotnet build`,
+      not only inside Visual Studio / Rider. Combined with the default
+      .NET SDK analyzer pack (Microsoft.CodeAnalysis.NetAnalyzers ships
+      with the .NET 9 SDK), this gives the same set of rules to the CI
+      build that contributors see in their editor.
+    -->
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+
+    <!--
+      "latest-default" is the standard Microsoft analyzer set for the
+      current SDK level — the rules .NET ships enabled by default. It
+      catches actual bugs (CA2016 forward-cancellation-token, CA2007
+      ConfigureAwait, etc.) without lighting up the perf-obsessed
+      "recommended" rules (CA1848 LoggerMessage delegates, CA1859
+      concrete-list returns) that would force a rewrite of every log
+      site and IReadOnlyList<T> signature.
+    -->
+    <AnalysisLevel>latest-default</AnalysisLevel>
+  </PropertyGroup>
+</Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,56 @@
+<Project>
+  <!--
+    Central Package Management (CPM) for the VoxFlow solution.
+    Every PackageReference across src/ and tests/ is versioned here, never in
+    individual .csproj files. To upgrade a package, edit this file ONLY — see
+    CONTRIBUTING.md "Package management rules".
+
+    The MauiVersion property is set by the Microsoft.Maui.Sdk targets that
+    ship with the .NET SDK; it is undefined for non-MAUI projects but the
+    PackageVersion entry is inert unless a project actually references the
+    corresponding package, so the conditional indirection works without
+    breaking Core / CLI / MCP restores.
+  -->
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Microsoft.Extensions.* — pinned to 9.0.0 to match the .NET 9 SDK baseline. -->
+    <PackageVersion Include="Microsoft.Extensions.AI.Abstractions" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
+
+    <!-- Test infrastructure. -->
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageVersion Include="Xunit.SkippableFact" Version="1.4.13" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.2" />
+    <PackageVersion Include="xunit" Version="2.9.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
+
+    <!-- MCP transport / protocol library used by VoxFlow.McpServer. -->
+    <PackageVersion Include="ModelContextProtocol" Version="1.1.0" />
+
+    <!-- JSON Schema validation for the Pyannote sidecar contract. -->
+    <PackageVersion Include="NJsonSchema" Version="11.1.0" />
+
+    <!-- Whisper.net managed assembly + native runtimes (Metal acceleration on macOS). -->
+    <PackageVersion Include="Whisper.net" Version="1.9.0" />
+    <PackageVersion Include="Whisper.net.Runtime" Version="1.9.0" />
+    <PackageVersion Include="Whisper.net.Runtime.Metal" Version="1.9.0" />
+
+    <!--
+      MAUI / Mac Catalyst — VoxFlow.Desktop only. MauiVersion is set by the
+      Microsoft.Maui.Sdk targets and varies with the installed MAUI workload,
+      so we keep the property reference here rather than freezing a literal.
+    -->
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="$(MauiVersion)" />
+    <PackageVersion Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
+    <PackageVersion Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
+  </ItemGroup>
+</Project>

--- a/docs/delivery/local-speaker-labeling/phase-1-manual-verification.md
+++ b/docs/delivery/local-speaker-labeling/phase-1-manual-verification.md
@@ -47,11 +47,11 @@ Tests under `[SkippableFact]` write their skip reason to the xUnit test-output s
 
 | Job leg | Project | Expected Skipped |
 |---|---|---|
-| Linux `core-hosts` | `VoxFlow.Core.Tests` (with `--filter Category!=RequiresPython`) | **1** — every `[SkippableFact]` is filtered out; the one explicit `[Fact(Skip=…)]` is `BatchTranscriptionServiceTests.TranscribeBatchAsync_ReportsNestedProgress_ForCurrentFile`, parallel-flaky and tracked by #42 |
+| Linux `core-hosts` | `VoxFlow.Core.Tests` (with `--filter Category!=RequiresPython`) | **0** — every `[SkippableFact]` is filtered out, no remaining `[Fact(Skip=…)]` |
 | Linux `core-hosts` | `VoxFlow.Cli.Tests` | **0** — no `[SkippableFact]` callsites |
 | Linux `core-hosts` | `VoxFlow.McpServer.Tests` | **0** — no `[SkippableFact]` callsites |
 | macOS `desktop` | `VoxFlow.Desktop.Tests` | **2** — runner Xcode forces `MtouchLink=SdkOnly`, which produces a Mac Catalyst bundle without the CLI bridge, so both `DesktopCliBundleTests` skip |
-| Local full solution (`dotnet test VoxFlow.sln`, no filter) | All projects | **7 + 1 + 2 = 10** — the 7 Core `RequiresPython` tests + the explicit `BatchTranscriptionService` skip + the 2 Desktop bundle tests |
+| Local full solution (`dotnet test VoxFlow.sln`, no filter) | All projects | **7 + 2 = 9** — the 7 Core `RequiresPython` tests + the 2 Desktop bundle tests |
 
 Drift = regression. If a count changes, the LoudSkip output names exactly which guard fired; update both this baseline table and the gate in `.github/workflows/ci.yml` only when the change is intentional.
 

--- a/docs/delivery/local-speaker-labeling/phase-1-manual-verification.md
+++ b/docs/delivery/local-speaker-labeling/phase-1-manual-verification.md
@@ -47,11 +47,11 @@ Tests under `[SkippableFact]` write their skip reason to the xUnit test-output s
 
 | Job leg | Project | Expected Skipped |
 |---|---|---|
-| Linux `core-hosts` | `VoxFlow.Core.Tests` (with `--filter Category!=RequiresPython`) | **0** — every `[SkippableFact]` in Core is filtered out, not skipped |
+| Linux `core-hosts` | `VoxFlow.Core.Tests` (with `--filter Category!=RequiresPython`) | **1** — every `[SkippableFact]` is filtered out; the one explicit `[Fact(Skip=…)]` is `BatchTranscriptionServiceTests.TranscribeBatchAsync_ReportsNestedProgress_ForCurrentFile`, parallel-flaky and tracked by #42 |
 | Linux `core-hosts` | `VoxFlow.Cli.Tests` | **0** — no `[SkippableFact]` callsites |
 | Linux `core-hosts` | `VoxFlow.McpServer.Tests` | **0** — no `[SkippableFact]` callsites |
 | macOS `desktop` | `VoxFlow.Desktop.Tests` | **2** — runner Xcode forces `MtouchLink=SdkOnly`, which produces a Mac Catalyst bundle without the CLI bridge, so both `DesktopCliBundleTests` skip |
-| Local full solution (`dotnet test VoxFlow.sln`, no filter) | All projects | **7 + 2 = 9** — the 7 Core `RequiresPython` tests + the 2 Desktop bundle tests, both classes of skip described above |
+| Local full solution (`dotnet test VoxFlow.sln`, no filter) | All projects | **7 + 1 + 2 = 10** — the 7 Core `RequiresPython` tests + the explicit `BatchTranscriptionService` skip + the 2 Desktop bundle tests |
 
 Drift = regression. If a count changes, the LoudSkip output names exactly which guard fired; update both this baseline table and the gate in `.github/workflows/ci.yml` only when the change is intentional.
 

--- a/docs/delivery/local-speaker-labeling/phase-1-manual-verification.md
+++ b/docs/delivery/local-speaker-labeling/phase-1-manual-verification.md
@@ -34,12 +34,26 @@ dotnet test VoxFlow.sln
 
 Expected: **all tests pass.** You should see roughly:
 
-- `VoxFlow.Core.Tests`: 296 passed, 7 skipped (the skipped tests are `Category=RequiresPython` / real-sidecar integration tests that need pyannote preinstalled — they stay skipped in a clean environment)
-- `VoxFlow.McpServer.Tests`: 35 passed
-- `VoxFlow.Cli.Tests`: 6 passed
-- `VoxFlow.Desktop.Tests`: 70 passed, 2 skipped
+- `VoxFlow.Core.Tests`: ≈340 passed, **7 skipped** (the skipped tests are `Category=RequiresPython` / real-sidecar integration tests that need pyannote preinstalled — they stay skipped in a clean environment)
+- `VoxFlow.McpServer.Tests`: 39 passed
+- `VoxFlow.Cli.Tests`: 29 passed
+- `VoxFlow.Desktop.Tests`: ≈145 passed, **2 skipped** (the two `DesktopCliBundleTests` skip until the Mac Catalyst `.app` bundle is built locally — they pass once the bundle has been produced via Visual Studio for Mac or `dotnet build … -t:Run` from `src/VoxFlow.Desktop/`)
 
 If any test **fails**, stop here and report the failure.
+
+### 1a. Skip-count baselines and the CI gate
+
+Tests under `[SkippableFact]` write their skip reason to the xUnit test-output sink via `LoudSkip.IfNot` / `LoudSkip.If` (see `tests/TestSupport/LoudSkip.cs`). The reason is visible regardless of `--verbosity` — look for lines like `[SKIP] python3 not available on PATH`. The CI workflow (`.github/workflows/ci.yml`) hard-fails the job if a project's `Skipped: N` summary drifts from the documented baseline:
+
+| Job leg | Project | Expected Skipped |
+|---|---|---|
+| Linux `core-hosts` | `VoxFlow.Core.Tests` (with `--filter Category!=RequiresPython`) | **0** — every `[SkippableFact]` in Core is filtered out, not skipped |
+| Linux `core-hosts` | `VoxFlow.Cli.Tests` | **0** — no `[SkippableFact]` callsites |
+| Linux `core-hosts` | `VoxFlow.McpServer.Tests` | **0** — no `[SkippableFact]` callsites |
+| macOS `desktop` | `VoxFlow.Desktop.Tests` | **2** — runner Xcode forces `MtouchLink=SdkOnly`, which produces a Mac Catalyst bundle without the CLI bridge, so both `DesktopCliBundleTests` skip |
+| Local full solution (`dotnet test VoxFlow.sln`, no filter) | All projects | **7 + 2 = 9** — the 7 Core `RequiresPython` tests + the 2 Desktop bundle tests, both classes of skip described above |
+
+Drift = regression. If a count changes, the LoudSkip output names exactly which guard fired; update both this baseline table and the gate in `.github/workflows/ci.yml` only when the change is intentional.
 
 ## 2. Disabled-path regression guard
 

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "9.0.100",
+    "rollForward": "latestFeature",
+    "allowPrerelease": false
+  }
+}

--- a/src/VoxFlow.Cli/VoxFlow.Cli.csproj
+++ b/src/VoxFlow.Cli/VoxFlow.Cli.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
-    <PackageReference Include="Whisper.net.Runtime" Version="1.9.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Whisper.net.Runtime" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/VoxFlow.Core/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/VoxFlow.Core/DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,5 +1,8 @@
 using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using VoxFlow.Core.Interfaces;
 using VoxFlow.Core.Services;
 using VoxFlow.Core.Services.Diarization;
@@ -14,10 +17,25 @@ public static class ServiceCollectionExtensions
 {
     /// <summary>
     /// Adds the core transcription pipeline services to the supplied service collection.
+    ///
+    /// Logging contract (#46 Phase 1): if the host has called
+    /// <c>services.AddLogging(...)</c> before this method, the host's
+    /// <see cref="ILoggerFactory"/> is reused and Core services receive its
+    /// <see cref="ILogger{T}"/> instances. If logging is not registered,
+    /// the open-generic <see cref="ILogger{T}"/> resolves to
+    /// <see cref="NullLogger{T}"/> — Core services keep working but their
+    /// log lines go nowhere. Phase 2 will roll the same wiring through
+    /// the CLI / MCP / Desktop hosts.
     /// </summary>
     public static IServiceCollection AddVoxFlowCore(this IServiceCollection services)
     {
         ArgumentNullException.ThrowIfNull(services);
+
+        // TryAdd, not Add: if the host has registered AddLogging() with real
+        // providers, that registration wins. This line only fires when nobody
+        // wired logging — the NullLogger fallback keeps tests and minimal hosts
+        // working without forcing them to set up logging up front.
+        services.TryAdd(ServiceDescriptor.Singleton(typeof(ILogger<>), typeof(NullLogger<>)));
 
         services.AddSingleton<IConfigurationService, ConfigurationService>();
         services.AddSingleton<IValidationService, ValidationService>();

--- a/src/VoxFlow.Core/Services/AudioConversionService.cs
+++ b/src/VoxFlow.Core/Services/AudioConversionService.cs
@@ -140,6 +140,7 @@ internal sealed class AudioConversionService : IAudioConversionService
             }
             catch (InvalidOperationException)
             {
+                // Process may have exited between HasExited check and Kill; swallow.
             }
         });
 

--- a/src/VoxFlow.Core/Services/AudioConversionService.cs
+++ b/src/VoxFlow.Core/Services/AudioConversionService.cs
@@ -5,6 +5,8 @@ using System.Globalization;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using VoxFlow.Core.Configuration;
 using VoxFlow.Core.Interfaces;
 
@@ -15,6 +17,13 @@ namespace VoxFlow.Core.Services;
 /// </summary>
 internal sealed class AudioConversionService : IAudioConversionService
 {
+    private readonly ILogger<AudioConversionService> _logger;
+
+    public AudioConversionService(ILogger<AudioConversionService>? logger = null)
+    {
+        _logger = logger ?? NullLogger<AudioConversionService>.Instance;
+    }
+
     /// <summary>
     /// Converts a specific input file into WAV format at the specified output path.
     /// </summary>
@@ -65,6 +74,11 @@ internal sealed class AudioConversionService : IAudioConversionService
 
         if (result.ExitCode != 0)
         {
+            _logger.LogError(
+                "ffmpeg WAV conversion failed for {InputPath} with exit code {ExitCode}: {StandardError}",
+                inputPath,
+                result.ExitCode,
+                result.StandardError);
             throw new InvalidOperationException(
                 $"ffmpeg conversion failed with exit code {result.ExitCode}: {result.StandardError}".Trim());
         }

--- a/src/VoxFlow.Core/Services/BatchTranscriptionService.cs
+++ b/src/VoxFlow.Core/Services/BatchTranscriptionService.cs
@@ -97,9 +97,21 @@ internal sealed class BatchTranscriptionService : IBatchTranscriptionService
         var speakerLabelingEnabled = request.EnableSpeakers ?? options.SpeakerLabeling.Enabled;
 
         // 4. Process each file
+        var cancelled = false;
+        var remainingStartIndex = discoveredFiles.Count;
         for (var i = 0; i < discoveredFiles.Count; i++)
         {
-            cancellationToken.ThrowIfCancellationRequested();
+            if (cancellationToken.IsCancellationRequested)
+            {
+                // Cancellation between files: stop the loop and let the post-loop
+                // block tag every remaining file as Cancelled in the result. This
+                // gives the caller a partial-progress BatchTranscribeResult instead
+                // of a bare OperationCanceledException with no visibility into
+                // which files completed.
+                cancelled = true;
+                remainingStartIndex = i;
+                break;
+            }
             var file = discoveredFiles[i];
 
             if (file.Status == DiscoveryStatus.Skipped)
@@ -204,7 +216,19 @@ internal sealed class BatchTranscriptionService : IBatchTranscriptionService
                     null, fileStopwatch.Elapsed,
                     detectedLanguage));
             }
-            catch (OperationCanceledException) { throw; }
+            catch (OperationCanceledException)
+            {
+                // Mid-file cancellation: record this file as Cancelled and exit the
+                // loop. The temp-WAV cleanup in `finally` still runs so the partially
+                // written WAV does not outlive the run.
+                fileStopwatch.Stop();
+                results.Add(new BatchFileResult(
+                    file.InputPath, file.OutputPath, "Cancelled",
+                    "Batch cancelled during transcription.", fileStopwatch.Elapsed, null));
+                cancelled = true;
+                remainingStartIndex = i + 1;
+                break;
+            }
             catch (Exception ex)
             {
                 fileStopwatch.Stop();
@@ -220,20 +244,42 @@ internal sealed class BatchTranscriptionService : IBatchTranscriptionService
             }
         }
 
+        // Mark every file that was discovered but never reached as Cancelled. This
+        // closes the gap left by the cancellation break above so caller-visible
+        // counts always satisfy succeeded + failed + skipped == TotalFiles.
+        for (var j = remainingStartIndex; j < discoveredFiles.Count; j++)
+        {
+            var remaining = discoveredFiles[j];
+            results.Add(new BatchFileResult(
+                remaining.InputPath, remaining.OutputPath, "Cancelled",
+                "Batch cancelled before this file started.", TimeSpan.Zero, null));
+        }
+
         // The summary writer already speaks the shared file-processing model, so project the batch-specific results once here.
+        // Cancelled buckets under Skipped for the summary file and for the integer
+        // counters: the existing FileProcessingStatus enum has Success/Failed/Skipped
+        // and the BatchTranscribeResult contract is positional, so adding a Cancelled
+        // counter would be a breaking record shape. The string Status preserves the
+        // distinction for callers that need it (Results[*].Status == "Cancelled").
         var fileResults = results.Select(r => new FileProcessingResult(
             r.InputPath, r.OutputPath,
             r.Status switch { "Success" => FileProcessingStatus.Success, "Failed" => FileProcessingStatus.Failed, _ => FileProcessingStatus.Skipped },
             r.ErrorMessage, r.Duration, r.DetectedLanguage)).ToList();
-        await _summaryWriter.WriteAsync(batchOptions.SummaryFilePath, fileResults, cancellationToken);
+        // The summary write itself uses the original (un-linked) cancellation token
+        // so an already-cancelled batch can still flush its partial summary to disk.
+        // Without this, a cancelled run would also lose its summary file.
+        await _summaryWriter.WriteAsync(batchOptions.SummaryFilePath, fileResults, CancellationToken.None);
 
         totalStopwatch.Stop();
         var succeeded = results.Count(r => r.Status == "Success");
         var failed = results.Count(r => r.Status == "Failed");
-        var skipped = results.Count(r => r.Status == "Skipped");
+        var skipped = results.Count(r => r.Status == "Skipped" || r.Status == "Cancelled");
+        var cancelledCount = results.Count(r => r.Status == "Cancelled");
 
-        progress?.Report(new ProgressUpdate(ProgressStage.Complete, 100, totalStopwatch.Elapsed,
-            $"Batch complete: {succeeded} succeeded, {failed} failed, {skipped} skipped"));
+        var completionMessage = cancelled
+            ? $"Batch cancelled: {succeeded} succeeded, {failed} failed, {skipped - cancelledCount} skipped, {cancelledCount} cancelled"
+            : $"Batch complete: {succeeded} succeeded, {failed} failed, {skipped} skipped";
+        progress?.Report(new ProgressUpdate(ProgressStage.Complete, 100, totalStopwatch.Elapsed, completionMessage));
 
         return new BatchTranscribeResult(
             results.Count, succeeded, failed, skipped,

--- a/src/VoxFlow.Core/Services/BatchTranscriptionService.cs
+++ b/src/VoxFlow.Core/Services/BatchTranscriptionService.cs
@@ -309,7 +309,13 @@ internal sealed class BatchTranscriptionService : IBatchTranscriptionService
             return null;
         }
 
-        return new Progress<ProgressUpdate>(update =>
+        // Synchronous IProgress<T> adapter — Progress<T> would queue to
+        // SynchronizationContext/ThreadPool and lose FIFO ordering between
+        // reports, plus it would mean an `await TranscribeBatchAsync` could
+        // return before all per-file progress callbacks have committed (which
+        // makes downstream progress-bar rendering and tests racy). Same shape
+        // as SpeakerEnrichmentService.DelegateProgress<T>.
+        return new DelegateProgress<ProgressUpdate>(update =>
         {
             var filePercent = FileTranscribingStartPercent +
                               ((FileTranscribingEndPercent - FileTranscribingStartPercent) *
@@ -324,6 +330,13 @@ internal sealed class BatchTranscriptionService : IBatchTranscriptionService
                 BatchFileTotal = totalFiles
             });
         });
+    }
+
+    private sealed class DelegateProgress<T> : IProgress<T>
+    {
+        private readonly Action<T> _handler;
+        public DelegateProgress(Action<T> handler) => _handler = handler;
+        public void Report(T value) => _handler(value);
     }
 
     private static void ReportBatchFileProgress(

--- a/src/VoxFlow.Core/Services/BatchTranscriptionService.cs
+++ b/src/VoxFlow.Core/Services/BatchTranscriptionService.cs
@@ -1,6 +1,8 @@
 namespace VoxFlow.Core.Services;
 
 using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using VoxFlow.Core.Configuration;
 using VoxFlow.Core.Interfaces;
 using VoxFlow.Core.Models;
@@ -23,7 +25,11 @@ internal sealed class BatchTranscriptionService : IBatchTranscriptionService
     private readonly IBatchSummaryWriter _summaryWriter;
     private readonly ISpeakerEnrichmentService _speakerEnrichment;
     private readonly IVoxflowTranscriptArtifactWriter _artifactWriter;
+    private readonly ILogger<BatchTranscriptionService> _logger;
 
+    // ILogger<T> is optional (NullLogger fallback) so existing tests that
+    // construct the service directly do not need to thread a logger through.
+    // DI-resolved instances pick up the host's ILogger<T> via ServiceCollectionExtensions.
     public BatchTranscriptionService(
         IConfigurationService configService,
         IValidationService validationService,
@@ -35,7 +41,8 @@ internal sealed class BatchTranscriptionService : IBatchTranscriptionService
         IOutputWriter outputWriter,
         IBatchSummaryWriter summaryWriter,
         ISpeakerEnrichmentService speakerEnrichment,
-        IVoxflowTranscriptArtifactWriter artifactWriter)
+        IVoxflowTranscriptArtifactWriter artifactWriter,
+        ILogger<BatchTranscriptionService>? logger = null)
     {
         ArgumentNullException.ThrowIfNull(configService);
         ArgumentNullException.ThrowIfNull(validationService);
@@ -60,6 +67,7 @@ internal sealed class BatchTranscriptionService : IBatchTranscriptionService
         _summaryWriter = summaryWriter;
         _speakerEnrichment = speakerEnrichment;
         _artifactWriter = artifactWriter;
+        _logger = logger ?? NullLogger<BatchTranscriptionService>.Instance;
     }
 
     public async Task<BatchTranscribeResult> TranscribeBatchAsync(
@@ -232,6 +240,11 @@ internal sealed class BatchTranscriptionService : IBatchTranscriptionService
             catch (Exception ex)
             {
                 fileStopwatch.Stop();
+                _logger.LogError(
+                    ex,
+                    "Batch transcription failed for {InputPath} after {ElapsedMs} ms.",
+                    file.InputPath,
+                    (long)fileStopwatch.Elapsed.TotalMilliseconds);
                 results.Add(new BatchFileResult(
                     file.InputPath, file.OutputPath, "Failed",
                     ex.Message, fileStopwatch.Elapsed, null));

--- a/src/VoxFlow.Core/Services/Diarization/PyannoteSidecarClient.cs
+++ b/src/VoxFlow.Core/Services/Diarization/PyannoteSidecarClient.cs
@@ -32,16 +32,21 @@ public sealed class PyannoteSidecarClient : IDiarizationSidecar
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
     };
 
-    private static readonly Lazy<JsonSchema> ResponseSchema = new(LoadResponseSchema);
+    // Async lazy: NJsonSchema 11 only exposes JsonSchema.FromJsonAsync, so the
+    // previous Lazy<JsonSchema> factory had to call .GetAwaiter().GetResult().
+    // Lazy<Task<JsonSchema>> caches the in-flight Task so concurrent callers
+    // share a single load, and DiarizeAsync awaits it on its own async stack.
+    private static readonly Lazy<Task<JsonSchema>> ResponseSchema = new(LoadResponseSchemaAsync);
 
-    private static JsonSchema LoadResponseSchema()
+    private static Task<JsonSchema> LoadResponseSchemaAsync()
     {
         using var stream = typeof(PyannoteSidecarClient).Assembly
             .GetManifestResourceStream(SchemaResourceName)
             ?? throw new InvalidOperationException(
                 $"Embedded schema '{SchemaResourceName}' not found.");
         using var reader = new StreamReader(stream);
-        return JsonSchema.FromJsonAsync(reader.ReadToEnd()).GetAwaiter().GetResult();
+        var schemaText = reader.ReadToEnd();
+        return JsonSchema.FromJsonAsync(schemaText);
     }
 
     private readonly IPythonRuntime _runtime;
@@ -149,7 +154,8 @@ public sealed class PyannoteSidecarClient : IDiarizationSidecar
                     $"voxflow_diarize.py returned error envelope: {message}");
             }
 
-            var validationErrors = ResponseSchema.Value.Validate(process.StdOut);
+            var schema = await ResponseSchema.Value.ConfigureAwait(false);
+            var validationErrors = schema.Validate(process.StdOut);
             if (validationErrors.Count > 0)
             {
                 var joined = string.Join("; ", validationErrors.Select(e => e.ToString()));

--- a/src/VoxFlow.Core/Services/ModelService.cs
+++ b/src/VoxFlow.Core/Services/ModelService.cs
@@ -62,8 +62,15 @@ internal sealed class ModelService : IModelService, IDisposable
                 using var factory = WhisperFactory.FromPath(options.ModelFilePath);
                 isLoadable = true;
             }
-            catch
+            catch (Exception ex)
             {
+                // Treat any load failure (corrupt file, version mismatch, native load
+                // error) as "needs re-download". Log to stderr so the operator can tell
+                // a corrupt-model recovery from a missing-model first-run; before #46
+                // ships ILogger<T> at the Core composition root, Console.Error is the
+                // only structured sink available without breaking the IModelService API.
+                Console.Error.WriteLine(
+                    $"ModelService.InspectModel: {options.ModelFilePath} failed to load — marking for re-download. {ex.GetType().Name}: {ex.Message}");
                 needsDownload = true;
             }
         }

--- a/src/VoxFlow.Core/Services/ModelService.cs
+++ b/src/VoxFlow.Core/Services/ModelService.cs
@@ -2,6 +2,8 @@ using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using VoxFlow.Core.Configuration;
 using VoxFlow.Core.Interfaces;
 using VoxFlow.Core.Models;
@@ -15,8 +17,14 @@ namespace VoxFlow.Core.Services;
 /// </summary>
 internal sealed class ModelService : IModelService, IDisposable
 {
+    private readonly ILogger<ModelService> _logger;
     private WhisperFactory? _cachedFactory;
     private string? _cachedModelPath;
+
+    public ModelService(ILogger<ModelService>? logger = null)
+    {
+        _logger = logger ?? NullLogger<ModelService>.Instance;
+    }
 
     /// <summary>
     /// Returns a cached factory if available, or creates a new one from the configured model.
@@ -65,12 +73,14 @@ internal sealed class ModelService : IModelService, IDisposable
             catch (Exception ex)
             {
                 // Treat any load failure (corrupt file, version mismatch, native load
-                // error) as "needs re-download". Log to stderr so the operator can tell
-                // a corrupt-model recovery from a missing-model first-run; before #46
-                // ships ILogger<T> at the Core composition root, Console.Error is the
-                // only structured sink available without breaking the IModelService API.
-                Console.Error.WriteLine(
-                    $"ModelService.InspectModel: {options.ModelFilePath} failed to load — marking for re-download. {ex.GetType().Name}: {ex.Message}");
+                // error) as "needs re-download". Logged via ILogger<ModelService> so
+                // the operator can tell a corrupt-model recovery from a missing-model
+                // first-run. Falls back to NullLogger when the host hasn't wired
+                // logging — see ServiceCollectionExtensions logging contract.
+                _logger.LogError(
+                    ex,
+                    "Whisper model at {ModelPath} failed to load; marking for re-download.",
+                    options.ModelFilePath);
                 needsDownload = true;
             }
         }

--- a/src/VoxFlow.Core/Services/TranscriptionService.cs
+++ b/src/VoxFlow.Core/Services/TranscriptionService.cs
@@ -1,6 +1,8 @@
 namespace VoxFlow.Core.Services;
 
 using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using VoxFlow.Core.Configuration;
 using VoxFlow.Core.Interfaces;
 using VoxFlow.Core.Models;
@@ -19,6 +21,7 @@ internal sealed class TranscriptionService : ITranscriptionService
     private readonly IOutputWriter _outputWriter;
     private readonly ISpeakerEnrichmentService _speakerEnrichment;
     private readonly IVoxflowTranscriptArtifactWriter _artifactWriter;
+    private readonly ILogger<TranscriptionService> _logger;
 
     public TranscriptionService(
         IConfigurationService configService,
@@ -29,7 +32,8 @@ internal sealed class TranscriptionService : ITranscriptionService
         ILanguageSelectionService languageSelection,
         IOutputWriter outputWriter,
         ISpeakerEnrichmentService speakerEnrichment,
-        IVoxflowTranscriptArtifactWriter artifactWriter)
+        IVoxflowTranscriptArtifactWriter artifactWriter,
+        ILogger<TranscriptionService>? logger = null)
     {
         _configService = configService;
         _validationService = validationService;
@@ -40,6 +44,7 @@ internal sealed class TranscriptionService : ITranscriptionService
         _outputWriter = outputWriter;
         _speakerEnrichment = speakerEnrichment;
         _artifactWriter = artifactWriter;
+        _logger = logger ?? NullLogger<TranscriptionService>.Instance;
     }
 
     public async Task<TranscribeFileResult> TranscribeFileAsync(
@@ -136,6 +141,10 @@ internal sealed class TranscriptionService : ITranscriptionService
             }
             catch (Exception ex)
             {
+                _logger.LogError(
+                    ex,
+                    "Speaker enrichment failed for {WavPath}; falling back to plain transcript.",
+                    wavPath);
                 var warning = $"speaker-labeling: internal error: {ex.Message}";
                 enrichmentWarnings = new[] { warning };
                 warnings.Add(warning);

--- a/src/VoxFlow.Core/Services/ValidationService.cs
+++ b/src/VoxFlow.Core/Services/ValidationService.cs
@@ -5,6 +5,8 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using VoxFlow.Core.Configuration;
 using VoxFlow.Core.Interfaces;
 using VoxFlow.Core.Models;
@@ -21,18 +23,21 @@ internal sealed class ValidationService : IValidationService
 {
     private readonly IAudioConversionService _audioConversion;
     private readonly ISpeakerLabelingPreflight _speakerPreflight;
+    private readonly ILogger<ValidationService> _logger;
 
     public ValidationService(IAudioConversionService audioConversion)
-        : this(audioConversion, new NullSpeakerLabelingPreflight())
+        : this(audioConversion, new NullSpeakerLabelingPreflight(), logger: null)
     {
     }
 
     public ValidationService(
         IAudioConversionService audioConversion,
-        ISpeakerLabelingPreflight speakerPreflight)
+        ISpeakerLabelingPreflight speakerPreflight,
+        ILogger<ValidationService>? logger = null)
     {
         _audioConversion = audioConversion;
         _speakerPreflight = speakerPreflight;
+        _logger = logger ?? NullLogger<ValidationService>.Instance;
     }
 
     /// <summary>
@@ -165,6 +170,7 @@ internal sealed class ValidationService : IValidationService
         }
         catch (Exception ex)
         {
+            _logger.LogWarning(ex, "ffmpeg validation failed: {Message}", ex.Message);
             return new ValidationCheck("ffmpeg", ValidationCheckStatus.Failed, ex.Message);
         }
     }

--- a/src/VoxFlow.Core/VoxFlow.Core.csproj
+++ b/src/VoxFlow.Core/VoxFlow.Core.csproj
@@ -8,14 +8,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Whisper.net" Version="1.9.0" ExcludeAssets="all" PrivateAssets="all" GeneratePathProperty="true" />
-    <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="10.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.0" />
-    <PackageReference Include="NJsonSchema" Version="11.1.0" />
+    <PackageReference Include="Whisper.net" ExcludeAssets="all" PrivateAssets="all" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.Extensions.AI.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
+    <PackageReference Include="NJsonSchema" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/VoxFlow.Core/VoxFlow.Core.csproj
+++ b/src/VoxFlow.Core/VoxFlow.Core.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Whisper.net" Version="1.9.0" ExcludeAssets="all" PrivateAssets="all" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.0" />

--- a/src/VoxFlow.Desktop/Configuration/DesktopConfigurationService.cs
+++ b/src/VoxFlow.Desktop/Configuration/DesktopConfigurationService.cs
@@ -42,12 +42,19 @@ public class DesktopConfigurationService : IConfigurationService
     }
 
     public Task<TranscriptionOptions> LoadAsync(string? configurationPath = null)
+        => Task.FromResult(LoadCore(configurationPath));
+
+    // Sync core for the configuration load. Both LoadAsync and GetSupportedLanguages
+    // share this so neither has to wait synchronously on the other's Task.
+    // The work is genuinely synchronous (file merge + parse + best-effort cleanup),
+    // so wrapping it in Task.FromResult inside LoadAsync keeps the existing async
+    // surface for callers that prefer it.
+    private TranscriptionOptions LoadCore(string? configurationPath)
     {
         var tempPath = WriteMergedConfigurationSnapshot(configurationPath, applyDesktopRuntimeOverrides: true);
         try
         {
-            var options = TranscriptionOptions.LoadFromPath(tempPath);
-            return Task.FromResult(options);
+            return TranscriptionOptions.LoadFromPath(tempPath);
         }
         finally
         {
@@ -109,7 +116,11 @@ public class DesktopConfigurationService : IConfigurationService
 
     public IReadOnlyList<SupportedLanguage> GetSupportedLanguages(string? configurationPath = null)
     {
-        var options = LoadAsync(configurationPath).GetAwaiter().GetResult();
+        // Use the sync core directly. Calling LoadAsync(...).GetAwaiter().GetResult()
+        // here would be sync-over-async even though LoadAsync's body is itself sync
+        // (Task.FromResult); the pattern still ties up a thread-pool worker on UI
+        // sync contexts and signals risk to readers.
+        var options = LoadCore(configurationPath);
         return options.SupportedLanguages
             .Select((lang, i) => new SupportedLanguage(lang.Code, lang.DisplayName, i))
             .ToList();

--- a/src/VoxFlow.Desktop/MainPage.xaml.cs
+++ b/src/VoxFlow.Desktop/MainPage.xaml.cs
@@ -160,7 +160,38 @@ public partial class MainPage : ContentPage
         e.AcceptedOperation = DataPackageOperation.Copy;
     }
 
+    // async void is reserved for UI event handlers like this one; the framework has no
+    // Task to observe so any uncaught exception escapes to the synchronization context
+    // and crashes the app. Wrap the body in a top-level try/catch that logs the failure
+    // and shows the user a non-crashing error dialog. The inner work runs in
+    // HandleNativeDropCoreAsync, which can be exercised independently of MAUI for tests
+    // that need it.
     private async void HandleNativeDrop(object? sender, DropEventArgs e)
+    {
+        try
+        {
+            await HandleNativeDropCoreAsync(e);
+        }
+        catch (Exception ex)
+        {
+            DesktopDiagnostics.LogException("MainPage.HandleNativeDrop", ex);
+            try
+            {
+                await DisplayAlert(
+                    "Drop failed",
+                    $"VoxFlow could not handle the dropped file: {ex.Message}",
+                    "OK");
+            }
+            catch (Exception alertEx)
+            {
+                // DisplayAlert can fail if the page is detached or the platform handler
+                // is not yet attached — last-ditch logging keeps the failure visible.
+                DesktopDiagnostics.LogException("MainPage.HandleNativeDrop.DisplayAlert", alertEx);
+            }
+        }
+    }
+
+    private async Task HandleNativeDropCoreAsync(DropEventArgs e)
     {
         DesktopDiagnostics.LogInfo("MAUI drop recognizer Drop invoked.");
         if (!_viewModel.CanStart)

--- a/src/VoxFlow.Desktop/Services/DesktopCliTranscriptionService.cs
+++ b/src/VoxFlow.Desktop/Services/DesktopCliTranscriptionService.cs
@@ -245,6 +245,7 @@ internal sealed class DesktopCliTranscriptionService : ITranscriptionService
         }
         catch
         {
+            // Process may have exited between HasExited check and Kill; swallow.
         }
     }
 
@@ -259,6 +260,9 @@ internal sealed class DesktopCliTranscriptionService : ITranscriptionService
         }
         catch
         {
+            // Best-effort cleanup of a disposable merged-config snapshot; a stray temp
+            // file is preferable to surfacing an unrelated cleanup error from the
+            // CLI bridge happy path.
         }
     }
 }

--- a/src/VoxFlow.Desktop/Services/ResultActionService.cs
+++ b/src/VoxFlow.Desktop/Services/ResultActionService.cs
@@ -25,6 +25,11 @@ public sealed class ResultActionService : IResultActionService
         });
     }
 
+    // 10s is generous for /usr/bin/open returning after handing the path to Finder.
+    // The hard cap exists so a stuck launch service or a broken Finder cannot block the
+    // UI thread that awaits this method indefinitely.
+    private static readonly TimeSpan OpenFolderTimeout = TimeSpan.FromSeconds(10);
+
     public async Task OpenResultFolderAsync(string resultFilePath, CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(resultFilePath))
@@ -39,19 +44,56 @@ public sealed class ResultActionService : IResultActionService
             throw new InvalidOperationException("Result folder is unavailable.");
         }
 
+        using var timeoutCts = new CancellationTokenSource(OpenFolderTimeout);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
+        var ct = linkedCts.Token;
+
         using var process = Process.Start(CreateOpenFolderProcessStartInfo(directory))
             ?? throw new InvalidOperationException("Could not start Finder.");
 
-        await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+        // Kill the launcher process if the caller cancels or the per-operation timeout fires.
+        // /usr/bin/open is short-lived in normal use, but this guards against a stuck Launch
+        // Services handoff blocking the UI await indefinitely.
+        using var registration = ct.Register(() =>
+        {
+            try
+            {
+                if (!process.HasExited)
+                {
+                    process.Kill(entireProcessTree: true);
+                }
+            }
+            catch
+            {
+                // Process may have exited between HasExited check and Kill; swallow.
+            }
+        });
+
+        // Drain both streams concurrently with the wait. /usr/bin/open is small, but a
+        // child that fills the stderr pipe buffer (~64 KB on macOS) would otherwise block
+        // at exit waiting for a reader — the same anti-pattern flagged in #40.
+        var stdOutTask = process.StandardOutput.ReadToEndAsync(ct);
+        var stdErrTask = process.StandardError.ReadToEndAsync(ct);
+
+        try
+        {
+            await process.WaitForExitAsync(ct).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+        {
+            throw new InvalidOperationException(
+                $"Finder did not return within {OpenFolderTimeout.TotalSeconds:0}s and was terminated.");
+        }
+
+        var stdOut = await stdOutTask.ConfigureAwait(false);
+        var stdErr = await stdErrTask.ConfigureAwait(false);
+
         if (process.ExitCode == 0)
         {
             return;
         }
 
-        var error = await process.StandardError.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
-        var output = await process.StandardOutput.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
-        var detail = string.IsNullOrWhiteSpace(error) ? output : error;
-
+        var detail = string.IsNullOrWhiteSpace(stdErr) ? stdOut : stdErr;
         throw new InvalidOperationException(
             string.IsNullOrWhiteSpace(detail)
                 ? $"Finder exited with code {process.ExitCode}."

--- a/src/VoxFlow.Desktop/ViewModels/AppViewModel.cs
+++ b/src/VoxFlow.Desktop/ViewModels/AppViewModel.cs
@@ -236,6 +236,9 @@ public class AppViewModel : INotifyPropertyChanged
             if (TranscriptionResult.Success)
             {
                 try { await Task.Delay(1500, cts.Token); }
+                // Cancellation during the post-success settle delay: return to Ready
+                // without surfacing as failure. Outer catch handles cancel during the
+                // actual transcription.
                 catch (OperationCanceledException) { GoToReady(); return; }
             }
             CurrentState = TranscriptionResult.Success ? AppState.Complete : AppState.Failed;

--- a/src/VoxFlow.Desktop/VoxFlow.Desktop.csproj
+++ b/src/VoxFlow.Desktop/VoxFlow.Desktop.csproj
@@ -49,9 +49,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
-    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="$(MauiVersion)" />
+    <PackageReference Include="Microsoft.Maui.Controls" />
+    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" />
   </ItemGroup>
 
   <ItemGroup>
@@ -59,12 +59,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Whisper.net" Version="1.9.0" ExcludeAssets="all" PrivateAssets="all" GeneratePathProperty="true" />
+    <PackageReference Include="Whisper.net" ExcludeAssets="all" PrivateAssets="all" GeneratePathProperty="true" />
     <!-- Restore the runtime packages but wire the native references manually.
          Whisper.net.Runtime 1.9.0 ships arm64-only maccatalyst archives, so
          Desktop uses the generic net9 Whisper.net assembly plus macOS dylibs. -->
-    <PackageReference Include="Whisper.net.Runtime" Version="1.9.0" ExcludeAssets="all" PrivateAssets="all" GeneratePathProperty="true" />
-    <PackageReference Include="Whisper.net.Runtime.Metal" Version="1.9.0" ExcludeAssets="all" PrivateAssets="all" GeneratePathProperty="true" />
+    <PackageReference Include="Whisper.net.Runtime" ExcludeAssets="all" PrivateAssets="all" GeneratePathProperty="true" />
+    <PackageReference Include="Whisper.net.Runtime.Metal" ExcludeAssets="all" PrivateAssets="all" GeneratePathProperty="true" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/VoxFlow.McpServer/Configuration/McpOptions.cs
+++ b/src/VoxFlow.McpServer/Configuration/McpOptions.cs
@@ -17,6 +17,15 @@ public sealed class McpOptions
     public List<string> AllowedOutputRoots { get; set; } = new();
     public int MaxBatchFiles { get; set; } = 100;
     public bool RequireAbsolutePaths { get; set; } = true;
+
+    /// <summary>
+    /// Grace period (in seconds) the host waits for in-flight tool invocations
+    /// to complete on SIGINT / SIGTERM before forcefully terminating. Mapped to
+    /// <see cref="Microsoft.Extensions.Hosting.HostOptions.ShutdownTimeout"/>
+    /// in <c>Program.cs</c>. Default 5 s — matches the .NET host default.
+    /// </summary>
+    public int ShutdownGracePeriodSeconds { get; set; } = 5;
+
     public McpResourceOptions Resources { get; set; } = new();
     public McpPromptOptions Prompts { get; set; } = new();
     public McpLoggingOptions Logging { get; set; } = new();

--- a/src/VoxFlow.McpServer/Program.cs
+++ b/src/VoxFlow.McpServer/Program.cs
@@ -2,6 +2,7 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 using ModelContextProtocol;
 using VoxFlow.Core.DependencyInjection;
 using VoxFlow.McpServer.Configuration;
@@ -16,31 +17,40 @@ Console.SetOut(Console.Error);
 
 var builder = Host.CreateApplicationBuilder(args);
 
-// Load MCP-specific configuration.
+// Single source of truth for McpOptions. The Configure<McpOptions> below makes
+// the same data available to anything that resolves IOptions<McpOptions> from
+// DI; the local instance below is only used for the AddMcpServer lambda
+// (which has no IServiceProvider hook) and for the host shutdown timeout.
 var mcpSection = builder.Configuration.GetSection("mcp");
+var mcpOptions = mcpSection.Get<McpOptions>() ?? new McpOptions();
 builder.Services.Configure<McpOptions>(mcpSection);
+
+// Map the configured grace period onto the .NET host's shutdown timeout so
+// hosted services (including the MCP transport) get a chance to drain
+// in-flight work before the process exits.
+builder.Services.Configure<HostOptions>(host =>
+    host.ShutdownTimeout = TimeSpan.FromSeconds(Math.Max(0, mcpOptions.ShutdownGracePeriodSeconds)));
 
 // Register Core services via DI extension.
 builder.Services.AddVoxFlowCore();
 
-// Register MCP-specific path policy.
+// Register MCP-specific path policy. Resolved via IOptions<McpOptions> so it
+// stays in sync with the single Configure<McpOptions> registration above.
 builder.Services.AddSingleton<IPathPolicy>(sp =>
 {
-    var mcpOptions = new McpOptions();
-    mcpSection.Bind(mcpOptions);
+    var opts = sp.GetRequiredService<IOptions<McpOptions>>().Value;
     return new PathPolicy(
-        mcpOptions.AllowedInputRoots,
-        mcpOptions.AllowedOutputRoots,
-        mcpOptions.RequireAbsolutePaths);
+        opts.AllowedInputRoots,
+        opts.AllowedOutputRoots,
+        opts.RequireAbsolutePaths);
 });
 
-// Configure MCP server with stdio transport.
+// Configure MCP server with stdio transport. AddMcpServer's options callback
+// has no IServiceProvider parameter, so it reads the local mcpOptions
+// captured via closure — the only consumer of the local instance.
 builder.Services
     .AddMcpServer(options =>
     {
-        var mcpOptions = new McpOptions();
-        mcpSection.Bind(mcpOptions);
-
         options.ServerInfo = new()
         {
             Name = mcpOptions.ServerName,
@@ -52,4 +62,13 @@ builder.Services
     .WithPromptsFromAssembly(typeof(WhisperMcpPrompts).Assembly);
 
 var app = builder.Build();
+
+// Surface the shutdown handoff so MCP clients (Claude Desktop, Cursor, etc.)
+// see a trace instead of an abrupt close. Goes to stderr because stdout is
+// reserved for the MCP protocol stream.
+var lifetime = app.Services.GetRequiredService<IHostApplicationLifetime>();
+lifetime.ApplicationStopping.Register(() =>
+    Console.Error.WriteLine(
+        $"[mcp] shutting down — waiting up to {mcpOptions.ShutdownGracePeriodSeconds}s for in-flight tool invocations to drain."));
+
 await app.RunAsync();

--- a/src/VoxFlow.McpServer/VoxFlow.McpServer.csproj
+++ b/src/VoxFlow.McpServer/VoxFlow.McpServer.csproj
@@ -9,11 +9,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
-    <PackageReference Include="ModelContextProtocol" Version="1.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
-    <PackageReference Include="Whisper.net.Runtime" Version="1.9.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="ModelContextProtocol" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="Whisper.net.Runtime" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/TestSupport/LoudSkip.cs
+++ b/tests/TestSupport/LoudSkip.cs
@@ -1,0 +1,30 @@
+using Xunit;
+using Xunit.Abstractions;
+
+/// <summary>
+/// Wrapper around <see cref="Skip.IfNot(bool, string)"/> / <see cref="Skip.If(bool, string)"/>
+/// that emits the skip reason to the xUnit test output sink before the underlying
+/// <see cref="SkipException"/> is raised. Plain Skip.IfNot/If only surface the reason
+/// at xUnit-detailed verbosity, so on default-verbosity CI runs silent skips look
+/// like passing tests. Logging upfront keeps the reason visible regardless of verbosity.
+/// </summary>
+internal static class LoudSkip
+{
+    public static void IfNot(ITestOutputHelper output, bool condition, string reason)
+    {
+        if (!condition)
+        {
+            output.WriteLine($"[SKIP] {reason}");
+        }
+        Skip.IfNot(condition, reason);
+    }
+
+    public static void If(ITestOutputHelper output, bool condition, string reason)
+    {
+        if (condition)
+        {
+            output.WriteLine($"[SKIP] {reason}");
+        }
+        Skip.If(condition, reason);
+    }
+}

--- a/tests/TestSupport/LoudSkip.cs
+++ b/tests/TestSupport/LoudSkip.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -7,10 +8,13 @@ using Xunit.Abstractions;
 /// <see cref="SkipException"/> is raised. Plain Skip.IfNot/If only surface the reason
 /// at xUnit-detailed verbosity, so on default-verbosity CI runs silent skips look
 /// like passing tests. Logging upfront keeps the reason visible regardless of verbosity.
+/// The DoesNotReturnIf attributes preserve the null-flow analysis callers get from
+/// the underlying Skip helpers (e.g. "after LoudSkip.If(x is null, ...) the value is
+/// known non-null").
 /// </summary>
 internal static class LoudSkip
 {
-    public static void IfNot(ITestOutputHelper output, bool condition, string reason)
+    public static void IfNot(ITestOutputHelper output, [DoesNotReturnIf(false)] bool condition, string reason)
     {
         if (!condition)
         {
@@ -19,7 +23,7 @@ internal static class LoudSkip
         Skip.IfNot(condition, reason);
     }
 
-    public static void If(ITestOutputHelper output, bool condition, string reason)
+    public static void If(ITestOutputHelper output, [DoesNotReturnIf(true)] bool condition, string reason)
     {
         if (condition)
         {

--- a/tests/TestSupport/TestFixtureLocator.cs
+++ b/tests/TestSupport/TestFixtureLocator.cs
@@ -1,0 +1,54 @@
+using System;
+using System.IO;
+
+/// <summary>
+/// Resolves on-disk fixture paths for tests in a portable, fail-loud way:
+/// 1. <c>VOXFLOW_TEST_FIXTURES_DIR</c> environment variable wins if set.
+/// 2. Otherwise the path is computed relative to the test assembly via
+///    <see cref="TestProjectPaths.RepositoryRoot"/>.
+/// Tests should pass the result to <see cref="LoudSkip.IfNot"/> with a
+/// reason that names the missing path so silent skips never hide a missing
+/// fixture from CI.
+/// </summary>
+internal static class TestFixtureLocator
+{
+    private const string FixturesDirEnvVar = "VOXFLOW_TEST_FIXTURES_DIR";
+
+    /// <summary>
+    /// Resolve a fixture path under the configured fixtures root. Does not
+    /// check existence — callers gate on <see cref="File.Exists"/> via
+    /// <see cref="LoudSkip"/> so the skip reason includes the resolved path.
+    /// </summary>
+    public static string Resolve(params string[] segments)
+    {
+        ArgumentNullException.ThrowIfNull(segments);
+        var root = ResolveFixturesRoot();
+        return segments.Length == 0
+            ? root
+            : Path.Combine(new[] { root }.Concat(segments).ToArray());
+    }
+
+    /// <summary>
+    /// Build a clear skip reason for a missing fixture, including the
+    /// resolved path and how to override it via environment variable.
+    /// </summary>
+    public static string FormatMissingFixtureReason(string resolvedPath)
+        => $"fixture not present at {resolvedPath}; set {FixturesDirEnvVar} to point at a directory that contains the expected files.";
+
+    private static string ResolveFixturesRoot()
+    {
+        var fromEnv = Environment.GetEnvironmentVariable(FixturesDirEnvVar);
+        if (!string.IsNullOrWhiteSpace(fromEnv))
+        {
+            return fromEnv;
+        }
+
+        // Default: <repo>/artifacts/Input — the location the original
+        // hardcoded paths used. Keeping it as the default means a clean
+        // checkout with the optional fixture set still finds the files
+        // without any env-var ceremony, while CI machines that lack the
+        // fixtures get a clear loud-skip message instead of a confusing
+        // "file not found" assertion.
+        return Path.Combine(TestProjectPaths.RepositoryRoot, "artifacts", "Input");
+    }
+}

--- a/tests/TestSupport/TestProcessRunner.cs
+++ b/tests/TestSupport/TestProcessRunner.cs
@@ -1,52 +1,34 @@
 using System;
 using System.Diagnostics;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 internal static class TestProcessRunner
 {
-    public static async Task<ProcessRunResult> RunAppAsync(string settingsPath, TimeSpan timeout)
-    {
-        var startInfo = CreateStartInfo(settingsPath);
-
-        using var process = new Process { StartInfo = startInfo };
-        process.Start();
-
-        var standardOutputTask = process.StandardOutput.ReadToEndAsync();
-        var standardErrorTask = process.StandardError.ReadToEndAsync();
-        var waitForExitTask = process.WaitForExitAsync();
-        var completedTask = await Task.WhenAny(waitForExitTask, Task.Delay(timeout)).ConfigureAwait(false);
-
-        if (completedTask != waitForExitTask)
-        {
-            try
-            {
-                process.Kill(entireProcessTree: true);
-            }
-            catch
-            {
-                // The process may already be gone when timeout cleanup runs.
-            }
-
-            throw new TimeoutException($"The application did not finish within {timeout}.");
-        }
-
-        var outputBuilder = new StringBuilder();
-        outputBuilder.Append(await standardOutputTask.ConfigureAwait(false));
-        outputBuilder.Append(await standardErrorTask.ConfigureAwait(false));
-
-        return new ProcessRunResult(process.ExitCode, outputBuilder.ToString());
-    }
+    public static Task<ProcessRunResult> RunAppAsync(
+        string settingsPath,
+        TimeSpan timeout,
+        CancellationToken cancellationToken = default)
+        => RunRawAsync(CreateStartInfo(settingsPath), timeout, cancellationToken);
 
     public static async Task<ProcessRunResult> RunAppUntilOutputAsync(
         string settingsPath,
         TimeSpan timeout,
-        string requiredOutput)
+        string requiredOutput,
+        CancellationToken cancellationToken = default)
     {
+        // Per-operation timeout linked with the caller token so cancellation OR timeout
+        // both lead to the same kill-on-cancel codepath; a hung child cannot outlive the
+        // test even if the caller forgets to cancel.
+        using var timeoutCts = new CancellationTokenSource(timeout);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
+        var ct = linkedCts.Token;
+
         var startInfo = CreateStartInfo(settingsPath);
         var outputBuilder = new StringBuilder();
-        // Complete as soon as a known milestone appears in output. This keeps
-        // tests focused on the stage they care about and avoids unnecessary waits.
+        // Complete as soon as a known milestone appears in output. This keeps tests
+        // focused on the stage they care about and avoids unnecessary waits.
         var requiredOutputSeen = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var sync = new object();
 
@@ -66,8 +48,8 @@ internal static class TestProcessRunner
             lock (sync)
             {
                 outputBuilder.AppendLine(line);
-                // Match against the accumulated output so tests can look for text
-                // that may span stdout and stderr ordering differences.
+                // Match against the accumulated output so tests can look for text that
+                // may span stdout and stderr ordering differences.
                 if (outputBuilder.ToString().Contains(requiredOutput, StringComparison.Ordinal))
                 {
                     requiredOutputSeen.TrySetResult();
@@ -82,25 +64,90 @@ internal static class TestProcessRunner
         process.BeginOutputReadLine();
         process.BeginErrorReadLine();
 
+        using var registration = ct.Register(() => TryKillProcess(process));
+
         var waitForExitTask = process.WaitForExitAsync();
-        var completedTask = await Task.WhenAny(requiredOutputSeen.Task, waitForExitTask, Task.Delay(timeout))
-            .ConfigureAwait(false);
+        var completedTask = await Task.WhenAny(requiredOutputSeen.Task, waitForExitTask).ConfigureAwait(false);
 
         if (completedTask == requiredOutputSeen.Task)
         {
+            // Required output arrived before exit — kill the child and wait for it to settle so
+            // the test does not leave a zombie behind when it returns.
             TryKillProcess(process);
             await waitForExitTask.ConfigureAwait(false);
             return new ProcessRunResult(process.ExitCode, outputBuilder.ToString());
         }
 
-        if (completedTask == waitForExitTask)
+        // Process exited on its own. If that was via the timeout/cancel kill path, surface
+        // the right exception; otherwise return the natural exit.
+        if (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
         {
-            return new ProcessRunResult(process.ExitCode, outputBuilder.ToString());
+            throw new TimeoutException($"The application did not reach the expected output within {timeout}.");
         }
 
-        TryKillProcess(process);
-        await waitForExitTask.ConfigureAwait(false);
-        throw new TimeoutException($"The application did not reach the expected output within {timeout}.");
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return new ProcessRunResult(process.ExitCode, outputBuilder.ToString());
+    }
+
+    /// <summary>
+    /// Run an arbitrary process to completion or kill it on cancellation/timeout. Drains
+    /// stdout and stderr concurrently with the wait so a child that fills its stderr pipe
+    /// buffer (~64 KB on macOS) cannot deadlock at exit. Public so cancellation behaviour
+    /// can be exercised in isolation.
+    /// </summary>
+    public static async Task<ProcessRunResult> RunRawAsync(
+        ProcessStartInfo startInfo,
+        TimeSpan timeout,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(startInfo);
+
+        startInfo.RedirectStandardOutput = true;
+        startInfo.RedirectStandardError = true;
+        startInfo.UseShellExecute = false;
+        startInfo.CreateNoWindow = true;
+
+        using var timeoutCts = new CancellationTokenSource(timeout);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
+        var ct = linkedCts.Token;
+
+        using var process = new Process { StartInfo = startInfo };
+        process.Start();
+
+        // Caller cancel OR per-operation timeout fires the same kill path; HasExited race
+        // is swallowed as in DefaultProcessLauncher.
+        using var registration = ct.Register(() => TryKillProcess(process));
+
+        var stdOutTask = process.StandardOutput.ReadToEndAsync(ct);
+        var stdErrTask = process.StandardError.ReadToEndAsync(ct);
+
+        try
+        {
+            await process.WaitForExitAsync(ct).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+        {
+            await DrainSafeAsync(stdOutTask, stdErrTask).ConfigureAwait(false);
+            throw new TimeoutException($"The application did not finish within {timeout}.");
+        }
+
+        var stdOut = await stdOutTask.ConfigureAwait(false);
+        var stdErr = await stdErrTask.ConfigureAwait(false);
+        var combined = new StringBuilder();
+        combined.Append(stdOut);
+        combined.Append(stdErr);
+        return new ProcessRunResult(process.ExitCode, combined.ToString());
+    }
+
+    private static async Task DrainSafeAsync(Task<string> stdOut, Task<string> stdErr)
+    {
+        // Stream reads were started with the linked token; after Kill they may surface
+        // OperationCanceledException or simply complete with whatever was buffered. Either
+        // way, await both so the Tasks are observed (otherwise unobserved-task-exception
+        // shows up later) and any pipe FDs are released here, not at GC time.
+        try { await stdOut.ConfigureAwait(false); } catch { }
+        try { await stdErr.ConfigureAwait(false); } catch { }
     }
 
     private static ProcessStartInfo CreateStartInfo(string settingsPath)

--- a/tests/TestSupport/TestProjectPaths.cs
+++ b/tests/TestSupport/TestProjectPaths.cs
@@ -8,7 +8,9 @@ internal static class TestProjectPaths
 
     public static string RepositoryRoot => RepositoryRootPath.Value;
 
-    public static string AppProjectPath => Path.Combine(RepositoryRoot, "VoxFlow.csproj");
+    // Default app project path used by the legacy TestProcessRunner.RunAppAsync path.
+    // The CLI is the canonical app entry point in this repo.
+    public static string AppProjectPath => Path.Combine(RepositoryRoot, "src", "VoxFlow.Cli", "VoxFlow.Cli.csproj");
 
     private static string FindRepositoryRoot()
     {
@@ -16,9 +18,11 @@ internal static class TestProjectPaths
 
         while (currentDirectory is not null)
         {
-            // Walk upward from the test output directory until the app project is found.
-            var candidateProjectPath = Path.Combine(currentDirectory.FullName, "VoxFlow.csproj");
-            if (File.Exists(candidateProjectPath))
+            // Walk upward from the test output directory until VoxFlow.sln is found.
+            // (The legacy version of this helper looked for VoxFlow.csproj at the root,
+            //  which has not existed since the project moved to a multi-project solution.)
+            var candidateSolutionPath = Path.Combine(currentDirectory.FullName, "VoxFlow.sln");
+            if (File.Exists(candidateSolutionPath))
             {
                 return currentDirectory.FullName;
             }
@@ -26,6 +30,6 @@ internal static class TestProjectPaths
             currentDirectory = currentDirectory.Parent;
         }
 
-        throw new InvalidOperationException("Could not locate the repository root for tests.");
+        throw new InvalidOperationException("Could not locate the repository root for tests (no VoxFlow.sln found above the test output directory).");
     }
 }

--- a/tests/TestSupport/WaitForCondition.cs
+++ b/tests/TestSupport/WaitForCondition.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+/// <summary>
+/// Tiny polling helper that replaces ad-hoc <c>while (!cond) await Task.Delay(10)</c>
+/// loops in async tests. Polls a predicate at a fixed interval until it returns
+/// true or the timeout elapses. Returns the final value so callers can either
+/// branch or assert on it.
+/// </summary>
+internal static class WaitForCondition
+{
+    /// <summary>
+    /// Poll <paramref name="predicate"/> every <paramref name="pollInterval"/> (default 10 ms)
+    /// up to <paramref name="timeout"/> (default 5 s). Returns true if the predicate became
+    /// true within the timeout, false otherwise.
+    /// </summary>
+    public static async Task<bool> WaitForAsync(
+        Func<bool> predicate,
+        TimeSpan? timeout = null,
+        TimeSpan? pollInterval = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        var effectiveTimeout = timeout ?? TimeSpan.FromSeconds(5);
+        var effectivePoll = pollInterval ?? TimeSpan.FromMilliseconds(10);
+
+        using var timeoutCts = new CancellationTokenSource(effectiveTimeout);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
+
+        while (!predicate())
+        {
+            try
+            {
+                await Task.Delay(effectivePoll, linkedCts.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    throw;
+                }
+                // Timeout fired — predicate never became true within the budget.
+                return predicate();
+            }
+        }
+        return true;
+    }
+}

--- a/tests/VoxFlow.Cli.Tests/CliTestProcessRunner.cs
+++ b/tests/VoxFlow.Cli.Tests/CliTestProcessRunner.cs
@@ -1,48 +1,29 @@
 using System;
 using System.Diagnostics;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 internal static class TestProcessRunner
 {
-    public static async Task<ProcessRunResult> RunAppAsync(string settingsPath, TimeSpan timeout)
-    {
-        var startInfo = CreateStartInfo(settingsPath);
-
-        using var process = new Process { StartInfo = startInfo };
-        process.Start();
-
-        var standardOutputTask = process.StandardOutput.ReadToEndAsync();
-        var standardErrorTask = process.StandardError.ReadToEndAsync();
-        var waitForExitTask = process.WaitForExitAsync();
-        var completedTask = await Task.WhenAny(waitForExitTask, Task.Delay(timeout)).ConfigureAwait(false);
-
-        if (completedTask != waitForExitTask)
-        {
-            try
-            {
-                process.Kill(entireProcessTree: true);
-            }
-            catch
-            {
-                // The process may already be gone when timeout cleanup runs.
-            }
-
-            throw new TimeoutException($"The application did not finish within {timeout}.");
-        }
-
-        var outputBuilder = new StringBuilder();
-        outputBuilder.Append(await standardOutputTask.ConfigureAwait(false));
-        outputBuilder.Append(await standardErrorTask.ConfigureAwait(false));
-
-        return new ProcessRunResult(process.ExitCode, outputBuilder.ToString());
-    }
+    public static Task<ProcessRunResult> RunAppAsync(
+        string settingsPath,
+        TimeSpan timeout,
+        CancellationToken cancellationToken = default)
+        => RunRawAsync(CreateStartInfo(settingsPath), timeout, cancellationToken);
 
     public static async Task<ProcessRunResult> RunAppUntilOutputAsync(
         string settingsPath,
         TimeSpan timeout,
-        string requiredOutput)
+        string requiredOutput,
+        CancellationToken cancellationToken = default)
     {
+        // Linked CTS: caller cancel OR per-operation timeout share one kill path. A hung
+        // child cannot outlive the test even if the caller forgets to cancel.
+        using var timeoutCts = new CancellationTokenSource(timeout);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
+        var ct = linkedCts.Token;
+
         var startInfo = CreateStartInfo(settingsPath);
         var outputBuilder = new StringBuilder();
         var requiredOutputSeen = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -78,25 +59,81 @@ internal static class TestProcessRunner
         process.BeginOutputReadLine();
         process.BeginErrorReadLine();
 
+        using var registration = ct.Register(() => TryKillProcess(process));
+
         var waitForExitTask = process.WaitForExitAsync();
-        var completedTask = await Task.WhenAny(requiredOutputSeen.Task, waitForExitTask, Task.Delay(timeout))
-            .ConfigureAwait(false);
+        var completedTask = await Task.WhenAny(requiredOutputSeen.Task, waitForExitTask).ConfigureAwait(false);
 
         if (completedTask == requiredOutputSeen.Task)
         {
+            // Required output arrived — kill the child and wait for it to settle so the
+            // test does not leave a zombie behind when it returns.
             TryKillProcess(process);
             await waitForExitTask.ConfigureAwait(false);
             return new ProcessRunResult(process.ExitCode, outputBuilder.ToString());
         }
 
-        if (completedTask == waitForExitTask)
+        if (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
         {
-            return new ProcessRunResult(process.ExitCode, outputBuilder.ToString());
+            throw new TimeoutException($"The application did not reach the expected output within {timeout}.");
         }
 
-        TryKillProcess(process);
-        await waitForExitTask.ConfigureAwait(false);
-        throw new TimeoutException($"The application did not reach the expected output within {timeout}.");
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return new ProcessRunResult(process.ExitCode, outputBuilder.ToString());
+    }
+
+    /// <summary>
+    /// Run an arbitrary process to completion or kill it on cancellation/timeout. Drains
+    /// stdout and stderr concurrently with the wait so a child that fills its stderr pipe
+    /// buffer (~64 KB on macOS) cannot deadlock at exit.
+    /// </summary>
+    public static async Task<ProcessRunResult> RunRawAsync(
+        ProcessStartInfo startInfo,
+        TimeSpan timeout,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(startInfo);
+
+        startInfo.RedirectStandardOutput = true;
+        startInfo.RedirectStandardError = true;
+        startInfo.UseShellExecute = false;
+        startInfo.CreateNoWindow = true;
+
+        using var timeoutCts = new CancellationTokenSource(timeout);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
+        var ct = linkedCts.Token;
+
+        using var process = new Process { StartInfo = startInfo };
+        process.Start();
+
+        using var registration = ct.Register(() => TryKillProcess(process));
+
+        var stdOutTask = process.StandardOutput.ReadToEndAsync(ct);
+        var stdErrTask = process.StandardError.ReadToEndAsync(ct);
+
+        try
+        {
+            await process.WaitForExitAsync(ct).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+        {
+            await DrainSafeAsync(stdOutTask, stdErrTask).ConfigureAwait(false);
+            throw new TimeoutException($"The application did not finish within {timeout}.");
+        }
+
+        var stdOut = await stdOutTask.ConfigureAwait(false);
+        var stdErr = await stdErrTask.ConfigureAwait(false);
+        var combined = new StringBuilder();
+        combined.Append(stdOut);
+        combined.Append(stdErr);
+        return new ProcessRunResult(process.ExitCode, combined.ToString());
+    }
+
+    private static async Task DrainSafeAsync(Task<string> stdOut, Task<string> stdErr)
+    {
+        try { await stdOut.ConfigureAwait(false); } catch { }
+        try { await stdErr.ConfigureAwait(false); } catch { }
     }
 
     private static ProcessStartInfo CreateStartInfo(string settingsPath)

--- a/tests/VoxFlow.Cli.Tests/VoxFlow.Cli.Tests.csproj
+++ b/tests/VoxFlow.Cli.Tests/VoxFlow.Cli.Tests.csproj
@@ -9,13 +9,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/VoxFlow.Core.Tests/BatchTranscriptionServiceTests.cs
+++ b/tests/VoxFlow.Core.Tests/BatchTranscriptionServiceTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using VoxFlow.Core.Configuration;
 using VoxFlow.Core.Interfaces;
 using VoxFlow.Core.Models;
@@ -356,15 +357,16 @@ public sealed class BatchTranscriptionServiceTests
         Assert.Equal(0, recordingArtifactWriter.CallCount);
     }
 
-    // Skipped because the test is racy on parallel runners: BatchTranscriptionService
-    // reports progress from multiple worker threads and the test asserts presence of a
-    // specific Transcribing-stage update in a plain List<ProgressUpdate>. Two distinct
-    // failure modes have been observed on CI:
-    //   1. "Collection was modified" — concurrent Add during Assert.Contains enumeration.
-    //   2. The Transcribing-stage update is absent from the captured list when the
-    //      production pipeline races past it before the IProgress callback lands.
-    // Issue #42 owns the proper fix (thread-safe capture + deterministic progress contract).
-    [Fact(Skip = "Flaky on parallel runners — race during Assert.Contains and intermittent missing Transcribing-stage update; tracked by #42.")]
+    // Was [Fact(Skip=...)] in PR #55 — the test was flaky on parallel CI runs in two
+    // ways: (1) the underlying List<ProgressUpdate> was being enumerated by Assert.Contains
+    // while a Progress<T> ThreadPool callback was still calling Add, surfacing as "Collection
+    // was modified"; (2) the Transcribing-stage update sometimes hadn't landed by the time
+    // the assertion ran because Progress<T>.Report is asynchronous. SynchronousProgress<T>
+    // calls the handler on the reporting thread inside the production code, so by the time
+    // `await service.TranscribeBatchAsync(...)` returns every progress.Report has already
+    // committed; ConcurrentBag<T> covers the residual case where progress is reported from
+    // multiple worker threads concurrently. Together they make the test deterministic.
+    [Fact]
     public async Task TranscribeBatchAsync_ReportsNestedProgress_ForCurrentFile()
     {
         using var directory = new TemporaryDirectory();
@@ -406,8 +408,8 @@ public sealed class BatchTranscriptionServiceTests
                     DiscoveryStatus.Ready,
                     null)
             ]);
-        var progressUpdates = new List<ProgressUpdate>();
-        var progress = new Progress<ProgressUpdate>(update => progressUpdates.Add(update));
+        var progressUpdates = new ConcurrentBag<ProgressUpdate>();
+        var progress = new SynchronousProgress<ProgressUpdate>(progressUpdates.Add);
 
         var service = new BatchTranscriptionService(
             new StubBatchConfigurationService(settingsPath),
@@ -436,6 +438,17 @@ public sealed class BatchTranscriptionServiceTests
                       update.Message is not null &&
                       update.Message.Contains("[1/1] demo.m4a", StringComparison.Ordinal) &&
                       update.Message.Contains("Transcribing English", StringComparison.Ordinal));
+    }
+
+    // Synchronous IProgress<T>: Progress<T> dispatches callbacks via SynchronizationContext
+    // or ThreadPool, so progressUpdates.Add can race with Assert.Contains' enumeration on
+    // CI. Capturing on the reporting thread is deterministic and exercises the same
+    // production code path. Same shape as SpeakerEnrichmentServiceTests.SynchronousProgress<T>.
+    private sealed class SynchronousProgress<T> : IProgress<T>
+    {
+        private readonly Action<T> _handler;
+        public SynchronousProgress(Action<T> handler) => _handler = handler;
+        public void Report(T value) => _handler(value);
     }
 
     private sealed class StubBatchConfigurationService(string settingsPath) : IConfigurationService

--- a/tests/VoxFlow.Core.Tests/BatchTranscriptionServiceTests.cs
+++ b/tests/VoxFlow.Core.Tests/BatchTranscriptionServiceTests.cs
@@ -356,7 +356,15 @@ public sealed class BatchTranscriptionServiceTests
         Assert.Equal(0, recordingArtifactWriter.CallCount);
     }
 
-    [Fact]
+    // Skipped because the test is racy on parallel runners: BatchTranscriptionService
+    // reports progress from multiple worker threads and the test asserts presence of a
+    // specific Transcribing-stage update in a plain List<ProgressUpdate>. Two distinct
+    // failure modes have been observed on CI:
+    //   1. "Collection was modified" — concurrent Add during Assert.Contains enumeration.
+    //   2. The Transcribing-stage update is absent from the captured list when the
+    //      production pipeline races past it before the IProgress callback lands.
+    // Issue #42 owns the proper fix (thread-safe capture + deterministic progress contract).
+    [Fact(Skip = "Flaky on parallel runners — race during Assert.Contains and intermittent missing Transcribing-stage update; tracked by #42.")]
     public async Task TranscribeBatchAsync_ReportsNestedProgress_ForCurrentFile()
     {
         using var directory = new TemporaryDirectory();

--- a/tests/VoxFlow.Core.Tests/Services/BatchTranscriptionServiceCancellationTests.cs
+++ b/tests/VoxFlow.Core.Tests/Services/BatchTranscriptionServiceCancellationTests.cs
@@ -1,0 +1,391 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using VoxFlow.Core.Configuration;
+using VoxFlow.Core.Interfaces;
+using VoxFlow.Core.Models;
+using VoxFlow.Core.Services;
+using Whisper.net;
+using Xunit;
+
+namespace VoxFlow.Core.Tests.Services;
+
+/// <summary>
+/// Cancellation and temp-WAV cleanup coverage for BatchTranscriptionService.
+/// IAsyncLifetime owns the temp-dir setup/teardown so tests do not have to
+/// orchestrate try/finally Delete blocks of their own (#42 acceptance).
+/// </summary>
+public sealed class BatchTranscriptionServiceCancellationTests : IAsyncLifetime
+{
+    private string _rootDir = null!;
+    private string _inputDir = null!;
+    private string _outputDir = null!;
+    private string _tempDir = null!;
+    private string _settingsPath = null!;
+
+    public Task InitializeAsync()
+    {
+        _rootDir = Path.Combine(Path.GetTempPath(), $"voxflow-batch-cancel-{Guid.NewGuid():N}");
+        _inputDir = Path.Combine(_rootDir, "input");
+        _outputDir = Path.Combine(_rootDir, "output");
+        _tempDir = Path.Combine(_rootDir, "temp");
+        Directory.CreateDirectory(_inputDir);
+        Directory.CreateDirectory(_outputDir);
+        Directory.CreateDirectory(_tempDir);
+
+        _settingsPath = TestSettingsFileFactory.Write(
+            _rootDir,
+            inputFilePath: string.Empty,
+            wavFilePath: string.Empty,
+            resultFilePath: string.Empty,
+            modelFilePath: Path.Combine(_rootDir, "model.bin"),
+            ffmpegExecutablePath: "ffmpeg",
+            processingMode: "batch",
+            batch: new
+            {
+                inputDirectory = _inputDir,
+                outputDirectory = _outputDir,
+                tempDirectory = _tempDir,
+                filePattern = "*.m4a",
+                summaryFilePath = Path.Combine(_outputDir, "summary.txt")
+            });
+
+        return Task.CompletedTask;
+    }
+
+    public Task DisposeAsync()
+    {
+        TryRestoreWritableMode(_tempDir);
+        try
+        {
+            if (Directory.Exists(_rootDir))
+            {
+                Directory.Delete(_rootDir, recursive: true);
+            }
+        }
+        catch
+        {
+            // Test temp dirs are disposable — best-effort cleanup is acceptable.
+        }
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task TranscribeBatchAsync_CancelBetweenFiles_ReturnsPartialResults_RemainingMarkedCancelled()
+    {
+        // Three discovered files. AudioConversion succeeds for file 0 and trips the
+        // shared CTS at the end of file 0's conversion. The loop's between-files
+        // cancellation check then marks files 1 and 2 as Cancelled before they start.
+        var files = BuildDiscoveredFiles("a.m4a", "b.m4a", "c.m4a");
+        using var cts = new CancellationTokenSource();
+        var conversion = new ScriptedAudioConversion(async (index, _, outputPath) =>
+        {
+            await File.WriteAllTextAsync(outputPath, "wav");
+            if (index == 0)
+            {
+                cts.Cancel();
+            }
+        });
+        var service = BuildService(files, conversion);
+
+        var result = await service.TranscribeBatchAsync(
+            new BatchTranscribeRequest(_inputDir, _outputDir, ConfigurationPath: _settingsPath),
+            progress: null,
+            cts.Token);
+
+        Assert.Equal(3, result.TotalFiles);
+        Assert.Equal(1, result.Succeeded);
+        Assert.Equal(0, result.Failed);
+        Assert.Equal(2, result.Skipped); // both Cancelled bucket under Skipped in the integer counters
+        Assert.Equal("Success", result.Results[0].Status);
+        Assert.Equal("Cancelled", result.Results[1].Status);
+        Assert.Equal("Cancelled", result.Results[2].Status);
+        Assert.Contains("cancelled", result.Results[1].ErrorMessage ?? string.Empty, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task TranscribeBatchAsync_CancelDuringFile_DeletesPartialTempWav()
+    {
+        // Two files. AudioConversion writes a partial WAV for file 0 then throws OCE
+        // (simulating a cancellation mid-write). The mid-file catch must record file 0
+        // as Cancelled and the temp-WAV cleanup in `finally` must remove the partial
+        // file so the test directory is left empty.
+        var files = BuildDiscoveredFiles("a.m4a", "b.m4a");
+        var partialWavPath = files[0].TempWavPath;
+        using var cts = new CancellationTokenSource();
+        var conversion = new ScriptedAudioConversion(async (index, _, outputPath) =>
+        {
+            if (index == 0)
+            {
+                await File.WriteAllTextAsync(outputPath, "partial-wav");
+                throw new OperationCanceledException("cancelled mid-file");
+            }
+            await File.WriteAllTextAsync(outputPath, "wav");
+        });
+        var service = BuildService(files, conversion);
+
+        var result = await service.TranscribeBatchAsync(
+            new BatchTranscribeRequest(_inputDir, _outputDir, ConfigurationPath: _settingsPath),
+            progress: null,
+            cts.Token);
+
+        Assert.Equal(2, result.TotalFiles);
+        Assert.Equal(0, result.Succeeded);
+        Assert.Equal("Cancelled", result.Results[0].Status);
+        Assert.Equal("Cancelled", result.Results[1].Status);
+        Assert.False(File.Exists(partialWavPath),
+            $"Partial temp WAV should have been cleaned up by the finally block; still present at {partialWavPath}.");
+    }
+
+    [Fact]
+    public async Task TranscribeBatchAsync_TempWavCleanupFails_BatchCompletesWithoutPropagating()
+    {
+        // POSIX-only: simulate an undeletable temp WAV by writing it inside a directory
+        // whose mode is then dropped to read+execute (no write). File.Delete on the
+        // child raises UnauthorizedAccessException, which CleanupTempWav swallows.
+        // The batch must still complete normally — cleanup failure must not poison the
+        // overall result.
+        if (!OperatingSystem.IsLinux() && !OperatingSystem.IsMacOS())
+        {
+            return; // chmod-style permission tricks are POSIX-only; the test asserts the swallow path.
+        }
+
+        var lockedDir = Path.Combine(_tempDir, "locked");
+        Directory.CreateDirectory(lockedDir);
+        var inputPath = Path.Combine(_inputDir, "demo.m4a");
+        await File.WriteAllTextAsync(inputPath, "stub");
+        var tempWavPath = Path.Combine(lockedDir, "demo.wav");
+        var outputPath = Path.Combine(_outputDir, "demo.txt");
+
+        var files = new List<DiscoveredFile>
+        {
+            new(inputPath, outputPath, tempWavPath, DiscoveryStatus.Ready, null)
+        };
+        var conversion = new ScriptedAudioConversion(async (_, _, wavPath) =>
+        {
+            await File.WriteAllTextAsync(wavPath, "wav");
+            // Drop the parent dir to r-x so File.Delete on the child raises
+            // UnauthorizedAccessException (the path the issue's "permission denied"
+            // scenario targets). DisposeAsync restores write perms before teardown.
+            // The OS check below makes the analyzer happy across the lambda boundary;
+            // the test method itself returns above on non-POSIX platforms.
+            if (OperatingSystem.IsLinux() || OperatingSystem.IsMacOS())
+            {
+                File.SetUnixFileMode(
+                    lockedDir,
+                    UnixFileMode.UserRead | UnixFileMode.UserExecute |
+                    UnixFileMode.GroupRead | UnixFileMode.GroupExecute |
+                    UnixFileMode.OtherRead | UnixFileMode.OtherExecute);
+            }
+        });
+        var service = BuildService(files, conversion);
+
+        var result = await service.TranscribeBatchAsync(
+            new BatchTranscribeRequest(_inputDir, _outputDir, ConfigurationPath: _settingsPath),
+            progress: null,
+            cancellationToken: CancellationToken.None);
+
+        Assert.Equal(1, result.TotalFiles);
+        Assert.Equal(1, result.Succeeded);
+        Assert.Equal(0, result.Failed);
+        Assert.Equal("Success", result.Results[0].Status);
+        // Cleanup failed silently; the WAV is still in the locked dir and DisposeAsync
+        // will restore perms and clean up the temp tree.
+        Assert.True(File.Exists(tempWavPath), "Cleanup was supposed to fail; the partial WAV should still exist.");
+    }
+
+    private List<DiscoveredFile> BuildDiscoveredFiles(params string[] fileNames)
+    {
+        var list = new List<DiscoveredFile>(fileNames.Length);
+        foreach (var name in fileNames)
+        {
+            var inputPath = Path.Combine(_inputDir, name);
+            var outputPath = Path.Combine(_outputDir, Path.ChangeExtension(name, ".txt"));
+            var tempWavPath = Path.Combine(_tempDir, Path.ChangeExtension(name, ".wav"));
+            File.WriteAllText(inputPath, "stub");
+            list.Add(new DiscoveredFile(inputPath, outputPath, tempWavPath, DiscoveryStatus.Ready, null));
+        }
+        return list;
+    }
+
+    private BatchTranscriptionService BuildService(
+        IReadOnlyList<DiscoveredFile> files,
+        IAudioConversionService conversion)
+    {
+        return new BatchTranscriptionService(
+            new StubBatchConfigurationService(_settingsPath),
+            new AlwaysPassValidationService(),
+            new RecordingFileDiscoveryService(files),
+            conversion,
+            new NullModelService(),
+            new TrivialWavAudioLoader(),
+            new TrivialLanguageSelectionService(),
+            new TouchFileOutputWriter(),
+            new RecordingBatchSummaryWriter(),
+            new NullSpeakerEnrichmentService(),
+            new NullVoxflowArtifactWriter());
+    }
+
+    private static void TryRestoreWritableMode(string dir)
+    {
+        if (!OperatingSystem.IsLinux() && !OperatingSystem.IsMacOS())
+        {
+            return;
+        }
+        try
+        {
+            if (Directory.Exists(dir))
+            {
+                File.SetUnixFileMode(
+                    dir,
+                    UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
+                    UnixFileMode.GroupRead | UnixFileMode.GroupExecute |
+                    UnixFileMode.OtherRead | UnixFileMode.OtherExecute);
+                foreach (var sub in Directory.EnumerateDirectories(dir, "*", SearchOption.AllDirectories))
+                {
+                    File.SetUnixFileMode(
+                        sub,
+                        UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
+                        UnixFileMode.GroupRead | UnixFileMode.GroupExecute |
+                        UnixFileMode.OtherRead | UnixFileMode.OtherExecute);
+                }
+            }
+        }
+        catch
+        {
+            // Best-effort restore; DisposeAsync will surface the rmdir failure if any.
+        }
+    }
+
+    private sealed class ScriptedAudioConversion(Func<int, string, string, Task> script) : IAudioConversionService
+    {
+        private int _index = -1;
+
+        public Task ConvertToWavAsync(
+            string inputPath,
+            string outputPath,
+            TranscriptionOptions options,
+            CancellationToken cancellationToken = default)
+        {
+            var thisIndex = Interlocked.Increment(ref _index);
+            return script(thisIndex, inputPath, outputPath);
+        }
+
+        public Task<bool> ValidateFfmpegAsync(
+            TranscriptionOptions options,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(true);
+    }
+
+    private sealed class StubBatchConfigurationService(string settingsPath) : IConfigurationService
+    {
+        public Task<TranscriptionOptions> LoadAsync(string? configurationPath = null)
+            => Task.FromResult(TranscriptionOptions.LoadFromPath(configurationPath ?? settingsPath));
+
+        public IReadOnlyList<SupportedLanguage> GetSupportedLanguages(string? configurationPath = null)
+            => LoadAsync(configurationPath).GetAwaiter().GetResult().SupportedLanguages;
+    }
+
+    private sealed class AlwaysPassValidationService : IValidationService
+    {
+        public Task<ValidationResult> ValidateAsync(
+            TranscriptionOptions options,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(new ValidationResult(
+                "PASSED",
+                CanStart: true,
+                HasWarnings: false,
+                options.ConfigurationPath,
+                [new ValidationCheck("Settings file", ValidationCheckStatus.Passed, options.ConfigurationPath)]));
+    }
+
+    private sealed class RecordingFileDiscoveryService(IReadOnlyList<DiscoveredFile> files) : IFileDiscoveryService
+    {
+        public IReadOnlyList<DiscoveredFile> DiscoverInputFiles(BatchOptions batchOptions, int? maxFiles = null, string outputExtension = ".txt")
+            => files;
+    }
+
+    private sealed class NullModelService : IModelService
+    {
+        public Task<WhisperFactory> GetOrCreateFactoryAsync(
+            TranscriptionOptions options,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult<WhisperFactory>(null!);
+
+        public ModelInfo InspectModel(TranscriptionOptions options)
+            => new(options.ModelFilePath, options.ModelType, false, null, false, true);
+    }
+
+    private sealed class TrivialWavAudioLoader : IWavAudioLoader
+    {
+        public Task<float[]> LoadSamplesAsync(
+            string wavPath,
+            TranscriptionOptions options,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(new float[16_000]);
+    }
+
+    private sealed class TrivialLanguageSelectionService : ILanguageSelectionService
+    {
+        public Task<LanguageSelectionResult> SelectBestCandidateAsync(
+            WhisperFactory factory,
+            float[] audioSamples,
+            TranscriptionOptions options,
+            IProgress<ProgressUpdate>? progress = null,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(new LanguageSelectionResult(
+                new SupportedLanguage("en", "English", 0),
+                0.9,
+                TimeSpan.FromSeconds(1),
+                [new FilteredSegment(TimeSpan.Zero, TimeSpan.FromSeconds(1), "hello", 0.9)],
+                Array.Empty<SkippedSegment>()));
+    }
+
+    private sealed class TouchFileOutputWriter : IOutputWriter
+    {
+        public Task WriteAsync(
+            string outputPath,
+            IReadOnlyList<FilteredSegment> segments,
+            TranscriptOutputContext context,
+            CancellationToken cancellationToken = default)
+        {
+            File.WriteAllText(outputPath, "out");
+            return Task.CompletedTask;
+        }
+
+        public string BuildOutputText(IReadOnlyList<FilteredSegment> segments, TranscriptOutputContext context)
+            => string.Empty;
+    }
+
+    private sealed class RecordingBatchSummaryWriter : IBatchSummaryWriter
+    {
+        public Task WriteAsync(
+            string summaryPath,
+            IReadOnlyList<FileProcessingResult> results,
+            CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+    }
+
+    private sealed class NullSpeakerEnrichmentService : ISpeakerEnrichmentService
+    {
+        public Task<SpeakerEnrichmentResult> EnrichAsync(
+            string wavPath,
+            IReadOnlyList<FilteredSegment> segments,
+            TranscriptMetadata metadata,
+            SpeakerLabelingOptions options,
+            IProgress<ProgressUpdate>? progress,
+            CancellationToken cancellationToken)
+            => Task.FromResult(SpeakerEnrichmentResult.Empty);
+    }
+
+    private sealed class NullVoxflowArtifactWriter : IVoxflowTranscriptArtifactWriter
+    {
+        public Task WriteAsync(
+            string resultPath,
+            TranscriptDocument document,
+            CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+    }
+}

--- a/tests/VoxFlow.Core.Tests/Services/Diarization/PyannoteSidecarClientIntegrationTests.cs
+++ b/tests/VoxFlow.Core.Tests/Services/Diarization/PyannoteSidecarClientIntegrationTests.cs
@@ -6,6 +6,7 @@ using VoxFlow.Core.Models;
 using VoxFlow.Core.Services.Diarization;
 using VoxFlow.Core.Services.Python;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace VoxFlow.Core.Tests.Services.Diarization;
 
@@ -20,6 +21,13 @@ namespace VoxFlow.Core.Tests.Services.Diarization;
 [Trait("Category", "RequiresPython")]
 public sealed class PyannoteSidecarClientIntegrationTests
 {
+    private readonly ITestOutputHelper _output;
+
+    public PyannoteSidecarClientIntegrationTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
     private static string ScriptPath => Path.Combine(
         AppContext.BaseDirectory, "python", "voxflow_diarize.py");
 
@@ -35,11 +43,11 @@ public sealed class PyannoteSidecarClientIntegrationTests
     [SkippableFact]
     public async Task DiarizeAsync_RealSidecar_SingleSpeakerWav_Returns1Speaker()
     {
-        Skip.IfNot(RequiresPythonOptedIn(), OptInSkipReason);
-        Skip.IfNot(File.Exists(ScriptPath), $"sidecar script missing at {ScriptPath}");
-        Skip.IfNot(await SystemPythonRuntimeReadyAsync(),
+        LoudSkip.IfNot(_output, RequiresPythonOptedIn(), OptInSkipReason);
+        LoudSkip.IfNot(_output, File.Exists(ScriptPath), $"sidecar script missing at {ScriptPath}");
+        LoudSkip.IfNot(_output, await SystemPythonRuntimeReadyAsync(),
             "system python3 not ready (missing or below required 3.10)");
-        Skip.IfNot(File.Exists(SingleSpeakerFixturePath),
+        LoudSkip.IfNot(_output, File.Exists(SingleSpeakerFixturePath),
             "fixture not yet committed; will be enabled in P0.8");
 
         var client = CreateClient();
@@ -55,11 +63,11 @@ public sealed class PyannoteSidecarClientIntegrationTests
     [SkippableFact]
     public async Task DiarizeAsync_RealSidecar_TwoSpeakerWav_Returns2Speakers()
     {
-        Skip.IfNot(RequiresPythonOptedIn(), OptInSkipReason);
-        Skip.IfNot(File.Exists(ScriptPath), $"sidecar script missing at {ScriptPath}");
-        Skip.IfNot(await SystemPythonRuntimeReadyAsync(),
+        LoudSkip.IfNot(_output, RequiresPythonOptedIn(), OptInSkipReason);
+        LoudSkip.IfNot(_output, File.Exists(ScriptPath), $"sidecar script missing at {ScriptPath}");
+        LoudSkip.IfNot(_output, await SystemPythonRuntimeReadyAsync(),
             "system python3 not ready (missing or below required 3.10)");
-        Skip.IfNot(File.Exists(TwoSpeakerFixturePath),
+        LoudSkip.IfNot(_output, File.Exists(TwoSpeakerFixturePath),
             "fixture not yet committed; will be enabled in P0.8");
 
         var client = CreateClient();
@@ -74,11 +82,11 @@ public sealed class PyannoteSidecarClientIntegrationTests
     [SkippableFact]
     public async Task DiarizeAsync_RealSidecar_ThreeSpeakerWav_ReturnsAtLeast3Speakers()
     {
-        Skip.IfNot(RequiresPythonOptedIn(), OptInSkipReason);
-        Skip.IfNot(File.Exists(ScriptPath), $"sidecar script missing at {ScriptPath}");
-        Skip.IfNot(await SystemPythonRuntimeReadyAsync(),
+        LoudSkip.IfNot(_output, RequiresPythonOptedIn(), OptInSkipReason);
+        LoudSkip.IfNot(_output, File.Exists(ScriptPath), $"sidecar script missing at {ScriptPath}");
+        LoudSkip.IfNot(_output, await SystemPythonRuntimeReadyAsync(),
             "system python3 not ready (missing or below required 3.10)");
-        Skip.IfNot(File.Exists(ThreeSpeakerFixturePath),
+        LoudSkip.IfNot(_output, File.Exists(ThreeSpeakerFixturePath),
             "fixture not yet committed; will be enabled in P0.8");
 
         var client = CreateClient();

--- a/tests/VoxFlow.Core.Tests/Services/Diarization/SpeakerEnrichmentServiceTests.cs
+++ b/tests/VoxFlow.Core.Tests/Services/Diarization/SpeakerEnrichmentServiceTests.cs
@@ -228,7 +228,10 @@ public sealed class SpeakerEnrichmentServiceTests
         var runtime = new FakePythonRuntime();
         var sidecar = new FakeDiarizationSidecar(async (_, _, ct) =>
         {
-            await Task.Delay(TimeSpan.FromSeconds(30), ct).ConfigureAwait(false);
+            // Block until the linked CTS (driven by options.TimeoutSeconds) cancels us.
+            // No magic upper bound — if cancellation is broken, the suite-level timeout
+            // is the only safety net, which is what we want a regression to surface.
+            await Task.Delay(Timeout.InfiniteTimeSpan, ct).ConfigureAwait(false);
             return new DiarizationResult(1, Array.Empty<DiarizationSpeaker>(), Array.Empty<DiarizationSegment>());
         });
         var mergeService = new ThrowingSpeakerMergeService();
@@ -257,7 +260,10 @@ public sealed class SpeakerEnrichmentServiceTests
         var sidecar = new FakeDiarizationSidecar(async (_, _, ct) =>
         {
             cts.Cancel();
-            await Task.Delay(TimeSpan.FromSeconds(30), ct).ConfigureAwait(false);
+            // After cts.Cancel() the linked token is already cancellation-requested,
+            // so this throws OperationCanceledException synchronously. Timeout.Infinite
+            // documents the intent ("never return on its own — only via ct").
+            await Task.Delay(Timeout.InfiniteTimeSpan, ct).ConfigureAwait(false);
             return new DiarizationResult(1, Array.Empty<DiarizationSpeaker>(), Array.Empty<DiarizationSegment>());
         });
         var mergeService = new ThrowingSpeakerMergeService();

--- a/tests/VoxFlow.Core.Tests/Services/Python/SidecarScriptContractTests.cs
+++ b/tests/VoxFlow.Core.Tests/Services/Python/SidecarScriptContractTests.cs
@@ -6,6 +6,7 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace VoxFlow.Core.Tests.Services.Python;
 
@@ -19,6 +20,13 @@ namespace VoxFlow.Core.Tests.Services.Python;
 [Trait("Category", "RequiresPython")]
 public sealed class SidecarScriptContractTests
 {
+    private readonly ITestOutputHelper _output;
+
+    public SidecarScriptContractTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
     private static string ScriptPath => Path.Combine(
         AppContext.BaseDirectory, "python", "voxflow_diarize.py");
 
@@ -31,10 +39,10 @@ public sealed class SidecarScriptContractTests
     [SkippableFact]
     public async Task RunAgainstSingleSpeakerWav_ReturnsOkResponse_WithOneSpeaker()
     {
-        Skip.IfNot(RequiresPythonOptedIn(), OptInSkipReason);
-        Skip.IfNot(Python3Available(), "python3 not available on PATH");
-        Skip.IfNot(File.Exists(ScriptPath), $"sidecar script missing at {ScriptPath}");
-        Skip.IfNot(File.Exists(SingleSpeakerFixturePath),
+        LoudSkip.IfNot(_output, RequiresPythonOptedIn(), OptInSkipReason);
+        LoudSkip.IfNot(_output, Python3Available(), "python3 not available on PATH");
+        LoudSkip.IfNot(_output, File.Exists(ScriptPath), $"sidecar script missing at {ScriptPath}");
+        LoudSkip.IfNot(_output, File.Exists(SingleSpeakerFixturePath),
             "fixture not yet committed; will be enabled in P0.8");
 
         var result = await RunSidecarAsync(
@@ -51,10 +59,10 @@ public sealed class SidecarScriptContractTests
     [SkippableFact]
     public async Task RunAgainstTwoSpeakerWav_ReturnsOkResponse_WithTwoSpeakers()
     {
-        Skip.IfNot(RequiresPythonOptedIn(), OptInSkipReason);
-        Skip.IfNot(Python3Available(), "python3 not available on PATH");
-        Skip.IfNot(File.Exists(ScriptPath), $"sidecar script missing at {ScriptPath}");
-        Skip.IfNot(File.Exists(TwoSpeakerFixturePath),
+        LoudSkip.IfNot(_output, RequiresPythonOptedIn(), OptInSkipReason);
+        LoudSkip.IfNot(_output, Python3Available(), "python3 not available on PATH");
+        LoudSkip.IfNot(_output, File.Exists(ScriptPath), $"sidecar script missing at {ScriptPath}");
+        LoudSkip.IfNot(_output, File.Exists(TwoSpeakerFixturePath),
             "fixture not yet committed; will be enabled in P0.8");
 
         var result = await RunSidecarAsync(
@@ -70,9 +78,9 @@ public sealed class SidecarScriptContractTests
     [SkippableFact]
     public async Task RunAgainstMissingWav_ReturnsErrorResponse()
     {
-        Skip.IfNot(RequiresPythonOptedIn(), OptInSkipReason);
-        Skip.IfNot(Python3Available(), "python3 not available on PATH");
-        Skip.IfNot(File.Exists(ScriptPath), $"sidecar script missing at {ScriptPath}");
+        LoudSkip.IfNot(_output, RequiresPythonOptedIn(), OptInSkipReason);
+        LoudSkip.IfNot(_output, Python3Available(), "python3 not available on PATH");
+        LoudSkip.IfNot(_output, File.Exists(ScriptPath), $"sidecar script missing at {ScriptPath}");
 
         var missing = Path.Combine(Path.GetTempPath(), $"voxflow-missing-{Guid.NewGuid():N}.wav");
         var result = await RunSidecarAsync(
@@ -89,9 +97,9 @@ public sealed class SidecarScriptContractTests
     [SkippableFact]
     public async Task RunWithMalformedJsonRequest_ReturnsErrorResponse_AndExitsNonZero()
     {
-        Skip.IfNot(RequiresPythonOptedIn(), OptInSkipReason);
-        Skip.IfNot(Python3Available(), "python3 not available on PATH");
-        Skip.IfNot(File.Exists(ScriptPath), $"sidecar script missing at {ScriptPath}");
+        LoudSkip.IfNot(_output, RequiresPythonOptedIn(), OptInSkipReason);
+        LoudSkip.IfNot(_output, Python3Available(), "python3 not available on PATH");
+        LoudSkip.IfNot(_output, File.Exists(ScriptPath), $"sidecar script missing at {ScriptPath}");
 
         var result = await RunSidecarAsync("{ this is not json");
 

--- a/tests/VoxFlow.Core.Tests/TestSupport/LoudSkipTests.cs
+++ b/tests/VoxFlow.Core.Tests/TestSupport/LoudSkipTests.cs
@@ -1,0 +1,62 @@
+using System.Collections.Generic;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace VoxFlow.Core.Tests.TestSupport;
+
+public sealed class LoudSkipTests
+{
+    [Fact]
+    public void IfNot_ConditionFalse_LogsReason_AndThrowsSkip()
+    {
+        var fake = new RecordingTestOutputHelper();
+
+        var ex = Assert.Throws<SkipException>(() =>
+            LoudSkip.IfNot(fake, condition: false, reason: "missing fixture"));
+
+        Assert.Contains("[SKIP] missing fixture", fake.Lines);
+        Assert.Equal("missing fixture", ex.Message);
+    }
+
+    [Fact]
+    public void IfNot_ConditionTrue_NoOutput_NoThrow()
+    {
+        var fake = new RecordingTestOutputHelper();
+
+        LoudSkip.IfNot(fake, condition: true, reason: "should not appear");
+
+        Assert.Empty(fake.Lines);
+    }
+
+    [Fact]
+    public void If_ConditionTrue_LogsReason_AndThrowsSkip()
+    {
+        var fake = new RecordingTestOutputHelper();
+
+        var ex = Assert.Throws<SkipException>(() =>
+            LoudSkip.If(fake, condition: true, reason: "bundle absent"));
+
+        Assert.Contains("[SKIP] bundle absent", fake.Lines);
+        Assert.Equal("bundle absent", ex.Message);
+    }
+
+    [Fact]
+    public void If_ConditionFalse_NoOutput_NoThrow()
+    {
+        var fake = new RecordingTestOutputHelper();
+
+        LoudSkip.If(fake, condition: false, reason: "should not appear");
+
+        Assert.Empty(fake.Lines);
+    }
+
+    private sealed class RecordingTestOutputHelper : ITestOutputHelper
+    {
+        public List<string> Lines { get; } = new();
+
+        public void WriteLine(string message) => Lines.Add(message);
+
+        public void WriteLine(string format, params object[] args)
+            => Lines.Add(string.Format(format, args));
+    }
+}

--- a/tests/VoxFlow.Core.Tests/TestSupport/TestProcessRunnerTests.cs
+++ b/tests/VoxFlow.Core.Tests/TestSupport/TestProcessRunnerTests.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace VoxFlow.Core.Tests.TestSupport;
+
+public sealed class TestProcessRunnerTests
+{
+    [Fact]
+    public async Task RunRawAsync_CancellationKillsHungChild_WithinTwoHundredMilliseconds()
+    {
+        // Acceptance criterion from #40: TestProcessRunner must kill the child process
+        // tree within 200 ms of cancellation. Spawn `sleep 30` (resolved via PATH so the
+        // test works on both macOS and Linux runners) and cancel after the child has
+        // started; the await must throw promptly and the kill must have actually fired.
+        Skip.If(RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
+            "sleep is POSIX-only; the harden targets the Linux core-hosts and macOS desktop CI legs.");
+
+        var startInfo = new ProcessStartInfo("sleep");
+        startInfo.ArgumentList.Add("30");
+
+        using var cts = new CancellationTokenSource();
+        // Generous outer timeout so the test surfaces the cancellation behaviour, not
+        // the timeout codepath (which is exercised separately by RunAppAsync's existing
+        // tests).
+        var task = TestProcessRunner.RunRawAsync(startInfo, TimeSpan.FromMinutes(5), cts.Token);
+
+        // Give the OS a moment to actually start `sleep` so the kill we issue below
+        // really targets a live child.
+        await Task.Delay(50);
+
+        var stopwatch = Stopwatch.StartNew();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => task);
+        stopwatch.Stop();
+
+        Assert.True(
+            stopwatch.ElapsedMilliseconds < 200,
+            $"Cancel-to-kill propagation took {stopwatch.ElapsedMilliseconds} ms; #40 acceptance bound is 200 ms.");
+    }
+}

--- a/tests/VoxFlow.Core.Tests/VoxFlow.Core.Tests.csproj
+++ b/tests/VoxFlow.Core.Tests/VoxFlow.Core.Tests.csproj
@@ -7,16 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="Whisper.net" Version="1.9.0" ExcludeAssets="all" PrivateAssets="all" GeneratePathProperty="true" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Whisper.net" ExcludeAssets="all" PrivateAssets="all" GeneratePathProperty="true" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
-    <PackageReference Include="NJsonSchema" Version="11.1.0" />
-    <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="NJsonSchema" />
+    <PackageReference Include="Xunit.SkippableFact" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/VoxFlow.Desktop.Tests/DesktopCliBundleTests.cs
+++ b/tests/VoxFlow.Desktop.Tests/DesktopCliBundleTests.cs
@@ -1,14 +1,22 @@
 using Xunit;
+using Xunit.Abstractions;
 
 namespace VoxFlow.Desktop.Tests;
 
 public sealed class DesktopCliBundleTests
 {
+    private readonly ITestOutputHelper _output;
+
+    public DesktopCliBundleTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
     [SkippableFact]
     public void MonoBundleCli_IncludesPyannoteSidecarScript()
     {
         var cliBundleDir = ResolveBuiltCliBundleDir();
-        Skip.If(cliBundleDir is null, "Mac Catalyst Desktop app bundle has not been built yet.");
+        LoudSkip.If(_output, cliBundleDir is null, "Mac Catalyst Desktop app bundle has not been built yet.");
 
         var expectedScript = Path.Combine(cliBundleDir, "python", "voxflow_diarize.py");
         Assert.True(
@@ -21,7 +29,7 @@ public sealed class DesktopCliBundleTests
     public void MonoBundleCli_IncludesPythonRequirementsTxt()
     {
         var cliBundleDir = ResolveBuiltCliBundleDir();
-        Skip.If(cliBundleDir is null, "Mac Catalyst Desktop app bundle has not been built yet.");
+        LoudSkip.If(_output, cliBundleDir is null, "Mac Catalyst Desktop app bundle has not been built yet.");
 
         var expectedRequirements = Path.Combine(cliBundleDir, "python", "python-requirements.txt");
         Assert.True(

--- a/tests/VoxFlow.Desktop.Tests/DesktopUiComponentTests.cs
+++ b/tests/VoxFlow.Desktop.Tests/DesktopUiComponentTests.cs
@@ -12,6 +12,14 @@ namespace VoxFlow.Desktop.Tests;
 
 public sealed class DesktopUiComponentTests
 {
+    // Hardcoded POSIX-style paths are non-portable (Windows lacks them). Path.GetTempPath()
+    // resolves to the platform's temp directory at runtime — these helper paths are passed
+    // to mocked services that don't actually touch the filesystem; the helpers exist purely
+    // so assertions and stub data stay platform-agnostic.
+    private static string FakeAudioPath(string fileName) => Path.Combine(Path.GetTempPath(), fileName);
+
+    private static string FakeResultPath(string fileName) => FakeAudioPath(fileName);
+
     [Fact]
     public async Task Routes_WhenInitializationFails_ShowsStartupError_AndRetryRecovers()
     {
@@ -78,11 +86,11 @@ public sealed class DesktopUiComponentTests
         var transcriptionService = new DelegateTranscriptionService((request, _, _) =>
             Task.FromResult(TestTranscriptionFactory.Create(
                 success: true,
-                path: $"/tmp/{Path.GetFileNameWithoutExtension(request.InputPath)}.txt")));
+                path: FakeResultPath($"{Path.GetFileNameWithoutExtension(request.InputPath)}.txt"))));
 
         await using var context = DesktopUiTestContext.Create(transcriptionService: transcriptionService);
         VoxFlow.Desktop.Platform.MacFilePicker.PickAudioFileAsyncHandler =
-            static () => Task.FromResult<string?>("/tmp/interview.m4a");
+            static () => Task.FromResult<string?>(FakeAudioPath("interview.m4a"));
 
         var rendered = await context.RenderAsync<Routes>();
         Assert.Equal(AppState.Ready, context.ViewModel.CurrentState);
@@ -93,7 +101,7 @@ public sealed class DesktopUiComponentTests
             "browse files button");
 
         var delegateTranscriptionService = Assert.IsType<DelegateTranscriptionService>(context.TranscriptionService);
-        Assert.Equal("/tmp/interview.m4a", delegateTranscriptionService.LastFilePath);
+        Assert.Equal(FakeAudioPath("interview.m4a"), delegateTranscriptionService.LastFilePath);
         Assert.Equal(AppState.Complete, context.ViewModel.CurrentState);
         Assert.NotNull(context.ViewModel.TranscriptionResult);
         Assert.True(context.ViewModel.TranscriptionResult!.Success);
@@ -135,7 +143,7 @@ public sealed class DesktopUiComponentTests
 
         await using var context = DesktopUiTestContext.Create(transcriptionService: transcriptionService);
         VoxFlow.Desktop.Platform.MacFilePicker.PickAudioFileAsyncHandler =
-            static () => Task.FromResult<string?>("/tmp/demo.m4a");
+            static () => Task.FromResult<string?>(FakeAudioPath("demo.m4a"));
         var rendered = await context.RenderAsync<Routes>();
 
         await rendered.ClickAsync(
@@ -162,11 +170,11 @@ public sealed class DesktopUiComponentTests
         var transcriptionService = new DelegateTranscriptionService((request, _, _) =>
             Task.FromResult(++attempts == 1
                 ? TestTranscriptionFactory.Create(success: false, warnings: ["retry me"])
-                : TestTranscriptionFactory.Create(success: true, path: $"/tmp/{Path.GetFileNameWithoutExtension(request.InputPath)}.txt")));
+                : TestTranscriptionFactory.Create(success: true, path: FakeResultPath($"{Path.GetFileNameWithoutExtension(request.InputPath)}.txt"))));
 
         await using var context = DesktopUiTestContext.Create(transcriptionService: transcriptionService);
         VoxFlow.Desktop.Platform.MacFilePicker.PickAudioFileAsyncHandler =
-            static () => Task.FromResult<string?>("/tmp/demo.wav");
+            static () => Task.FromResult<string?>(FakeAudioPath("demo.wav"));
         var rendered = await context.RenderAsync<Routes>();
 
         await rendered.ClickAsync(
@@ -183,7 +191,7 @@ public sealed class DesktopUiComponentTests
 
         var delegateTranscriptionService = Assert.IsType<DelegateTranscriptionService>(context.TranscriptionService);
         Assert.Equal(2, attempts);
-        Assert.Equal("/tmp/demo.wav", delegateTranscriptionService.LastFilePath);
+        Assert.Equal(FakeAudioPath("demo.wav"), delegateTranscriptionService.LastFilePath);
         Assert.Equal(AppState.Complete, context.ViewModel.CurrentState);
         Assert.NotNull(context.ViewModel.TranscriptionResult);
         Assert.True(context.ViewModel.TranscriptionResult!.Success);
@@ -197,46 +205,33 @@ public sealed class DesktopUiComponentTests
     {
         var repositoryRoot = Path.GetDirectoryName(ViewModelFactory.ResolveRootSettingsPath())
             ?? throw new InvalidOperationException("Could not resolve repository root.");
-        var inputPath = Path.Combine(repositoryRoot, "artifacts", "Input", fileName);
-        Assert.True(File.Exists(inputPath), $"Expected integration input file to exist: {inputPath}");
+        var inputPath = TestFixtureLocator.Resolve(fileName);
+        Assert.True(File.Exists(inputPath), TestFixtureLocator.FormatMissingFixtureReason(inputPath));
 
-        var tempDir = Path.Combine(Path.GetTempPath(), $"voxflow-ui-real-{Path.GetFileNameWithoutExtension(fileName)}-{Guid.NewGuid():N}");
-        Directory.CreateDirectory(tempDir);
+        // TemporaryDirectory.Dispose handles recursive delete on exit, so the test
+        // body no longer needs a try/finally + bare catch for cleanup.
+        using var tempDir = new TemporaryDirectory();
+        var configPath = WriteSingleFileConfig(repositoryRoot, tempDir.Path, inputPath);
+        await using var context = DesktopUiTestContext.CreateWithRealCore(configPath);
 
-        try
-        {
-            var configPath = WriteSingleFileConfig(repositoryRoot, tempDir, inputPath);
-            await using var context = DesktopUiTestContext.CreateWithRealCore(configPath);
+        VoxFlow.Desktop.Platform.MacFilePicker.PickAudioFileAsyncHandler =
+            () => Task.FromResult<string?>(inputPath);
 
-            VoxFlow.Desktop.Platform.MacFilePicker.PickAudioFileAsyncHandler =
-                () => Task.FromResult<string?>(inputPath);
+        var rendered = await context.RenderAsync<Routes>();
+        Assert.Equal(AppState.Ready, context.ViewModel.CurrentState);
 
-            var rendered = await context.RenderAsync<Routes>();
-            Assert.Equal(AppState.Ready, context.ViewModel.CurrentState);
+        await rendered.ClickAsync(
+            element => element.Name == "button" && element.TextContent == "Choose File",
+            "browse files button");
 
-            await rendered.ClickAsync(
-                element => element.Name == "button" && element.TextContent == "Choose File",
-                "browse files button");
+        var resultFilePath = Path.Combine(tempDir.Path, $"{Path.GetFileNameWithoutExtension(fileName)}.txt");
 
-            var resultFilePath = Path.Combine(tempDir, $"{Path.GetFileNameWithoutExtension(fileName)}.txt");
-
-            Assert.Equal(AppState.Complete, context.ViewModel.CurrentState);
-            Assert.NotNull(context.ViewModel.TranscriptionResult);
-            Assert.True(context.ViewModel.TranscriptionResult!.Success);
-            Assert.Equal(resultFilePath, context.ViewModel.TranscriptionResult.ResultFilePath);
-            Assert.True(File.Exists(resultFilePath), $"Expected result file to exist: {resultFilePath}");
-            Assert.Contains(Path.GetFileName(inputPath), rendered.TextContent);
-        }
-        finally
-        {
-            try
-            {
-                Directory.Delete(tempDir, recursive: true);
-            }
-            catch
-            {
-            }
-        }
+        Assert.Equal(AppState.Complete, context.ViewModel.CurrentState);
+        Assert.NotNull(context.ViewModel.TranscriptionResult);
+        Assert.True(context.ViewModel.TranscriptionResult!.Success);
+        Assert.Equal(resultFilePath, context.ViewModel.TranscriptionResult.ResultFilePath);
+        Assert.True(File.Exists(resultFilePath), $"Expected result file to exist: {resultFilePath}");
+        Assert.Contains(Path.GetFileName(inputPath), rendered.TextContent);
     }
 
     [DesktopRealAudioFact]
@@ -244,44 +239,29 @@ public sealed class DesktopUiComponentTests
     {
         var repositoryRoot = Path.GetDirectoryName(ViewModelFactory.ResolveRootSettingsPath())
             ?? throw new InvalidOperationException("Could not resolve repository root.");
-        var inputPath = Path.Combine(repositoryRoot, "artifacts", "Input", "Test 1.m4a");
-        Assert.True(File.Exists(inputPath), $"Expected integration input file to exist: {inputPath}");
+        var inputPath = TestFixtureLocator.Resolve("Test 1.m4a");
+        Assert.True(File.Exists(inputPath), TestFixtureLocator.FormatMissingFixtureReason(inputPath));
 
-        var tempDir = Path.Combine(Path.GetTempPath(), $"voxflow-ui-ready-{Guid.NewGuid():N}");
-        Directory.CreateDirectory(tempDir);
+        using var tempDir = new TemporaryDirectory();
+        var configPath = WriteSingleFileConfig(repositoryRoot, tempDir.Path, inputPath);
+        await using var context = DesktopUiTestContext.CreateWithRealCore(configPath);
 
-        try
-        {
-            var configPath = WriteSingleFileConfig(repositoryRoot, tempDir, inputPath);
-            await using var context = DesktopUiTestContext.CreateWithRealCore(configPath);
+        VoxFlow.Desktop.Platform.MacFilePicker.PickAudioFileAsyncHandler =
+            () => Task.FromResult<string?>(inputPath);
 
-            VoxFlow.Desktop.Platform.MacFilePicker.PickAudioFileAsyncHandler =
-                () => Task.FromResult<string?>(inputPath);
+        var rendered = await context.RenderAsync<ReadyView>();
 
-            var rendered = await context.RenderAsync<ReadyView>();
+        await rendered.ClickAsync(
+            element => element.Name == "button" && element.TextContent == "Choose File",
+            "browse files button");
 
-            await rendered.ClickAsync(
-                element => element.Name == "button" && element.TextContent == "Choose File",
-                "browse files button");
+        var resultFilePath = Path.Combine(tempDir.Path, "Test 1.txt");
 
-            var resultFilePath = Path.Combine(tempDir, "Test 1.txt");
-
-            Assert.Equal(AppState.Complete, context.ViewModel.CurrentState);
-            Assert.NotNull(context.ViewModel.TranscriptionResult);
-            Assert.True(context.ViewModel.TranscriptionResult!.Success);
-            Assert.Equal(resultFilePath, context.ViewModel.TranscriptionResult.ResultFilePath);
-            Assert.True(File.Exists(resultFilePath), $"Expected result file to exist: {resultFilePath}");
-        }
-        finally
-        {
-            try
-            {
-                Directory.Delete(tempDir, recursive: true);
-            }
-            catch
-            {
-            }
-        }
+        Assert.Equal(AppState.Complete, context.ViewModel.CurrentState);
+        Assert.NotNull(context.ViewModel.TranscriptionResult);
+        Assert.True(context.ViewModel.TranscriptionResult!.Success);
+        Assert.Equal(resultFilePath, context.ViewModel.TranscriptionResult.ResultFilePath);
+        Assert.True(File.Exists(resultFilePath), $"Expected result file to exist: {resultFilePath}");
     }
 
     [Fact]
@@ -317,11 +297,11 @@ public sealed class DesktopUiComponentTests
         var transcriptionService = new DelegateTranscriptionService((request, _, _) =>
             Task.FromResult(TestTranscriptionFactory.Create(
                 success: true,
-                path: $"/tmp/{Path.GetFileNameWithoutExtension(request.InputPath)}.txt")));
+                path: FakeResultPath($"{Path.GetFileNameWithoutExtension(request.InputPath)}.txt"))));
 
         await using var context = DesktopUiTestContext.Create(transcriptionService: transcriptionService);
         VoxFlow.Desktop.Platform.MacFilePicker.PickAudioFileAsyncHandler =
-            static () => Task.FromResult<string?>("/tmp/meeting_01.m4a");
+            static () => Task.FromResult<string?>(FakeAudioPath("meeting_01.m4a"));
 
         var rendered = await context.RenderAsync<Routes>();
 
@@ -348,7 +328,7 @@ public sealed class DesktopUiComponentTests
 
         await using var context = DesktopUiTestContext.Create();
         VoxFlow.Desktop.Platform.MacFilePicker.PickAudioFileAsyncHandler =
-            static () => Task.FromResult<string?>("/tmp/interview.wav");
+            static () => Task.FromResult<string?>(FakeAudioPath("interview.wav"));
         var parameters = ParameterView.FromDictionary(new Dictionary<string, object?>
         {
             [nameof(DropZone.Label)] = "Pick audio",
@@ -363,7 +343,7 @@ public sealed class DesktopUiComponentTests
             element => element.Name == "button" && element.TextContent == "Choose File",
             "browse files button");
 
-        Assert.Equal("/tmp/interview.wav", selectedFile);
+        Assert.Equal(FakeAudioPath("interview.wav"), selectedFile);
         Assert.Contains("Drop audio file here", rendered.TextContent);
     }
 
@@ -420,7 +400,7 @@ public sealed class DesktopUiComponentTests
 
         await using var context = DesktopUiTestContext.Create(transcriptionService: transcriptionService);
         VoxFlow.Desktop.Platform.MacFilePicker.PickAudioFileAsyncHandler =
-            static () => Task.FromResult<string?>("/tmp/long-recording.m4a");
+            static () => Task.FromResult<string?>(FakeAudioPath("long-recording.m4a"));
 
         var rendered = await context.RenderAsync<Routes>();
         Assert.Equal(AppState.Ready, context.ViewModel.CurrentState);
@@ -433,15 +413,12 @@ public sealed class DesktopUiComponentTests
                 "browse files button");
         });
 
-        // Wait until the ViewModel enters Running state
-        var timeout = Task.Delay(TimeSpan.FromSeconds(5));
-        while (context.ViewModel.CurrentState != AppState.Running)
-        {
-            if (timeout.IsCompleted) throw new TimeoutException("ViewModel did not enter Running state.");
-            await Task.Delay(10);
-        }
-
-        Assert.Equal(AppState.Running, context.ViewModel.CurrentState);
+        // Wait until the ViewModel enters Running state. WaitForCondition replaces the
+        // ad-hoc polling loop the test had before; the helper polls at 10 ms with a 5 s
+        // cap and surfaces a clear failure if the predicate never holds.
+        var becameRunning = await WaitForCondition.WaitForAsync(
+            () => context.ViewModel.CurrentState == AppState.Running);
+        Assert.True(becameRunning, "ViewModel did not enter Running state within 5 s.");
 
         // Click Cancel
         context.ViewModel.CancelTranscription();
@@ -460,7 +437,7 @@ public sealed class DesktopUiComponentTests
 
         await using var context = DesktopUiTestContext.Create();
         VoxFlow.Desktop.Platform.MacFilePicker.PickAudioFileAsyncHandler =
-            static () => Task.FromResult<string?>("/tmp/keyboard-test.wav");
+            static () => Task.FromResult<string?>(FakeAudioPath("keyboard-test.wav"));
         var parameters = ParameterView.FromDictionary(new Dictionary<string, object?>
         {
             [nameof(DropZone.OnFileSelected)] = EventCallback.Factory.Create<string>(
@@ -475,7 +452,7 @@ public sealed class DesktopUiComponentTests
             "drop zone div",
             "Enter");
 
-        Assert.Equal("/tmp/keyboard-test.wav", selectedFile);
+        Assert.Equal(FakeAudioPath("keyboard-test.wav"), selectedFile);
     }
 
     [Fact]
@@ -485,7 +462,7 @@ public sealed class DesktopUiComponentTests
 
         await using var context = DesktopUiTestContext.Create();
         VoxFlow.Desktop.Platform.MacFilePicker.PickAudioFileAsyncHandler =
-            static () => Task.FromResult<string?>("/tmp/space-key.wav");
+            static () => Task.FromResult<string?>(FakeAudioPath("space-key.wav"));
         var parameters = ParameterView.FromDictionary(new Dictionary<string, object?>
         {
             [nameof(DropZone.OnFileSelected)] = EventCallback.Factory.Create<string>(
@@ -500,7 +477,7 @@ public sealed class DesktopUiComponentTests
             "drop zone div",
             " ");
 
-        Assert.Equal("/tmp/space-key.wav", selectedFile);
+        Assert.Equal(FakeAudioPath("space-key.wav"), selectedFile);
     }
 
     [Fact]
@@ -510,7 +487,7 @@ public sealed class DesktopUiComponentTests
 
         await using var context = DesktopUiTestContext.Create();
         VoxFlow.Desktop.Platform.MacFilePicker.PickAudioFileAsyncHandler =
-            static () => Task.FromResult<string?>("/tmp/should-not-select.wav");
+            static () => Task.FromResult<string?>(FakeAudioPath("should-not-select.wav"));
         var parameters = ParameterView.FromDictionary(new Dictionary<string, object?>
         {
             [nameof(DropZone.OnFileSelected)] = EventCallback.Factory.Create<string>(
@@ -538,7 +515,7 @@ public sealed class DesktopUiComponentTests
             transcriptionResult: new TranscribeFileResult(
                 Success: true,
                 DetectedLanguage: "en",
-                ResultFilePath: "/tmp/output/result.txt",
+                ResultFilePath: Path.Combine(Path.GetTempPath(), "output", "result.txt"),
                 AcceptedSegmentCount: 5,
                 SkippedSegmentCount: 0,
                 Duration: TimeSpan.FromSeconds(10),
@@ -551,7 +528,7 @@ public sealed class DesktopUiComponentTests
             element => element.Name == "button" && element.TextContent.Contains("Open Folder"),
             "open folder button");
 
-        Assert.Equal(["/tmp/output/result.txt"], context.ResultActionService.OpenedResultPaths);
+        Assert.Equal([Path.Combine(Path.GetTempPath(), "output", "result.txt")], context.ResultActionService.OpenedResultPaths);
     }
 
     [Fact]
@@ -606,7 +583,7 @@ public sealed class DesktopUiComponentTests
         AppViewModelStateAccessor.SetState(
             context.ViewModel,
             currentState: AppState.Running,
-            lastFilePath: "/tmp/audio.m4a");
+            lastFilePath: FakeAudioPath("audio.m4a"));
 
         var rendered = await context.RenderAsync<RunningView>();
 
@@ -664,7 +641,7 @@ public sealed class DesktopUiComponentTests
 
         await using var context = DesktopUiTestContext.Create();
         VoxFlow.Desktop.Platform.MacFilePicker.PickAudioFileAsyncHandler =
-            static () => Task.FromResult<string?>("/tmp/should-not-select.wav");
+            static () => Task.FromResult<string?>(FakeAudioPath("should-not-select.wav"));
         var parameters = ParameterView.FromDictionary(new Dictionary<string, object?>
         {
             [nameof(DropZone.IsDisabled)] = true,
@@ -735,7 +712,7 @@ public sealed class DesktopUiComponentTests
         AppViewModelStateAccessor.SetState(
             context.ViewModel,
             currentState: AppState.Running,
-            lastFilePath: "/tmp/audio.m4a");
+            lastFilePath: FakeAudioPath("audio.m4a"));
 
         var rendered = await context.RenderAsync<RunningView>();
 
@@ -872,7 +849,7 @@ public sealed class DesktopUiComponentTests
             transcriptionResult: new TranscribeFileResult(
                 Success: true,
                 DetectedLanguage: "en",
-                ResultFilePath: "/tmp/result.txt",
+                ResultFilePath: FakeResultPath("result.txt"),
                 AcceptedSegmentCount: 5,
                 SkippedSegmentCount: 0,
                 Duration: TimeSpan.FromSeconds(8),
@@ -971,7 +948,7 @@ public sealed class DesktopUiComponentTests
             transcriptionResult: new TranscribeFileResult(
                 Success: true,
                 DetectedLanguage: "en",
-                ResultFilePath: "/tmp/result.txt",
+                ResultFilePath: FakeResultPath("result.txt"),
                 AcceptedSegmentCount: 5,
                 SkippedSegmentCount: 0,
                 Duration: TimeSpan.FromSeconds(8),
@@ -996,7 +973,7 @@ public sealed class DesktopUiComponentTests
             transcriptionResult: new TranscribeFileResult(
                 Success: true,
                 DetectedLanguage: "en",
-                ResultFilePath: "/tmp/result.voxflow.json",
+                ResultFilePath: FakeResultPath("result.voxflow.json"),
                 AcceptedSegmentCount: 2,
                 SkippedSegmentCount: 0,
                 Duration: TimeSpan.FromSeconds(2),
@@ -1025,7 +1002,7 @@ public sealed class DesktopUiComponentTests
             transcriptionResult: new TranscribeFileResult(
                 Success: true,
                 DetectedLanguage: "en",
-                ResultFilePath: "/tmp/result.txt",
+                ResultFilePath: FakeResultPath("result.txt"),
                 AcceptedSegmentCount: 5,
                 SkippedSegmentCount: 0,
                 Duration: TimeSpan.FromSeconds(8),
@@ -1049,7 +1026,7 @@ public sealed class DesktopUiComponentTests
             transcriptionResult: new TranscribeFileResult(
                 Success: true,
                 DetectedLanguage: "en",
-                ResultFilePath: "/tmp/result.txt",
+                ResultFilePath: FakeResultPath("result.txt"),
                 AcceptedSegmentCount: 5,
                 SkippedSegmentCount: 0,
                 Duration: TimeSpan.FromSeconds(8),
@@ -1073,7 +1050,7 @@ public sealed class DesktopUiComponentTests
             transcriptionResult: new TranscribeFileResult(
                 Success: true,
                 DetectedLanguage: "en",
-                ResultFilePath: "/tmp/result.voxflow.json",
+                ResultFilePath: FakeResultPath("result.voxflow.json"),
                 AcceptedSegmentCount: 1,
                 SkippedSegmentCount: 0,
                 Duration: TimeSpan.FromSeconds(1),

--- a/tests/VoxFlow.Desktop.Tests/VoxFlow.Desktop.Tests.csproj
+++ b/tests/VoxFlow.Desktop.Tests/VoxFlow.Desktop.Tests.csproj
@@ -36,6 +36,10 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\TestSupport\LoudSkip.cs" Link="TestSupport\LoudSkip.cs" />
+    <Compile Include="..\TestSupport\TemporaryDirectory.cs" Link="TestSupport\TemporaryDirectory.cs" />
+    <Compile Include="..\TestSupport\TestProjectPaths.cs" Link="TestSupport\TestProjectPaths.cs" />
+    <Compile Include="..\TestSupport\TestFixtureLocator.cs" Link="TestSupport\TestFixtureLocator.cs" />
+    <Compile Include="..\TestSupport\WaitForCondition.cs" Link="TestSupport\WaitForCondition.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\src\VoxFlow.Desktop\ViewModels\AppViewModel.cs" Link="ViewModels\AppViewModel.cs" />

--- a/tests/VoxFlow.Desktop.Tests/VoxFlow.Desktop.Tests.csproj
+++ b/tests/VoxFlow.Desktop.Tests/VoxFlow.Desktop.Tests.csproj
@@ -35,6 +35,9 @@
     <RazorComponent Include="..\..\src\VoxFlow.Desktop\Components\**\*.razor" Link="Components\%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\TestSupport\LoudSkip.cs" Link="TestSupport\LoudSkip.cs" />
+  </ItemGroup>
+  <ItemGroup>
     <Compile Include="..\..\src\VoxFlow.Desktop\ViewModels\AppViewModel.cs" Link="ViewModels\AppViewModel.cs" />
     <Compile Include="..\..\src\VoxFlow.Desktop\ViewModels\PhaseProgressTracker.cs" Link="ViewModels\PhaseProgressTracker.cs" />
     <Compile Include="..\..\src\VoxFlow.Desktop\Configuration\DesktopConfigurationService.cs" Link="Configuration\DesktopConfigurationService.cs" />

--- a/tests/VoxFlow.Desktop.Tests/VoxFlow.Desktop.Tests.csproj
+++ b/tests/VoxFlow.Desktop.Tests/VoxFlow.Desktop.Tests.csproj
@@ -8,15 +8,15 @@
     <NoWarn>$(NoWarn);BL0006</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="Whisper.net" Version="1.9.0" ExcludeAssets="all" PrivateAssets="all" GeneratePathProperty="true" />
-    <PackageReference Include="Whisper.net.Runtime" Version="1.9.0" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Whisper.net" ExcludeAssets="all" PrivateAssets="all" GeneratePathProperty="true" />
+    <PackageReference Include="Whisper.net.Runtime" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
+    <PackageReference Include="Xunit.SkippableFact" />
   </ItemGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/tests/VoxFlow.Desktop.UiTests/VoxFlow.Desktop.UiTests.csproj
+++ b/tests/VoxFlow.Desktop.UiTests/VoxFlow.Desktop.UiTests.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/VoxFlow.McpServer.Tests/McpConfigurationTests.cs
+++ b/tests/VoxFlow.McpServer.Tests/McpConfigurationTests.cs
@@ -18,6 +18,7 @@ public sealed class McpConfigurationTests
         Assert.Empty(options.AllowedOutputRoots);
         Assert.Equal(100, options.MaxBatchFiles);
         Assert.True(options.RequireAbsolutePaths);
+        Assert.Equal(5, options.ShutdownGracePeriodSeconds);
     }
 
     [Fact]

--- a/tests/VoxFlow.McpServer.Tests/VoxFlow.McpServer.Tests.csproj
+++ b/tests/VoxFlow.McpServer.Tests/VoxFlow.McpServer.Tests.csproj
@@ -9,14 +9,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="Whisper.net" Version="1.9.0" ExcludeAssets="all" PrivateAssets="all" GeneratePathProperty="true" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Whisper.net" ExcludeAssets="all" PrivateAssets="all" GeneratePathProperty="true" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Closes #51 (Epic). Twelve sub-issues closed across P1 (reliability) and P2 (quality gates + observability) — see the Epic comment thread for the full progress log. P3 (documentation: #48, #49, #50) is left as a follow-up cycle on master.

## What this PR does
Rolls the stabilization integration branch `stabilization/epic-51` back into `master` as a single review point. 25 commits, ~1,575 insertions / ~312 deletions across 46 files. Every sub-task was merged into the integration branch via its own PR, ran CI green there, and the integration branch itself has been continuously green throughout the sequence.

## P1 — reliability and correctness (7/7) ✅
- **#36 / PR #52** — Stabilize Speaker Enrichment tests; replaced two `Task.Delay(TimeSpan.FromSeconds(30), ct)` calls with `Task.Delay(Timeout.InfiniteTimeSpan, ct)` so a regression in cancellation propagation surfaces against the suite-level timeout instead of being masked by a 30 s ceiling.
- **#37 / PR #53** — `LoudSkip` helper that emits `[SKIP] {reason}` to xUnit's test-output sink + a CI skip-count gate that fails the job if the `Skipped: N` summary drifts from the documented baseline. Linux Core/CLI/MCP expected `Skipped: 0`; macOS Desktop expected `2` (current empirical baseline — `MtouchLink=SdkOnly` produces a bundle without the CLI bridge, surfacing a pre-existing silent skip).
- **#38 / PR #54** — Eliminated `.GetAwaiter().GetResult()` in `src/`: `PyannoteSidecarClient` switched to `Lazy<Task<JsonSchema>>` async-lazy pattern; `DesktopConfigurationService` factored a private sync `LoadCore` that both `LoadAsync` and `GetSupportedLanguages` call.
- **#39 / PR #55** — Wrapped `MainPage.HandleNativeDrop` (the only `async void` in `src/`) in a top-level try/catch with `DesktopDiagnostics.LogException` + `DisplayAlert`. Documented the async/concurrency rules in `CONTRIBUTING.md`.
- **#40 / PR #56** — Hardened `Process.Start` usage across `src/` and `tests/TestSupport/`: `ResultActionService.OpenResultFolderAsync` drains streams + cancel-kill + 10 s timeout; `TestProcessRunner` accepts `CancellationToken`, uses linked CTS + drained streams + new `RunRawAsync` primitive. New regression test asserts cancellation kills a `sleep 30` child within 200 ms.
- **#42 / PR #57** — Cancellation + temp-WAV cleanup tests for `BatchTranscriptionService` via xUnit `IAsyncLifetime`. Also un-skipped the parallel-flaky `TranscribeBatchAsync_ReportsNestedProgress_ForCurrentFile` test by fixing its production root cause: `CreateBatchFileProgressReporter` now uses a synchronous `DelegateProgress<T>` adapter (same shape as `SpeakerEnrichmentService.DelegateProgress<T>`) instead of `Progress<T>` that queued every per-file event to the ThreadPool.
- **#43 / PR #58** — Replaced hardcoded fixture paths and ad-hoc temp dirs in `DesktopUiComponentTests`. New `TestFixtureLocator` (env var `VOXFLOW_TEST_FIXTURES_DIR` override + sensible default), `WaitForCondition` polling helper, fixed `TestProjectPaths.cs` (was looking for non-existent `VoxFlow.csproj`).

## P2 — quality gates and observability (5/5) ✅
- **#41 / PR #59** — Every `catch` in `src/` now rethrows, logs, or carries a one-line justification comment. `CONTRIBUTING.md` documents the rule with strict acceptance grep.
- **#44 / PR #62** — `Directory.Packages.props` centralizes 21 NuGet package versions; `global.json` pins .NET SDK to 9.0.x with `rollForward: latestFeature`. All 9 `.csproj`s versionless.
- **#46 / PR #61** — `ILogger<T>` infrastructure at the Core composition root (Phase 1). Five services (`Model`, `BatchTranscription`, `AudioConversion`, `Validation`, `Transcription`) constructor-inject `ILogger<T>` with `NullLogger<T>` fallback so existing tests don't need a logger. Follow-up #60 tracks host wiring + composition path.
- **#47 / PR #63** — `McpOptions` binding deduped from 3 sites to 1; `PathPolicy` resolves `IOptions<McpOptions>` via DI. Graceful-shutdown stderr message + `HostOptions.ShutdownTimeout` mapped to `McpOptions.ShutdownGracePeriodSeconds` (default 5).
- **#45 / PR #64** — `TreatWarningsAsErrors=true` + `EnforceCodeStyleInBuild=true` + `AnalysisLevel=latest-default` in `Directory.Build.props`. `.editorconfig` at repo root for future per-rule severity overrides. Existing code is already clean at `latest-default` — no production fixes needed.

## P3 — documentation (open, follow-up cycle)
- [ ] **#48** — `docs/runbooks/error-catalog.md`
- [ ] **#49** — MCP server security model + `PathPolicy` semantics
- [ ] **#50** — Desktop developer setup (macOS / Xcode / MAUI prereqs)

## Notable follow-ups surfaced during P1+P2 (not yet ticketed unless linked)
- **#60** — Phase 2 of `ILogger<T>` rollout: CLI / MCP / Desktop hosts + composition-built services (`SpeakerEnrichmentService`, `PyannoteSidecarClient`).
- **TestProcessRunner duplication** — `tests/TestSupport/TestProcessRunner.cs` ↔ `tests/VoxFlow.Cli.Tests/CliTestProcessRunner.cs` (and the two `TestProjectPaths` siblings) — same shape after #40's harden.
- **macOS Desktop bundle CI** — `DesktopCliBundleTests` skip baseline frozen at 2 because `MtouchLink=SdkOnly` skips `CopyBundledCliBridge`. Tracked as TODO in `.github/workflows/ci.yml`; the right fix populates the bundle in CI.
- **DesktopRealAudio attributes** — still hardcodes `artifacts/Input`. Adopt `TestFixtureLocator` so `VOXFLOW_TEST_FIXTURES_DIR` flows end-to-end.
- **Stricter analyzers** — `latest-recommended` surfaces ~30 errors (mostly CA1848 LoggerMessage delegates, CA1859 concrete-list returns, CA1305 globalization). Path forward: enable per-rule via `.editorconfig` after a focused PR fixes each batch.

## Verification
- 25 commits, every sub-PR ran the same CI matrix green on the integration branch.
- Final integration branch CI on #64: Core/CLI/MCP 57 s, Desktop 2m1s, CodeQL pass, C# analysis pass.
- Local last run: Core 355/355 (`Category!=RequiresPython`), CLI 29/29, MCP 39/39, Desktop 145/2-skip, Desktop net9.0-maccatalyst build clean.
- `dotnet build VoxFlow.sln --no-incremental` → `0 Warning(s), 0 Error(s)`.

## Merge expectations
- **Squash vs merge commit**: a merge commit preserves the per-issue history (25 commits, each pointing back to its issue and sub-PR). Recommend keeping individual commits so `git blame` lands on the right sub-PR.
- After merge, P3 (#48, #49, #50) proceeds on `master` in a separate branch — no further `stabilization/epic-51` work expected.
