### PR TITLE
docs(mcp): document security model + PathPolicy semantics + per-option reference (#49)

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ The shared pipeline remains configuration loading, startup validation, ffmpeg-ba
 | [Architecture Decisions](docs/adr/README.md) | ADR index and decision log |
 | [Architecture Overview](ARCHITECTURE.md) | High-level architecture summary |
 | [Deployment](docs/deployment/macos-packaging.md) | macOS packaging and distribution |
+| [MCP server security model](docs/deployment/mcp-server-security.md) | Threat model, `PathPolicy` semantics, per-option reference, deployment gaps |
 | [Runbooks](docs/runbooks/) | Smoke tests, troubleshooting, Desktop UI automation |
 | [Error catalog](docs/runbooks/error-catalog.md) | Every user-facing error with root cause, remediation, and source-line link |
 | [PRD](docs/product/PRD.md) | Product requirements document |

--- a/docs/deployment/mcp-server-security.md
+++ b/docs/deployment/mcp-server-security.md
@@ -1,0 +1,101 @@
+# MCP server security model
+
+This document explains the security boundary the VoxFlow MCP server enforces, how it is configured, and what it explicitly does not protect against. Read it before deploying `VoxFlow.McpServer` behind an MCP-capable client (Claude Desktop, Cursor, VS Code MCP, etc.).
+
+## Threat model
+
+The MCP server is a stdio process that an MCP-capable client launches and talks to over stdin / stdout. The client passes file paths to the server's tools (`transcribe_file`, `transcribe_batch`, etc.); the server reads input audio, writes output transcripts, and may launch ffmpeg + Python sidecars. The server runs **with the user's full filesystem permissions** — there is no sandbox, no chroot, no seccomp.
+
+The whole protection surface lives in [`PathPolicy`](../../src/VoxFlow.McpServer/Security/PathPolicy.cs): every tool that takes a path passes it through `ValidateInputPath` or `ValidateOutputPath` before touching disk. The policy is configured through the `mcp` section of [`appsettings.json`](../../src/VoxFlow.McpServer/appsettings.json) (see [appsettings reference](../../src/VoxFlow.McpServer/appsettings.json.md)).
+
+### What `PathPolicy` defends against
+
+| Attack | Defense | Source |
+|---|---|---|
+| **Path traversal via `..`** — `transcribe_file("/Users/me/audio/../../etc/passwd")` | `ContainsTraversalSegments` rejects any path containing `..` before resolution. | [`PathPolicy.cs:120`](../../src/VoxFlow.McpServer/Security/PathPolicy.cs#L120) |
+| **Path traversal via `~`** — `transcribe_file("~/.ssh/id_rsa")` (the .NET runtime does not expand `~`, but a polite-looking path is a red flag). | `ContainsTraversalSegments` rejects any `~`. | [`PathPolicy.cs:120`](../../src/VoxFlow.McpServer/Security/PathPolicy.cs#L120) |
+| **Null-byte injection** — `transcribe_file("/safe/path\0/etc/passwd")`. | `ContainsTraversalSegments` rejects any `\0`. | [`PathPolicy.cs:120`](../../src/VoxFlow.McpServer/Security/PathPolicy.cs#L120) |
+| **Reading outside allowed input roots** (when configured) | `IsUnderAnyRoot` checks the normalized path starts with one of the allowed roots. | [`PathPolicy.cs:109`](../../src/VoxFlow.McpServer/Security/PathPolicy.cs#L109) |
+| **Writing outside allowed output roots** (when configured) | Same check on the output-root list. | [`PathPolicy.cs:109`](../../src/VoxFlow.McpServer/Security/PathPolicy.cs#L109) |
+| **Prefix-match attack** — `/Users/me/audio-evil` satisfying a root of `/Users/me/audio`. | `NormalizeRoots` forces a trailing separator on every configured root, so the `StartsWith` check needs a full segment boundary. | [`PathPolicy.cs:127`](../../src/VoxFlow.McpServer/Security/PathPolicy.cs#L127) |
+| **Relative path tricks** — `transcribe_file("audio/clip.m4a")` interpreted against the server's CWD. | `requireAbsolutePaths=true` (default) forces every path through `Path.IsPathRooted`. | [`PathPolicy.cs:94`](../../src/VoxFlow.McpServer/Security/PathPolicy.cs#L94) |
+| **Batch-size DoS** — `transcribe_batch` invoked with a directory holding 10 000 files. | `maxBatchFiles` (default 100) caps how many files one call processes. Enforced inside the batch tool, not in `PathPolicy` itself. | [`McpOptions.cs`](../../src/VoxFlow.McpServer/Configuration/McpOptions.cs) |
+
+### What `PathPolicy` does **NOT** defend against
+
+Read these before deploying — each is a real gap, not a theoretical one.
+
+| Gap | Why it matters | Mitigation |
+|---|---|---|
+| **Empty `allowedInputRoots` / `allowedOutputRoots` mean no root check at all.** The default `appsettings.json` ships with `[]` for both. With the defaults, any absolute path that survives the traversal/null/relative checks is accepted — including `/etc/`, `~/.ssh/`, anywhere the user has read access. | The default config is **unrestricted by design** because root paths are deployment-specific. The server is "safe" only after you've populated both lists. | Always set `allowedInputRoots` and `allowedOutputRoots` before exposing the server to an MCP client. See [worked example](#worked-example) below. |
+| **Symlink traversal.** `Path.GetFullPath` does not resolve symlinks. A symlink inside an allowed root pointing outside still satisfies the check. | If `~/Audio/` is allowed and `~/Audio/secrets -> /etc/` exists, `transcribe_file("~/Audio/secrets/passwd")` is accepted. | Audit your allowed roots for symlinks; for production deployments treat the allow-list as a "trusted directory" promise, not a sandbox. |
+| **TOCTOU between policy check and file IO.** `ValidateInputPath` runs before the actual `File.Open*` / ffmpeg launch. A symlink swap between the two is not detected. | Same threat as symlink traversal; same mitigation. The window is small (microseconds) but real. | Restrict file ownership in the allowed roots to the same user running the MCP server. |
+| **No content validation.** `PathPolicy` only checks the path, not what is at the path. A path under an allowed root that points at a malicious WAV crafted to crash ffmpeg or pyannote still gets processed. | Crash / RCE risk is bounded by ffmpeg / pyannote.audio / Whisper.net hardness, not by VoxFlow. | Keep those dependencies up to date. The diarization sidecar is a separate Python process, which limits blast radius to the venv. |
+| **No rate limiting / concurrency caps.** Each tool call is processed sequentially per the MCP server, but an MCP client can fire a thousand calls back-to-back. | Disk fill, CPU exhaustion, model-cache thrashing. | `maxBatchFiles` only caps the per-call work. For broader rate limiting, run the server in a wrapper that enforces it. |
+| **`logging.writeToFile` writes to whatever path you set.** That path is **not** filtered through `PathPolicy`. | A misconfigured `logFilePath` can write large logs anywhere the server has access. | Treat `logFilePath` as a trusted setting — only operators (you) should ever change it. |
+
+## Per-option reference
+
+See [`src/VoxFlow.McpServer/appsettings.json.md`](../../src/VoxFlow.McpServer/appsettings.json.md) for every option in the `mcp` section: default, recommended value, what attack it prevents, and what happens when set permissively.
+
+## Worked example
+
+Scenario: you want the MCP server to transcribe files in `~/Audio/` and write transcripts to `~/Audio/transcripts/`. Nothing else.
+
+```jsonc
+{
+  "mcp": {
+    "enabled": true,
+    "transport": "stdio",
+
+    // PathPolicy gates — the heart of the security boundary.
+    "allowedInputRoots":  [ "/Users/YOURNAME/Audio" ],
+    "allowedOutputRoots": [ "/Users/YOURNAME/Audio/transcripts" ],
+    "requireAbsolutePaths": true,
+
+    // Batch-DoS cap; tune to the largest legitimate batch you expect.
+    "maxBatchFiles": 100,
+    "allowBatch": true,
+
+    // Optional advertisement; clients display these to the user.
+    "serverName": "voxflow",
+    "serverVersion": "1.0.0",
+
+    // Logging — `writeToFile` writes wherever you point it; not gated by PathPolicy.
+    "logging": {
+      "minimumLevel": "Information",
+      "writeToStdErr": true,
+      "writeToFile": false,
+      "logFilePath": ""
+    }
+  }
+}
+```
+
+Notes:
+- **Absolute paths only.** The defaults `~/Audio` and `~/Audio/transcripts` do **not** work — `~` is rejected by `ContainsTraversalSegments`. Use the fully expanded path (`/Users/yourname/Audio` on macOS, `/home/yourname/Audio` on Linux).
+- **Output root nested under input root is fine.** The lists are checked independently.
+- **Want read-only?** Leave `allowedOutputRoots = []` and the server will refuse every write — but every tool that writes (`transcribe_file`, `transcribe_batch`) will fail. There is currently no read-only mode flag; emptying output roots is the closest equivalent and breaks the write tools.
+
+## Limits (gaps acknowledged)
+
+This is the short list of attacks `PathPolicy` cannot block, intended for explicit acknowledgement before deployment:
+
+1. **Empty allow-lists = no restriction** — see the top of the gaps table above. The default config is intentionally permissive; restricting it is the operator's job.
+2. **Symlinks inside allowed roots** — `PathPolicy` does not call `realpath()` / `Path.GetFullPath` does not resolve symlinks. Audit the roots manually.
+3. **TOCTOU races** — micro-window between path validation and file IO. Restrict ownership of the allowed roots to the server's user account.
+4. **Content-level attacks** — malicious media files can still trigger crashes / OOM in ffmpeg / pyannote / Whisper.net. Keep those dependencies current.
+5. **No per-client identity** — the MCP stdio transport has no notion of "which client is calling". Every connection has the same privileges.
+6. **No audit log of denied requests** — `UnauthorizedAccessException` is thrown, the MCP client gets an error envelope, but there is no structured log of "client X tried to read /etc/passwd at T". `logging.writeToStdErr` captures the operational stderr, not denied-request audit. Track via the host's stderr capture if needed.
+
+## Reference implementation
+
+- Path validation: [`src/VoxFlow.McpServer/Security/PathPolicy.cs`](../../src/VoxFlow.McpServer/Security/PathPolicy.cs).
+- Option binding: [`src/VoxFlow.McpServer/Configuration/McpOptions.cs`](../../src/VoxFlow.McpServer/Configuration/McpOptions.cs).
+- Composition root and DI wiring: [`src/VoxFlow.McpServer/Program.cs`](../../src/VoxFlow.McpServer/Program.cs).
+- Test coverage: [`tests/VoxFlow.McpServer.Tests/PathPolicyTests.cs`](../../tests/VoxFlow.McpServer.Tests/PathPolicyTests.cs).
+
+## Related
+
+- [Error catalog](../runbooks/error-catalog.md) — the `Path is not under any allowed … root` / `Path contains traversal sequences` / `Path must be absolute` patterns are listed there with their throwing lines.
+- [Speaker labeling runbook](../runbooks/speaker-labeling.md) — the diarization sidecar runs as a separate Python process started by VoxFlow.Core, **not** by the MCP server directly; its security boundary is "what the venv can do as the local user".

--- a/src/VoxFlow.McpServer/appsettings.json.md
+++ b/src/VoxFlow.McpServer/appsettings.json.md
@@ -1,0 +1,69 @@
+# MCP server `appsettings.json` reference
+
+`appsettings.json` is plain JSON and cannot carry inline comments, so this file documents every option in the `mcp` section. It is the per-option reference paired with [`docs/deployment/mcp-server-security.md`](../../docs/deployment/mcp-server-security.md), which covers the threat model end-to-end. **Read the security doc first** if you are about to expose the server to an MCP client.
+
+Bound to [`McpOptions`](Configuration/McpOptions.cs) at startup. See `Program.cs` for the binding pipeline.
+
+## Top-level options
+
+| Option | Type | Default | Recommended | Notes |
+|---|---|---|---|---|
+| `enabled` | `bool` | `true` | `true` for any deployed server | Master switch. When `false` the server still starts but tools may refuse. Today there is no shutdown path tied to this; it is a config gate the host can branch on. |
+| `transport` | `string` | `"stdio"` | `"stdio"` | The only supported transport. Reserved for future HTTP/socket transports. |
+| `serverName` | `string` | `"voxflow"` | Brand-specific (`"voxflow-prod"`, `"voxflow-staging"`) | Advertised to MCP clients via the `serverInfo` handshake. Clients display this. |
+| `serverVersion` | `string` | `"1.0.0"` | Pinned to your release | Advertised to MCP clients. Bump on every published change so clients can detect rollouts. |
+| `allowBatch` | `bool` | `true` | `false` if you want to disable `transcribe_batch` | Gates the batch-transcription tool. If `false`, only single-file transcription is exposed. |
+| `allowedInputRoots` | `string[]` | `[]` | **MUST be populated** for deployed servers | See the [security doc gaps table](../../docs/deployment/mcp-server-security.md#what-pathpolicy-does-not-defend-against) — `[]` means no read restriction. Set this to one or more absolute directory paths. Paths must be **absolute** when `requireAbsolutePaths=true`. |
+| `allowedOutputRoots` | `string[]` | `[]` | **MUST be populated** for deployed servers | Same shape and semantics as `allowedInputRoots`, but for write paths (`transcribe_file`'s `outputPath`, batch's output directory). |
+| `maxBatchFiles` | `int` | `100` | Sized to your largest legitimate batch | Caps how many files one `transcribe_batch` call processes. Defense against batch-size DoS. Does **not** rate-limit successive calls. |
+| `requireAbsolutePaths` | `bool` | `true` | `true` | When `true`, every path passed to a tool must be absolute. Blocks "relative path interpreted against server CWD" attacks. Leave at `true` unless you have a deliberate reason and have audited every caller. |
+| `shutdownGracePeriodSeconds` | `int` | `5` | `5`–`30` depending on workload | How long the .NET host waits for in-flight tool invocations to drain on SIGINT/SIGTERM. Maps to `HostOptions.ShutdownTimeout`. Increase if your longest tool call can exceed 5 s and you want clean shutdowns. |
+
+## `resources` subsection
+
+Reserved for future "MCP resources" capability — the server can expose read-only resources (last-run summaries, configuration) to clients without going through a tool call.
+
+| Option | Type | Default | Notes |
+|---|---|---|---|
+| `resources.enabled` | `bool` | `true` | Master switch for the resources feature. |
+| `resources.exposeLastRun` | `bool` | `true` | If `true`, exposes the most recent transcription's metadata as an MCP resource. |
+
+## `prompts` subsection
+
+Same shape — gates predefined MCP prompts.
+
+| Option | Type | Default | Notes |
+|---|---|---|---|
+| `prompts.enabled` | `bool` | `true` | Master switch for the prompts feature. |
+
+## `logging` subsection
+
+Server-side logging. **Not** filtered through `PathPolicy` — `logFilePath` writes wherever you point it.
+
+| Option | Type | Default | Notes |
+|---|---|---|---|
+| `logging.minimumLevel` | `string` | `"Information"` | Standard `ILogger` levels: `Trace`, `Debug`, `Information`, `Warning`, `Error`, `Critical`, `None`. |
+| `logging.writeToStdErr` | `bool` | `true` | Writes logs to **stderr** (stdout is reserved for the MCP protocol stream). Keep `true` for `stdio` transport. |
+| `logging.writeToFile` | `bool` | `false` | When `true`, also writes to `logFilePath`. |
+| `logging.logFilePath` | `string` | `""` | File-sink target. Treat as a trusted operator setting — `PathPolicy` does **not** validate this path. |
+
+## Minimal safe config
+
+The shortest config that locks the server down for a single user transcribing `~/Audio/` (expand `~` to the absolute path your shell resolves):
+
+```json
+{
+  "mcp": {
+    "allowedInputRoots":  [ "/Users/YOURNAME/Audio" ],
+    "allowedOutputRoots": [ "/Users/YOURNAME/Audio/transcripts" ]
+  }
+}
+```
+
+Every other option keeps its default — the table above lists what those defaults are. For the full worked example with comments, see [`docs/deployment/mcp-server-security.md` § Worked example](../../docs/deployment/mcp-server-security.md#worked-example).
+
+## When you change an option
+
+1. Restart the MCP server — bindings are read once at startup.
+2. If you tightened a root, confirm legitimate paths still resolve under the new list. Easy mistake: forgetting to include both the input directory and its `transcripts/` subdirectory when those live in two different trees.
+3. For changes to `allowedInputRoots` / `allowedOutputRoots`, run `tests/VoxFlow.McpServer.Tests/PathPolicyTests.cs` against the new shape to confirm the prefix-match contract still holds.


### PR DESCRIPTION
Closes #49. Second P3 documentation task.

## Summary
Two new docs + one README link, paired so a deployer can read the threat model, drill into the per-option reference, then copy a minimal safe config.

## `docs/deployment/mcp-server-security.md` (new)
Full threat-model walk-through grounded in the actual [`PathPolicy.cs`](../../src/VoxFlow.McpServer/Security/PathPolicy.cs) implementation.

**Defends-against table** (what `PathPolicy` blocks):
- `..` traversal (via `ContainsTraversalSegments`)
- `~` rejection
- `\0` null-byte injection
- Reads outside `allowedInputRoots` (when configured)
- Writes outside `allowedOutputRoots` (when configured)
- Prefix-match attacks (e.g. `/audio-evil` masquerading as `/audio`) — closed by `NormalizeRoots`'s trailing-separator normalization
- Relative path tricks (via `requireAbsolutePaths`)
- Batch-size DoS (`maxBatchFiles` cap)

**Does-NOT table** (load-bearing — these are real gaps, not theoretical):
1. **Empty `allowedInputRoots` / `allowedOutputRoots` mean no root check at all** — the shipped default config is intentionally permissive; restricting it is the operator's job.
2. **Symlink traversal** — `Path.GetFullPath` does not resolve symlinks. A symlink inside an allowed root pointing outside still satisfies the check.
3. **TOCTOU** between policy validation and file IO.
4. **No content validation** — malicious media files can still trigger ffmpeg / pyannote / Whisper.net crashes.
5. **No rate limiting** beyond `maxBatchFiles` per-call.
6. **`logging.logFilePath` is NOT filtered by `PathPolicy`** — treat it as a trusted operator setting.

**Worked example** for "transcribe `~/Audio/`, write to `~/Audio/transcripts/`" with absolute-path reminder and read-only caveat.

**Limits section** restates the six gaps in numbered form for sign-off-style review.

Every claim links back to the line in `PathPolicy.cs` that implements it; spot-checked against `[`PathPolicy.cs:NN`]` jumps.

## `src/VoxFlow.McpServer/appsettings.json.md` (new)
JSON disallows comments, so this is the per-option sidecar reference. Every key in the `mcp` section gets a row: Type / Default / Recommended / Notes. Subsections for `resources`, `prompts`, `logging`. Ends with the shortest possible safe config (just two populated arrays) and a "when you change an option" checklist.

## `README.md`
New docs-table row pointing at the security doc.

## Acceptance criteria (from #49)
- [x] `docs/deployment/mcp-server-security.md` exists with the four sections: threat model, per-option, worked example, limits.
- [x] Every appsettings option in the `mcp` section is documented — top-level keys, `resources.*`, `prompts.*`, `logging.*` all covered.
- [x] Sibling `appsettings.json.md` (since JSON disallows comments) explains each option.
- [x] Linked from `README.md`.

## Files changed
- `docs/deployment/mcp-server-security.md` (new)
- `src/VoxFlow.McpServer/appsettings.json.md` (new)
- `README.md` (docs-table row)
